### PR TITLE
feat: jittered backoff for stale-connection retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1394,6 +1394,7 @@ dependencies = [
  "nix",
  "nutype",
  "proptest",
+ "rand 0.8.5",
  "ratatui",
  "rustls",
  "rustls-native-certs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ twox-hash = "2.1.2"
 rand = "0.8"  # Jittered backoff for stale-connection retries
 
 [dev-dependencies]
+tokio = { version = "1.0", features = ["test-util"] }  # Paused time for deterministic async tests
 tempfile = "3.23"
 serde_json = "1.0"  # For testing serde implementations
 divan = "0.1"  # Modern benchmarking framework

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ yenc = "0.2.2"  # yEnc encoding/decoding - faster and more correct than custom i
 bytesize = { version = "2.3.1", features = ["serde"] }
 serde_bytes = "0.11.19"
 twox-hash = "2.1.2"
+rand = "0.8"  # Jittered backoff for stale-connection retries
 
 [dev-dependencies]
 tempfile = "3.23"

--- a/src/session/retry.rs
+++ b/src/session/retry.rs
@@ -2,10 +2,11 @@
 //!
 //! Provides a shared pattern for retrying operations that may fail due to stale
 //! pooled connections. Both command execution and precheck use this pattern:
-//! call once → on error → log → retry once → return original error if retry fails.
+//! call once → on error → log → jittered sleep → retry once → return original error if retry fails.
 //!
-//! The optional sleep hook between attempts is a no-op today but provides a clean
-//! insertion point for jittered backoff (see `feature/retry-backoff-jitter`).
+//! The jittered delay (10–59ms) prevents thundering-herd retries when multiple
+//! connections go stale simultaneously (e.g. backend restart). Fail fast after
+//! one retry — let the router try a different backend.
 //!
 //! Uses a macro rather than a generic async function because callsites capture
 //! `&mut` references that cannot escape `FnMut` closure bodies.
@@ -36,8 +37,11 @@ macro_rules! retry_once_on_stale {
                     $label
                 );
 
-                // Future: insert jittered sleep here
-                // tokio::time::sleep(Duration::from_millis(10 + rand::random::<u64>() % 50)).await;
+                // Jittered backoff: 10–59ms prevents thundering-herd retries
+                tokio::time::sleep(std::time::Duration::from_millis(
+                    10 + rand::random::<u64>() % 50,
+                ))
+                .await;
 
                 match $expr {
                     Ok(val) => Ok(val),


### PR DESCRIPTION
## Summary

- Add `rand = "0.8"` dependency
- Replace no-op sleep placeholder in `retry_once_on_stale!` macro with 10–59ms random jitter before retry
- Prevents thundering-herd retries when multiple pooled connections go stale simultaneously (e.g. backend restart)
- Single retry with jitter, then fail fast — let the router try a different backend

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt --check` clean
- Existing retry unit tests still pass (jitter only affects timing, not logic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)