### PR TITLE
fix: preserve backend read-ahead across pooled commands

### DIFF
--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-HOOKS_DIR=".git/hooks"
+HOOKS_DIR="$(git rev-parse --path-format=absolute --git-path hooks)"
 HOOK_FILE="$HOOKS_DIR/pre-commit"
 
 if [ ! -d "$HOOKS_DIR" ]; then
@@ -17,9 +17,20 @@ echo "Installing pre-commit hook..."
 cat > "$HOOK_FILE" << 'EOF'
 #!/bin/sh
 # Pre-commit hook for nntp-proxy
-# Runs cargo fmt and cargo clippy before allowing commits
+# Runs cargo fmt and cargo clippy before allowing commits.
+# If the repository has a Nix flake, prefer the dev shell for consistent tooling.
 
 set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+if [ -z "${NNTP_PROXY_PRE_COMMIT_IN_NIX:-}" ] \
+    && command -v nix >/dev/null 2>&1 \
+    && [ -f "flake.nix" ]; then
+    echo "Entering Nix development environment for pre-commit checks..."
+    exec nix develop -c env NNTP_PROXY_PRE_COMMIT_IN_NIX=1 "$0" "$@"
+fi
 
 echo "Running cargo fmt..."
 cargo fmt --check
@@ -49,5 +60,6 @@ echo ""
 echo "The hook will run the following checks before each commit:"
 echo "  - cargo fmt --check (code formatting)"
 echo "  - cargo clippy --all-features (linting)"
+echo "  - nix develop -c ... when flake.nix and nix are available"
 echo ""
 echo "To bypass the hook temporarily, use: git commit --no-verify"

--- a/src/args.rs
+++ b/src/args.rs
@@ -339,8 +339,10 @@ mod tests {
             cache_articles: Some(false),
             ..default_args()
         };
-        let mut config = Config::default();
-        config.cache = None; // Start with no cache section
+        let mut config = Config {
+            cache: None, // Start with no cache section
+            ..Default::default()
+        };
 
         args.apply_overrides(&mut config);
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -164,69 +164,73 @@ impl NntpClient {
         // Validate response - early return on errors
         Self::validate_response(&response)?;
 
-        // Handle multiline responses - need to stream remaining data
-        // For single-line responses, io_buffer already has correct initialized count
         if response.is_multiline {
-            self.handle_multiline_response(&mut conn, &mut io_buffer, response.bytes_read)
-                .await?;
+            // Use a capture buffer as the accumulator: pooled, can grow beyond io_buffer
+            // capacity without panicking, returned to pool on drop.
+            let mut capture = self.buffer_pool.acquire_capture().await;
+            Self::drain_multiline_into(
+                &mut conn,
+                &mut io_buffer,
+                &mut capture,
+                response.bytes_read,
+            )
+            .await?;
+            Ok(capture)
+        } else {
+            Ok(io_buffer)
         }
-
-        Ok(io_buffer)
     }
 
-    /// Handle multiline response - stream until terminator, extending io_buffer in-place.
-    async fn handle_multiline_response(
-        &self,
+    /// Stream remaining multiline response data into `capture`.
+    ///
+    /// `io_buffer` is the scratch buffer for socket reads (fixed size).
+    /// `capture` is the accumulator returned to the caller (can grow).
+    async fn drain_multiline_into(
         conn: &mut Object<TcpManager>,
         io_buffer: &mut PooledBuffer,
+        capture: &mut PooledBuffer,
         first_chunk_size: usize,
     ) -> Result<()> {
         use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
 
-        // Copy first chunk out before using io_buffer for subsequent reads
-        let first_chunk: Vec<u8> = io_buffer.as_mut_slice()[..first_chunk_size].to_vec();
+        let first_chunk = &io_buffer.as_mut_slice()[..first_chunk_size];
         let mut tail = TailBuffer::default();
 
-        match tail.detect_terminator(&first_chunk) {
+        match tail.detect_terminator(first_chunk) {
             TerminatorStatus::FoundAt(pos) => {
-                // pos is after the terminator (terminator included in [..pos]).
-                io_buffer.copy_from_slice(&first_chunk[..pos]);
+                // pos is after the terminator (terminator included in [..pos])
+                capture.extend_from_slice(&first_chunk[..pos]);
                 return Ok(());
             }
-            TerminatorStatus::NotFound => tail.update(&first_chunk),
+            TerminatorStatus::NotFound => {
+                tail.update(first_chunk);
+                capture.extend_from_slice(first_chunk);
+            }
         }
-
-        // Stream remaining chunks until terminator.
-        // Accumulate into Vec because articles can exceed io_buffer's fixed capacity.
-        let mut accumulated = Vec::with_capacity(first_chunk_size * 2);
-        accumulated.extend_from_slice(&first_chunk);
 
         while let Ok(n) = io_buffer.read_from(&mut **conn).await {
             if n == 0 {
                 break; // EOF
             }
-
-            // NLL: chunk borrow ends after match block, before next read_from call
-            let status = {
+            // NLL: chunk borrow ends before next read_from call
+            let found_at = {
                 let chunk = &io_buffer.as_mut_slice()[..n];
-                (tail.detect_terminator(chunk), n)
+                tail.detect_terminator(chunk)
             };
-            match status {
-                (TerminatorStatus::FoundAt(pos), _) => {
-                    // pos is after the terminator (terminator included in [..pos]).
-                    accumulated.extend_from_slice(&io_buffer.as_mut_slice()[..pos]);
+            match found_at {
+                TerminatorStatus::FoundAt(pos) => {
+                    // pos is after the terminator (terminator included in [..pos])
+                    capture.extend_from_slice(&io_buffer.as_mut_slice()[..pos]);
                     break;
                 }
-                (TerminatorStatus::NotFound, n) => {
+                TerminatorStatus::NotFound => {
                     let chunk = &io_buffer.as_mut_slice()[..n];
                     tail.update(chunk);
-                    accumulated.extend_from_slice(chunk);
+                    capture.extend_from_slice(chunk);
                 }
             }
         }
 
-        // Copy accumulated data back to io_buffer (sets initialized count)
-        io_buffer.copy_from_slice(&accumulated);
         Ok(())
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -167,29 +167,20 @@ impl NntpClient {
         // Handle multiline responses - need to stream remaining data
         // For single-line responses, io_buffer already has correct initialized count
         if response.is_multiline {
-            let desynced = self
-                .handle_multiline_response(&mut conn, &mut io_buffer, response.bytes_read)
+            self.handle_multiline_response(&mut conn, &mut io_buffer, response.bytes_read)
                 .await?;
-            if desynced {
-                crate::pool::remove_from_pool(conn);
-                return Ok(io_buffer);
-            }
         }
 
         Ok(io_buffer)
     }
 
     /// Handle multiline response - stream until terminator, extending io_buffer in-place.
-    ///
-    /// Returns `true` if the connection is desynchronized (terminator found mid-chunk
-    /// with leftover bytes already consumed from socket). Caller must remove the
-    /// connection from pool in that case.
     async fn handle_multiline_response(
         &self,
         conn: &mut Object<TcpManager>,
         io_buffer: &mut PooledBuffer,
         first_chunk_size: usize,
-    ) -> Result<bool> {
+    ) -> Result<()> {
         use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
 
         // Copy first chunk out before using io_buffer for subsequent reads
@@ -198,11 +189,9 @@ impl NntpClient {
 
         match tail.detect_terminator(&first_chunk) {
             TerminatorStatus::FoundAt(pos) => {
-                // Terminator found in first chunk. If pos < first_chunk_size, extra bytes
-                // were already read from the socket — connection is desynchronized.
-                let desynced = pos < first_chunk_size;
+                // pos is after the terminator (terminator included in [..pos]).
                 io_buffer.copy_from_slice(&first_chunk[..pos]);
-                return Ok(desynced);
+                return Ok(());
             }
             TerminatorStatus::NotFound => tail.update(&first_chunk),
         }
@@ -211,7 +200,6 @@ impl NntpClient {
         // Accumulate into Vec because articles can exceed io_buffer's fixed capacity.
         let mut accumulated = Vec::with_capacity(first_chunk_size * 2);
         accumulated.extend_from_slice(&first_chunk);
-        let mut desynced = false;
 
         while let Ok(n) = io_buffer.read_from(&mut **conn).await {
             if n == 0 {
@@ -224,11 +212,8 @@ impl NntpClient {
                 (tail.detect_terminator(chunk), n)
             };
             match status {
-                (TerminatorStatus::FoundAt(pos), n) => {
-                    // If pos < n, leftover bytes already consumed from socket.
-                    if pos < n {
-                        desynced = true;
-                    }
+                (TerminatorStatus::FoundAt(pos), _) => {
+                    // pos is after the terminator (terminator included in [..pos]).
                     accumulated.extend_from_slice(&io_buffer.as_mut_slice()[..pos]);
                     break;
                 }
@@ -242,7 +227,7 @@ impl NntpClient {
 
         // Copy accumulated data back to io_buffer (sets initialized count)
         io_buffer.copy_from_slice(&accumulated);
-        Ok(desynced)
+        Ok(())
     }
 
     /// Validate NNTP response status code

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -12,7 +12,7 @@
 //! use nntp_proxy::client::NntpClient;
 //! use nntp_proxy::pool::{BufferPool, DeadpoolConnectionProvider};
 //! use nntp_proxy::protocol::Article;
-//! use nntp_proxy::types::BufferSize;
+//! use nntp_proxy::types::{BufferSize, MessageId};
 //!
 //! # async fn example() -> anyhow::Result<()> {
 //! // One buffer pool shared across all clients
@@ -23,9 +23,9 @@
 //! )?;
 //! let client = NntpClient::new(conn_pool, buffer_pool.clone());
 //!
-//! # let message_ids: Vec<&str> = vec![];
+//! # let message_ids: Vec<MessageId<'static>> = vec![];
 //! for msg_id in message_ids {
-//!     let buffer = client.fetch_body(msg_id).await?;
+//!     let buffer = client.fetch_body(&msg_id).await?;
 //!     let article = Article::parse(&buffer, true)?;
 //!     if let Some(decoded) = article.decode() {
 //!         process(&decoded);

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -43,9 +43,6 @@ use crate::pool::{BufferPool, DeadpoolConnectionProvider, PooledBuffer};
 use crate::protocol::{article_by_msgid, body_by_msgid, head_by_msgid, stat_by_msgid};
 use crate::session::backend::send_command;
 
-/// NNTP multiline terminator
-const TERMINATOR: &[u8] = b"\r\n.\r\n";
-
 /// Standalone NNTP client for fetching articles
 ///
 /// Zero-allocation design using caller-provided buffer pool.
@@ -184,10 +181,14 @@ impl NntpClient {
         io_buffer: &mut PooledBuffer,
         first_chunk_size: usize,
     ) -> Result<()> {
-        // Early return if first chunk contains terminator
+        use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
+
         let first_chunk = &io_buffer.as_mut_slice()[..first_chunk_size];
-        if first_chunk.ends_with(TERMINATOR) {
-            return Ok(());
+        let mut tail = TailBuffer::default();
+
+        match tail.detect_terminator(first_chunk) {
+            TerminatorStatus::FoundAt(_) => return Ok(()),
+            TerminatorStatus::NotFound => tail.update(first_chunk),
         }
 
         // Stream remaining chunks until terminator
@@ -201,10 +202,16 @@ impl NntpClient {
                 break; // EOF
             }
 
-            accumulated.extend_from_slice(&io_buffer.as_mut_slice()[..n]);
-
-            if accumulated.ends_with(TERMINATOR) {
-                break;
+            let chunk = &io_buffer.as_mut_slice()[..n];
+            match tail.detect_terminator(chunk) {
+                TerminatorStatus::FoundAt(pos) => {
+                    accumulated.extend_from_slice(&chunk[..pos]);
+                    break;
+                }
+                TerminatorStatus::NotFound => {
+                    tail.update(chunk);
+                    accumulated.extend_from_slice(chunk);
+                }
             }
         }
 
@@ -233,15 +240,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_terminator_detection() {
-        let with_term = b"content\r\n.\r\n";
-        let without_term = b"content\r\n";
-
-        assert!(with_term.ends_with(TERMINATOR));
-        assert!(!without_term.ends_with(TERMINATOR));
-    }
-
-    #[test]
     fn test_parse_stat_response_success() {
         use crate::protocol::StatusCode;
         // Article exists (223)
@@ -261,11 +259,5 @@ mod tests {
         assert!(NntpClient::parse_stat_response(StatusCode::parse(b"500")).is_err());
         assert!(NntpClient::parse_stat_response(StatusCode::parse(b"200")).is_err());
         assert!(NntpClient::parse_stat_response(StatusCode::parse(b"400")).is_err());
-    }
-
-    #[test]
-    fn test_terminator_constant() {
-        assert_eq!(TERMINATOR, b"\r\n.\r\n");
-        assert_eq!(TERMINATOR.len(), 5);
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -215,9 +215,13 @@ impl NntpClient {
             }
         }
 
-        while let Ok(n) = io_buffer.read_from(conn).await {
+        loop {
+            let n = io_buffer
+                .read_from(conn)
+                .await
+                .context("Failed to read multiline response from backend")?;
             if n == 0 {
-                break; // EOF
+                anyhow::bail!("Backend closed connection before multiline terminator");
             }
             // NLL: chunk borrow ends before next read_from call
             let found_at = {
@@ -231,7 +235,7 @@ impl NntpClient {
                     if pos < n {
                         conn.stash_leftover(&io_buffer.as_mut_slice()[pos..n])?;
                     }
-                    break;
+                    return Ok(());
                 }
                 TerminatorStatus::NotFound => {
                     let chunk = &io_buffer.as_mut_slice()[..n];
@@ -240,8 +244,6 @@ impl NntpClient {
                 }
             }
         }
-
-        Ok(())
     }
 
     /// Validate NNTP response status code
@@ -317,6 +319,36 @@ mod tests {
                         let _ = stream.write_all(article_data).await;
                         // Keep alive so recycle's try_read sees WouldBlock
                         tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                    });
+                }
+            }
+        });
+
+        (addr, notify)
+    }
+
+    async fn spawn_truncated_test_server(
+        article_prefix: &'static [u8],
+    ) -> (std::net::SocketAddr, std::sync::Arc<tokio::sync::Notify>) {
+        use std::sync::Arc;
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+        use tokio::sync::Notify;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let notify = Arc::new(Notify::new());
+        let n = Arc::clone(&notify);
+
+        tokio::spawn(async move {
+            loop {
+                if let Ok((mut stream, _)) = listener.accept().await {
+                    let wake = Arc::clone(&n);
+                    tokio::spawn(async move {
+                        let _ = stream.write_all(b"200 mock\r\n").await;
+                        wake.notified().await;
+                        let _ = stream.write_all(article_prefix).await;
+                        let _ = stream.shutdown().await;
                     });
                 }
             }
@@ -403,5 +435,32 @@ mod tests {
             .unwrap();
 
         assert_eq!(&capture[..], article as &[u8]);
+    }
+
+    #[tokio::test]
+    async fn test_drain_multiline_into_errors_on_truncated_response() {
+        use crate::pool::BufferPool;
+        use crate::types::BufferSize;
+
+        let article_prefix = b"220 body follows\r\npartial article";
+        let (addr, notify) = spawn_truncated_test_server(article_prefix).await;
+        let pool = make_test_pool(addr).await;
+        let buffer_pool = BufferPool::new(BufferSize::try_new(8).unwrap(), 4);
+
+        let mut conn = pool.get().await.unwrap();
+        notify.notify_one();
+
+        let mut io_buffer = buffer_pool.acquire().await;
+        let mut capture = buffer_pool.acquire_capture().await;
+
+        let err = NntpClient::drain_multiline_into(&mut conn, &mut io_buffer, &mut capture, 0)
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("Backend closed connection before multiline terminator"),
+            "unexpected error: {err:#}"
+        );
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -274,4 +274,124 @@ mod tests {
         assert!(NntpClient::parse_stat_response(StatusCode::parse(b"200")).is_err());
         assert!(NntpClient::parse_stat_response(StatusCode::parse(b"400")).is_err());
     }
+
+    /// Spawn a minimal NNTP server that sends a greeting, then waits for
+    /// `notify` before sending `article_data`. Returns (addr, notify).
+    ///
+    /// The caller calls `pool.get()` first (which consumes only the greeting),
+    /// then fires the notify so the server sends article data into the established
+    /// connection. This prevents `consume_greeting` from inadvertently consuming
+    /// article bytes (both writes arriving in the same TCP segment).
+    async fn spawn_test_server(
+        article_data: &'static [u8],
+    ) -> (std::net::SocketAddr, std::sync::Arc<tokio::sync::Notify>) {
+        use std::sync::Arc;
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+        use tokio::sync::Notify;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let notify = Arc::new(Notify::new());
+        let n = Arc::clone(&notify);
+
+        tokio::spawn(async move {
+            loop {
+                if let Ok((mut stream, _)) = listener.accept().await {
+                    let wake = Arc::clone(&n);
+                    tokio::spawn(async move {
+                        let _ = stream.write_all(b"200 mock\r\n").await;
+                        // Block until the test signals that pool.get() has returned
+                        // (greeting already consumed) before sending article data
+                        wake.notified().await;
+                        let _ = stream.write_all(article_data).await;
+                        // Keep alive so recycle's try_read sees WouldBlock
+                        tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                    });
+                }
+            }
+        });
+
+        (addr, notify)
+    }
+
+    async fn make_test_pool(addr: std::net::SocketAddr) -> crate::pool::deadpool_connection::Pool {
+        let manager = crate::pool::deadpool_connection::TcpManager::new(
+            addr.ip().to_string(),
+            addr.port(),
+            "test".to_string(),
+            None,
+            None,
+            None,
+            Some(false), // disable compression — mock doesn't handle it
+            None,
+        )
+        .unwrap();
+        crate::pool::deadpool_connection::Pool::builder(manager)
+            .max_size(2)
+            .build()
+            .unwrap()
+    }
+
+    /// Verify drain_multiline_into captures the complete response when it all
+    /// arrives in the first pre-read chunk (first_chunk_size == article length).
+    #[tokio::test]
+    async fn test_drain_multiline_into_single_read() {
+        use crate::pool::BufferPool;
+        use crate::types::BufferSize;
+
+        let article = b"220 body follows\r\nHello world\r\n.\r\n";
+        let (addr, notify) = spawn_test_server(article).await;
+        let pool = make_test_pool(addr).await;
+        let buffer_pool = BufferPool::new(BufferSize::try_new(4096).unwrap(), 2);
+
+        let mut conn = pool.get().await.unwrap();
+        // Signal server to send article data now that the greeting is consumed
+        notify.notify_one();
+
+        let mut io_buffer = buffer_pool.acquire().await;
+        let mut capture = buffer_pool.acquire_capture().await;
+
+        // Simulate send_command pre-reading the full first response chunk
+        let first_chunk_size = io_buffer.read_from(&mut *conn).await.unwrap();
+
+        NntpClient::drain_multiline_into(&mut conn, &mut io_buffer, &mut capture, first_chunk_size)
+            .await
+            .unwrap();
+
+        assert_eq!(&capture[..], article as &[u8]);
+    }
+
+    /// Verify drain_multiline_into accumulates correctly across multiple reads,
+    /// including when the NNTP terminator spans a read boundary (3+ reads).
+    ///
+    /// Uses an 8-byte I/O buffer against a 36-byte article, forcing 5 reads.
+    /// Read 4 ends with `\r` and read 5 starts with `\n.\r\n`, so the terminator
+    /// `\r\n.\r\n` spans the boundary — exercising TailBuffer spanning detection.
+    #[tokio::test]
+    async fn test_drain_multiline_into_multi_read_spanning_terminator() {
+        use crate::pool::BufferPool;
+        use crate::types::BufferSize;
+
+        // 36 bytes total: 5 × 8-byte reads with 8-byte io_buffer.
+        // Terminator \r\n.\r\n spans read 4 ("\r") → read 5 ("\n.\r\n").
+        let article = b"220 article\r\nLine one\r\nLine two\r\n.\r\n";
+        let (addr, notify) = spawn_test_server(article).await;
+        let pool = make_test_pool(addr).await;
+        // Tiny I/O buffer forces multiple reads and exercises the streaming loop
+        let buffer_pool = BufferPool::new(BufferSize::try_new(8).unwrap(), 4);
+
+        let mut conn = pool.get().await.unwrap();
+        notify.notify_one();
+
+        let mut io_buffer = buffer_pool.acquire().await;
+        let mut capture = buffer_pool.acquire_capture().await;
+
+        // first_chunk_size = 0: no pre-loaded data, all bytes arrive via the loop
+        NntpClient::drain_multiline_into(&mut conn, &mut io_buffer, &mut capture, 0)
+            .await
+            .unwrap();
+
+        assert_eq!(&capture[..], article as &[u8]);
+    }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -38,7 +38,9 @@
 //! ```
 
 use anyhow::{Context, Result};
+use deadpool::managed::Object;
 
+use crate::pool::deadpool_connection::TcpManager;
 use crate::pool::{BufferPool, DeadpoolConnectionProvider, PooledBuffer};
 use crate::protocol::{article_by_msgid, body_by_msgid, head_by_msgid, stat_by_msgid};
 use crate::session::backend::send_command;
@@ -145,9 +147,7 @@ impl NntpClient {
 
     /// Get a connection from the pool
     #[inline]
-    async fn get_connection(
-        &self,
-    ) -> Result<impl std::ops::DerefMut<Target = crate::stream::ConnectionStream>> {
+    async fn get_connection(&self) -> Result<Object<TcpManager>> {
         self.conn_pool
             .get_pooled_connection()
             .await
@@ -167,48 +167,73 @@ impl NntpClient {
         // Handle multiline responses - need to stream remaining data
         // For single-line responses, io_buffer already has correct initialized count
         if response.is_multiline {
-            self.handle_multiline_response(&mut conn, &mut io_buffer, response.bytes_read)
+            let desynced = self
+                .handle_multiline_response(&mut conn, &mut io_buffer, response.bytes_read)
                 .await?;
+            if desynced {
+                crate::pool::remove_from_pool(conn);
+                return Ok(io_buffer);
+            }
         }
 
         Ok(io_buffer)
     }
 
-    /// Handle multiline response - stream until terminator, extending io_buffer in-place
+    /// Handle multiline response - stream until terminator, extending io_buffer in-place.
+    ///
+    /// Returns `true` if the connection is desynchronized (terminator found mid-chunk
+    /// with leftover bytes already consumed from socket). Caller must remove the
+    /// connection from pool in that case.
     async fn handle_multiline_response(
         &self,
-        conn: &mut crate::stream::ConnectionStream,
+        conn: &mut Object<TcpManager>,
         io_buffer: &mut PooledBuffer,
         first_chunk_size: usize,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
 
-        let first_chunk = &io_buffer.as_mut_slice()[..first_chunk_size];
+        // Copy first chunk out before using io_buffer for subsequent reads
+        let first_chunk: Vec<u8> = io_buffer.as_mut_slice()[..first_chunk_size].to_vec();
         let mut tail = TailBuffer::default();
 
-        match tail.detect_terminator(first_chunk) {
-            TerminatorStatus::FoundAt(_) => return Ok(()),
-            TerminatorStatus::NotFound => tail.update(first_chunk),
+        match tail.detect_terminator(&first_chunk) {
+            TerminatorStatus::FoundAt(pos) => {
+                // Terminator found in first chunk. If pos < first_chunk_size, extra bytes
+                // were already read from the socket — connection is desynchronized.
+                let desynced = pos < first_chunk_size;
+                io_buffer.copy_from_slice(&first_chunk[..pos]);
+                return Ok(desynced);
+            }
+            TerminatorStatus::NotFound => tail.update(&first_chunk),
         }
 
-        // Stream remaining chunks until terminator
-        // Note: We need to accumulate because io_buffer has fixed capacity
-        // and articles can exceed it. Using Vec for dynamic growth.
+        // Stream remaining chunks until terminator.
+        // Accumulate into Vec because articles can exceed io_buffer's fixed capacity.
         let mut accumulated = Vec::with_capacity(first_chunk_size * 2);
-        accumulated.extend_from_slice(first_chunk);
+        accumulated.extend_from_slice(&first_chunk);
+        let mut desynced = false;
 
-        while let Ok(n) = io_buffer.read_from(conn).await {
+        while let Ok(n) = io_buffer.read_from(&mut **conn).await {
             if n == 0 {
                 break; // EOF
             }
 
-            let chunk = &io_buffer.as_mut_slice()[..n];
-            match tail.detect_terminator(chunk) {
-                TerminatorStatus::FoundAt(pos) => {
-                    accumulated.extend_from_slice(&chunk[..pos]);
+            // NLL: chunk borrow ends after match block, before next read_from call
+            let status = {
+                let chunk = &io_buffer.as_mut_slice()[..n];
+                (tail.detect_terminator(chunk), n)
+            };
+            match status {
+                (TerminatorStatus::FoundAt(pos), n) => {
+                    // If pos < n, leftover bytes already consumed from socket.
+                    if pos < n {
+                        desynced = true;
+                    }
+                    accumulated.extend_from_slice(&io_buffer.as_mut_slice()[..pos]);
                     break;
                 }
-                TerminatorStatus::NotFound => {
+                (TerminatorStatus::NotFound, n) => {
+                    let chunk = &io_buffer.as_mut_slice()[..n];
                     tail.update(chunk);
                     accumulated.extend_from_slice(chunk);
                 }
@@ -217,7 +242,7 @@ impl NntpClient {
 
         // Copy accumulated data back to io_buffer (sets initialized count)
         io_buffer.copy_from_slice(&accumulated);
-        Ok(())
+        Ok(desynced)
     }
 
     /// Validate NNTP response status code

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -168,13 +168,17 @@ impl NntpClient {
             // Use a capture buffer as the accumulator: pooled, can grow beyond io_buffer
             // capacity without panicking, returned to pool on drop.
             let mut capture = self.buffer_pool.acquire_capture().await;
-            Self::drain_multiline_into(
+            if let Err(err) = Self::drain_multiline_into(
                 &mut conn,
                 &mut io_buffer,
                 &mut capture,
                 response.bytes_read,
             )
-            .await?;
+            .await
+            {
+                self.conn_pool.remove_with_cooldown(conn);
+                return Err(err);
+            }
             Ok(capture)
         } else {
             Ok(io_buffer)
@@ -186,7 +190,7 @@ impl NntpClient {
     /// `io_buffer` is the scratch buffer for socket reads (fixed size).
     /// `capture` is the accumulator returned to the caller (can grow).
     async fn drain_multiline_into(
-        conn: &mut Object<TcpManager>,
+        conn: &mut crate::stream::ConnectionStream,
         io_buffer: &mut PooledBuffer,
         capture: &mut PooledBuffer,
         first_chunk_size: usize,
@@ -200,6 +204,9 @@ impl NntpClient {
             TerminatorStatus::FoundAt(pos) => {
                 // pos is after the terminator (terminator included in [..pos])
                 capture.extend_from_slice(&first_chunk[..pos]);
+                if pos < first_chunk.len() {
+                    conn.stash_leftover(&first_chunk[pos..])?;
+                }
                 return Ok(());
             }
             TerminatorStatus::NotFound => {
@@ -208,7 +215,7 @@ impl NntpClient {
             }
         }
 
-        while let Ok(n) = io_buffer.read_from(&mut **conn).await {
+        while let Ok(n) = io_buffer.read_from(conn).await {
             if n == 0 {
                 break; // EOF
             }
@@ -221,6 +228,9 @@ impl NntpClient {
                 TerminatorStatus::FoundAt(pos) => {
                     // pos is after the terminator (terminator included in [..pos])
                     capture.extend_from_slice(&io_buffer.as_mut_slice()[..pos]);
+                    if pos < n {
+                        conn.stash_leftover(&io_buffer.as_mut_slice()[pos..n])?;
+                    }
                     break;
                 }
                 TerminatorStatus::NotFound => {

--- a/src/connection_error.rs
+++ b/src/connection_error.rs
@@ -232,7 +232,7 @@ mod tests {
         assert!(err.is_client_disconnect());
 
         // Other errors are not disconnects
-        let io_err = std::io::Error::new(std::io::ErrorKind::Other, "other");
+        let io_err = std::io::Error::other("other");
         let err = ConnectionError::IoError(io_err);
         assert!(!err.is_client_disconnect());
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -132,6 +132,19 @@ pub mod timeout {
     /// If a backend doesn't respond within this time, treat as 430 (missing)
     /// This prevents slow backends from blocking all client connections
     pub const PRECHECK_QUERY: Duration = Duration::from_secs(2);
+
+    /// Timeout for closing the cache during graceful shutdown
+    /// foyer's close() can hang indefinitely if the runtime is winding down
+    pub const CACHE_CLOSE: Duration = Duration::from_secs(3);
+
+    /// Timeout for sending QUIT to an idle backend connection during shutdown
+    /// Half-closed connections can block write_all indefinitely without this
+    pub const SHUTDOWN_QUIT_WRITE: Duration = Duration::from_millis(500);
+
+    /// Timeout for acquiring an idle connection from the pool during shutdown
+    /// Used to drain connections one at a time; should be near-instant if
+    /// the connection is truly idle
+    pub const SHUTDOWN_POOL_GET: Duration = Duration::from_millis(1);
 }
 
 /// Connection pool constants

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,7 +75,6 @@ pub mod streaming {
     //! fetch articles directly from servers.
     pub use crate::session::streaming::{
         stream_and_capture_multiline_response, stream_multiline_response,
-        stream_multiline_response_pipelined,
     };
 }
 

--- a/src/network.rs
+++ b/src/network.rs
@@ -301,7 +301,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let tcp_stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let connection_stream = ConnectionStream::Plain(tcp_stream);
+        let connection_stream = ConnectionStream::plain(tcp_stream);
         let optimizer = ConnectionOptimizer::new(&connection_stream);
 
         assert_eq!(optimizer.description(), "Connection-level TCP optimization");
@@ -316,7 +316,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let tcp_stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let connection_stream = ConnectionStream::Plain(tcp_stream);
+        let connection_stream = ConnectionStream::plain(tcp_stream);
 
         // Test that ConnectionOptimizer implements NetworkOptimizer trait
         let optimizer: Box<dyn NetworkOptimizer> =
@@ -332,7 +332,7 @@ mod tests {
         let addr = listener.local_addr().unwrap();
 
         let tcp_stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let connection_stream = ConnectionStream::Plain(tcp_stream);
+        let connection_stream = ConnectionStream::plain(tcp_stream);
         let optimizer = ConnectionOptimizer::with_buffer_sizes(&connection_stream, 4096, 8192);
 
         assert_eq!(optimizer.description(), "Connection-level TCP optimization");
@@ -436,7 +436,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let stream = ConnectionStream::Plain(tcp);
+        let stream = ConnectionStream::plain(tcp);
 
         let optimizer = ConnectionOptimizer::new(&stream);
         assert_eq!(optimizer.description(), "Connection-level TCP optimization");
@@ -449,7 +449,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let stream = ConnectionStream::Plain(tcp);
+        let stream = ConnectionStream::plain(tcp);
 
         let optimizer = ConnectionOptimizer::new(&stream);
         assert!(optimizer.recv_buffer_size.is_none());
@@ -461,7 +461,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let stream = ConnectionStream::Plain(tcp);
+        let stream = ConnectionStream::plain(tcp);
 
         let recv = 16384;
         let send = 32768;
@@ -529,7 +529,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let stream = ConnectionStream::Plain(tcp);
+        let stream = ConnectionStream::plain(tcp);
 
         let optimizer = ConnectionOptimizer::new(&stream);
         // Can be used as a trait object

--- a/src/pool/connection_guard.rs
+++ b/src/pool/connection_guard.rs
@@ -345,6 +345,63 @@ mod tests {
         }
     }
 
+    /// Verify that a mid-chunk terminator (pos < n) is treated as a desynchronized
+    /// connection, not a clean one. This guards the pool-removal branch added in
+    /// drain_connection_async: FoundAt(pos) with leftover bytes must remove from pool.
+    #[test]
+    fn test_drain_mid_chunk_terminator_is_desynced() {
+        use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
+
+        // Chunk contains the terminator mid-way, with extra bytes after it.
+        // Simulates a backend that sent two pipelined responses in one TCP read.
+        let chunk = b"220 Article follows\r\nBody\r\n.\r\nEXTRA DATA FROM NEXT RESPONSE";
+        let n = chunk.len();
+
+        let mut tail = TailBuffer::default();
+        let status = tail.detect_terminator(chunk);
+
+        match status {
+            TerminatorStatus::FoundAt(pos) => {
+                assert!(
+                    pos < n,
+                    "Terminator should be mid-chunk (pos={} < n={})",
+                    pos,
+                    n
+                );
+                // This is the condition that triggers remove_from_pool in
+                // drain_connection_async — connection is desynchronized
+            }
+            other => panic!("Expected FoundAt, got {:?}", other),
+        }
+    }
+
+    /// Verify that a terminator at the exact end of a chunk (pos == n) is treated
+    /// as a clean connection that can safely be returned to the pool.
+    #[test]
+    fn test_drain_end_of_chunk_terminator_is_clean() {
+        use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
+
+        // Chunk ends exactly with the terminator — no leftover bytes.
+        let chunk = b"220 Article follows\r\nBody\r\n.\r\n";
+        let n = chunk.len();
+
+        let mut tail = TailBuffer::default();
+        let status = tail.detect_terminator(chunk);
+
+        match status {
+            TerminatorStatus::FoundAt(pos) => {
+                assert_eq!(
+                    pos, n,
+                    "Terminator at end of chunk should have pos == n ({} == {})",
+                    pos, n
+                );
+                // This is the condition that allows returning to pool in
+                // drain_connection_async — connection is clean
+            }
+            other => panic!("Expected FoundAt, got {:?}", other),
+        }
+    }
+
     /// Verify that TailBuffer detects terminators that span chunk boundaries,
     /// which the old `windows()` approach in `drain_connection_async` would miss.
     #[test]

--- a/src/pool/connection_guard.rs
+++ b/src/pool/connection_guard.rs
@@ -433,23 +433,18 @@ mod tests {
         let count = Arc::clone(&accept_count);
         let n = Arc::clone(&notify);
         tokio::spawn(async move {
-            loop {
-                match listener.accept().await {
-                    Ok((mut stream, _)) => {
-                        count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        let wake = Arc::clone(&n);
-                        tokio::spawn(async move {
-                            let _ = stream.write_all(b"200 mock\r\n").await;
-                            // Block until the test signals that pool.get() has returned
-                            // (greeting already consumed) before sending article data
-                            wake.notified().await;
-                            let _ = stream.write_all(data).await;
-                            // Keep alive so recycle's try_read sees WouldBlock (not EOF)
-                            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-                        });
-                    }
-                    Err(_) => break,
-                }
+            while let Ok((mut stream, _)) = listener.accept().await {
+                count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                let wake = Arc::clone(&n);
+                tokio::spawn(async move {
+                    let _ = stream.write_all(b"200 mock\r\n").await;
+                    // Block until the test signals that pool.get() has returned
+                    // (greeting already consumed) before sending article data
+                    wake.notified().await;
+                    let _ = stream.write_all(data).await;
+                    // Keep alive so recycle's try_read sees WouldBlock (not EOF)
+                    tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                });
             }
         });
         (addr, accept_count, notify)

--- a/src/pool/connection_guard.rs
+++ b/src/pool/connection_guard.rs
@@ -144,13 +144,25 @@ pub async fn drain_connection_async(
     for _ in 0..MAX_DRAIN_ITERATIONS {
         match tokio::time::timeout(DRAIN_TIMEOUT, buffer.read_from(&mut *conn)).await {
             Ok(Ok(n)) if n > 0 => {
+                use crate::session::streaming::tail_buffer::TerminatorStatus;
                 let data = &buffer[..n];
-                // Check for terminator (handles mid-chunk and cross-boundary spanning)
-                if tail.detect_terminator(data).is_found() {
-                    debug!("Successfully drained connection - returning to pool");
-                    return; // Drop returns connection to pool
+                match tail.detect_terminator(data) {
+                    TerminatorStatus::FoundAt(pos) if pos == n => {
+                        // Terminator at exact end of chunk — no leftover bytes, connection clean
+                        debug!("Successfully drained connection - returning to pool");
+                        return; // Drop returns connection to pool
+                    }
+                    TerminatorStatus::FoundAt(_) => {
+                        // Terminator mid-chunk: leftover bytes already consumed from socket,
+                        // connection is desynchronized and cannot be safely reused
+                        debug!("Leftover bytes after terminator - removing from pool");
+                        remove_from_pool(conn);
+                        return;
+                    }
+                    TerminatorStatus::NotFound => {
+                        tail.update(data);
+                    }
                 }
-                tail.update(data);
             }
             _ => {
                 // Timeout, EOF, or error - connection broken

--- a/src/pool/connection_guard.rs
+++ b/src/pool/connection_guard.rs
@@ -345,11 +345,12 @@ mod tests {
         }
     }
 
-    /// Verify that a mid-chunk terminator (pos < n) is treated as a desynchronized
-    /// connection, not a clean one. This guards the pool-removal branch added in
-    /// drain_connection_async: FoundAt(pos) with leftover bytes must remove from pool.
+    /// Verify that TailBuffer sees pos < n for a mid-chunk terminator.
+    /// This guards the condition checked by drain_connection_async: FoundAt(pos) with
+    /// leftover bytes must remove from pool. The end-to-end pool behavior is verified
+    /// in test_drain_async_mid_chunk_terminator_removes_from_pool.
     #[test]
-    fn test_drain_mid_chunk_terminator_is_desynced() {
+    fn test_tailbuffer_mid_chunk_terminator_pos_less_than_n() {
         use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
 
         // Chunk contains the terminator mid-way, with extra bytes after it.
@@ -357,7 +358,7 @@ mod tests {
         let chunk = b"220 Article follows\r\nBody\r\n.\r\nEXTRA DATA FROM NEXT RESPONSE";
         let n = chunk.len();
 
-        let mut tail = TailBuffer::default();
+        let tail = TailBuffer::default();
         let status = tail.detect_terminator(chunk);
 
         match status {
@@ -375,17 +376,19 @@ mod tests {
         }
     }
 
-    /// Verify that a terminator at the exact end of a chunk (pos == n) is treated
-    /// as a clean connection that can safely be returned to the pool.
+    /// Verify that TailBuffer sees pos == n for a terminator exactly at chunk end.
+    /// This guards the condition checked by drain_connection_async: FoundAt(pos) with
+    /// no leftover bytes returns the connection to the pool. The end-to-end pool
+    /// behavior is verified in test_drain_async_clean_terminator_returns_to_pool.
     #[test]
-    fn test_drain_end_of_chunk_terminator_is_clean() {
+    fn test_tailbuffer_end_of_chunk_terminator_pos_equals_n() {
         use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
 
         // Chunk ends exactly with the terminator — no leftover bytes.
         let chunk = b"220 Article follows\r\nBody\r\n.\r\n";
         let n = chunk.len();
 
-        let mut tail = TailBuffer::default();
+        let tail = TailBuffer::default();
         let status = tail.detect_terminator(chunk);
 
         match status {
@@ -400,6 +403,145 @@ mod tests {
             }
             other => panic!("Expected FoundAt, got {:?}", other),
         }
+    }
+
+    /// Spawn a minimal NNTP mock server that sends a greeting, then waits for
+    /// `notify` before sending `data`. Loops to accept multiple connections
+    /// (needed when a broken connection is replaced by `create_new`).
+    ///
+    /// The caller calls `pool.get()` first (which consumes only the greeting),
+    /// then fires the notify so the server sends article data into the established
+    /// connection. This prevents `consume_greeting` from inadvertently consuming
+    /// article bytes (both writes arriving in the same TCP segment).
+    async fn spawn_test_nntp_server(
+        data: &'static [u8],
+    ) -> (
+        std::net::SocketAddr,
+        std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        std::sync::Arc<tokio::sync::Notify>,
+    ) {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicUsize;
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
+        use tokio::sync::Notify;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let accept_count = Arc::new(AtomicUsize::new(0));
+        let notify = Arc::new(Notify::new());
+        let count = Arc::clone(&accept_count);
+        let n = Arc::clone(&notify);
+        tokio::spawn(async move {
+            loop {
+                match listener.accept().await {
+                    Ok((mut stream, _)) => {
+                        count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        let wake = Arc::clone(&n);
+                        tokio::spawn(async move {
+                            let _ = stream.write_all(b"200 mock\r\n").await;
+                            // Block until the test signals that pool.get() has returned
+                            // (greeting already consumed) before sending article data
+                            wake.notified().await;
+                            let _ = stream.write_all(data).await;
+                            // Keep alive so recycle's try_read sees WouldBlock (not EOF)
+                            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                        });
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+        (addr, accept_count, notify)
+    }
+
+    async fn make_test_pool(addr: std::net::SocketAddr) -> crate::pool::deadpool_connection::Pool {
+        let manager = crate::pool::deadpool_connection::TcpManager::new(
+            addr.ip().to_string(),
+            addr.port(),
+            "test".to_string(),
+            None,
+            None,
+            None,
+            Some(false), // disable compression — mock doesn't handle it
+            None,
+        )
+        .unwrap();
+        crate::pool::deadpool_connection::Pool::builder(manager)
+            .max_size(2)
+            .build()
+            .unwrap()
+    }
+
+    /// `drain_connection_async` returns the connection to the pool when the
+    /// terminator arrives exactly at the end of a read chunk (pos == n).
+    /// Verifies via pool.status() and that the same server connection is reused.
+    #[tokio::test]
+    async fn test_drain_async_clean_terminator_returns_to_pool() {
+        use crate::pool::BufferPool;
+        use crate::types::BufferSize;
+        use std::sync::atomic::Ordering;
+
+        let (addr, accept_count, notify) = spawn_test_nntp_server(b"article body\r\n.\r\n").await;
+        let pool = make_test_pool(addr).await;
+        let buffer_pool = BufferPool::new(BufferSize::try_new(4096).unwrap(), 2);
+
+        let conn = pool.get().await.unwrap();
+        // Signal server to send article data now that the greeting is consumed
+        notify.notify_one();
+        assert_eq!(pool.status().available, 0);
+
+        drain_connection_async(conn, buffer_pool).await;
+
+        // Object dropped synchronously → returned to ready queue immediately
+        assert_eq!(pool.status().available, 1, "connection must return to pool");
+
+        // Recycle check: try_read sees WouldBlock (server idle) → recycle succeeds
+        // No new server connection should be required
+        let _conn2 = pool.get().await.unwrap();
+        assert_eq!(
+            accept_count.load(Ordering::Relaxed),
+            1,
+            "clean path: same connection recycled, no new server connection"
+        );
+    }
+
+    /// `drain_connection_async` removes the connection from the pool when the
+    /// terminator is found mid-chunk (pos < n), meaning leftover bytes from the
+    /// next response were already consumed from the socket.
+    /// Verifies that the dead connection is detected during recycle and replaced.
+    #[tokio::test]
+    async fn test_drain_async_mid_chunk_terminator_removes_from_pool() {
+        use crate::pool::BufferPool;
+        use crate::types::BufferSize;
+        use std::sync::atomic::Ordering;
+
+        let (addr, accept_count, notify) =
+            spawn_test_nntp_server(b"article body\r\n.\r\nEXTRA_BYTES").await;
+        let pool = make_test_pool(addr).await;
+        let buffer_pool = BufferPool::new(BufferSize::try_new(4096).unwrap(), 2);
+
+        let conn = pool.get().await.unwrap();
+        // Signal server to send article data now that the greeting is consumed
+        notify.notify_one();
+        drain_connection_async(conn, buffer_pool).await;
+
+        // Object is returned to the ready queue (deadpool doesn't know it's broken)
+        assert_eq!(pool.status().available, 1);
+
+        // Yield to let tokio process the pending EPOLLRDHUP event from shutdown(Both).
+        // Without this, check_tcp_alive's try_read sees WouldBlock (readiness not yet
+        // updated) instead of Ok(0) (EOF), causing recycle to succeed incorrectly.
+        tokio::task::yield_now().await;
+
+        // Next get() calls try_recycle → check_tcp_alive on the shutdown socket
+        // sees EOF → recycle fails → create_new → server accepts a second connection
+        let _conn2 = pool.get().await.unwrap();
+        assert_eq!(
+            accept_count.load(Ordering::Relaxed),
+            2,
+            "remove path: broken connection replaced with fresh server connection"
+        );
     }
 
     /// Verify that TailBuffer detects terminators that span chunk boundaries,

--- a/src/pool/deadpool_connection.rs
+++ b/src/pool/deadpool_connection.rs
@@ -127,9 +127,9 @@ impl TcpManager {
                     backend: self.name.clone(),
                     source: e.into(),
                 })?;
-            Ok(ConnectionStream::Tls(Box::new(tls_stream)))
+            Ok(ConnectionStream::tls(tls_stream))
         } else {
-            Ok(ConnectionStream::Plain(tcp_stream))
+            Ok(ConnectionStream::plain(tcp_stream))
         }
     }
 }
@@ -307,8 +307,6 @@ impl managed::Manager for TcpManager {
     type Error = ConnectionError;
 
     async fn create(&self) -> Result<ConnectionStream, ConnectionError> {
-        use crate::compression::DecompressStream;
-
         let mut stream = self.create_optimized_stream().await?;
         let mut buffer = [0u8; 4096];
 
@@ -317,18 +315,7 @@ impl managed::Manager for TcpManager {
 
         if self.negotiate_compression(&mut stream, &mut buffer).await? {
             let level = self.compress_level.unwrap_or(1);
-            stream = match stream {
-                ConnectionStream::Plain(tcp) => ConnectionStream::CompressedPlain(Box::new(
-                    DecompressStream::with_level(tcp, level),
-                )),
-                ConnectionStream::Tls(tls) => ConnectionStream::CompressedTls(Box::new(
-                    DecompressStream::with_level(*tls, level),
-                )),
-                // create_optimized_stream() only returns Plain or Tls
-                ConnectionStream::CompressedPlain(_) | ConnectionStream::CompressedTls(_) => {
-                    unreachable!("fresh connections are never already compressed")
-                }
-            };
+            stream = stream.into_compressed(level);
         }
 
         Ok(stream)

--- a/src/pool/deadpool_connection.rs
+++ b/src/pool/deadpool_connection.rs
@@ -315,7 +315,7 @@ impl managed::Manager for TcpManager {
 
         if self.negotiate_compression(&mut stream, &mut buffer).await? {
             let level = self.compress_level.unwrap_or(1);
-            stream = stream.into_compressed(level);
+            stream = stream.into_compressed(level)?;
         }
 
         Ok(stream)

--- a/src/pool/health_check.rs
+++ b/src/pool/health_check.rs
@@ -126,6 +126,10 @@ impl HealthCheckMetrics {
 pub fn check_tcp_alive(
     conn: &mut ConnectionStream,
 ) -> managed::RecycleResult<crate::connection_error::ConnectionError> {
+    if conn.has_leftover() {
+        return Err(HealthCheckError::UnexpectedData.into());
+    }
+
     let mut peek_buf = [0u8; TCP_PEEK_BUFFER_SIZE];
 
     // Check the underlying TCP stream regardless of TLS/compression layers
@@ -263,6 +267,26 @@ mod tests {
         assert_eq!(metrics.connections_checked(), 50);
         assert_eq!(metrics.connections_failed(), 5);
         assert_eq!(metrics.failure_rate(), 0.1);
+    }
+
+    #[tokio::test]
+    async fn test_tcp_alive_check_rejects_buffered_leftover() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let client_handle =
+            tokio::spawn(async move { tokio::net::TcpStream::connect(addr).await.unwrap() });
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client = client_handle.await.unwrap();
+
+        let mut conn = ConnectionStream::plain(server_stream);
+        conn.stash_leftover(b"430 stale response\r\n").unwrap();
+
+        let result = check_tcp_alive(&mut conn);
+        assert!(
+            result.is_err(),
+            "connections with buffered leftovers must not recycle"
+        );
     }
 
     #[test]

--- a/src/pool/provider.rs
+++ b/src/pool/provider.rs
@@ -716,14 +716,14 @@ impl DeadpoolConnectionProvider {
 
         // Send QUIT to idle connections with minimal timeout
         let mut timeouts = managed::Timeouts::new();
-        timeouts.wait = Some(std::time::Duration::from_millis(1));
+        timeouts.wait = Some(crate::constants::timeout::SHUTDOWN_POOL_GET);
 
         for _ in 0..status.available {
             if let Ok(conn_obj) = self.pool.timeout_get(&timeouts).await {
                 let mut conn = Object::take(conn_obj);
                 // Timeout the write: a half-closed backend connection can block indefinitely
                 let _ = tokio::time::timeout(
-                    std::time::Duration::from_millis(500),
+                    crate::constants::timeout::SHUTDOWN_QUIT_WRITE,
                     conn.write_all(b"QUIT\r\n"),
                 )
                 .await;

--- a/src/pool/provider.rs
+++ b/src/pool/provider.rs
@@ -721,7 +721,12 @@ impl DeadpoolConnectionProvider {
         for _ in 0..status.available {
             if let Ok(conn_obj) = self.pool.timeout_get(&timeouts).await {
                 let mut conn = Object::take(conn_obj);
-                let _ = conn.write_all(b"QUIT\r\n").await;
+                // Timeout the write: a half-closed backend connection can block indefinitely
+                let _ = tokio::time::timeout(
+                    std::time::Duration::from_millis(500),
+                    conn.write_all(b"QUIT\r\n"),
+                )
+                .await;
             } else {
                 break;
             }

--- a/src/pool/provider.rs
+++ b/src/pool/provider.rs
@@ -1013,21 +1013,16 @@ mod tests {
         let keep_alive = Arc::new(tokio::sync::Notify::new());
 
         tokio::spawn(async move {
-            loop {
-                match listener.accept().await {
-                    Ok((mut stream, _)) => {
-                        let keep = keep_alive.clone();
-                        // Spawn a handler per connection so they stay alive concurrently
-                        tokio::spawn(async move {
-                            let _ = stream.write_all(b"200 mock\r\n").await;
-                            // Keep alive until test drops the connection.
-                            // Notify::notified() does NOT auto-advance with
-                            // start_paused, unlike sleep().
-                            keep.notified().await;
-                        });
-                    }
-                    Err(_) => break,
-                }
+            while let Ok((mut stream, _)) = listener.accept().await {
+                let keep = keep_alive.clone();
+                // Spawn a handler per connection so they stay alive concurrently
+                tokio::spawn(async move {
+                    let _ = stream.write_all(b"200 mock\r\n").await;
+                    // Keep alive until test drops the connection.
+                    // Notify::notified() does NOT auto-advance with
+                    // start_paused, unlike sleep().
+                    keep.notified().await;
+                });
             }
         });
 

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -166,10 +166,14 @@ impl NntpProxy {
         // With WriteOnInsertion, writes are enqueued async - close() waits for completion
         // Use a timeout: foyer's close() can hang if the runtime is winding down
         info!("Flushing disk cache writes...");
-        match tokio::time::timeout(std::time::Duration::from_secs(3), self.cache.close()).await {
+        match tokio::time::timeout(crate::constants::timeout::CACHE_CLOSE, self.cache.close()).await
+        {
             Ok(Ok(())) => {}
             Ok(Err(e)) => tracing::warn!("Error closing cache: {}", e),
-            Err(_) => tracing::warn!("Cache close timed out after 3s, forcing shutdown"),
+            Err(_) => tracing::warn!(
+                "Cache close timed out after {}s, forcing shutdown",
+                crate::constants::timeout::CACHE_CLOSE.as_secs()
+            ),
         }
 
         info!("Shutting down connection pools...");

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -164,9 +164,12 @@ impl NntpProxy {
 
         // Flush cache writes to disk before shutting down
         // With WriteOnInsertion, writes are enqueued async - close() waits for completion
+        // Use a timeout: foyer's close() can hang if the runtime is winding down
         info!("Flushing disk cache writes...");
-        if let Err(e) = self.cache.close().await {
-            tracing::warn!("Error closing cache: {}", e);
+        match tokio::time::timeout(std::time::Duration::from_secs(3), self.cache.close()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::warn!("Error closing cache: {}", e),
+            Err(_) => tracing::warn!("Cache close timed out after 3s, forcing shutdown"),
         }
 
         info!("Shutting down connection pools...");

--- a/src/session/auth_state.rs
+++ b/src/session/auth_state.rs
@@ -28,7 +28,7 @@ use std::sync::{Arc, OnceLock};
 /// // After authentication
 /// auth_state.mark_authenticated("user@example.com");
 /// assert!(auth_state.is_authenticated());
-/// assert_eq!(auth_state.username().unwrap().as_ref(), "user@example.com");
+/// assert_eq!(auth_state.username().unwrap(), "user@example.com");
 /// ```
 #[derive(Debug)]
 pub struct AuthState {
@@ -112,7 +112,7 @@ impl AuthState {
     /// auth_state.mark_authenticated("bob");
     ///
     /// assert!(auth_state.is_authenticated());
-    /// assert_eq!(auth_state.username().unwrap().as_ref(), "bob");
+    /// assert_eq!(auth_state.username().unwrap(), "bob");
     /// ```
     #[inline]
     pub fn mark_authenticated(&self, username: impl Into<Arc<str>>) {
@@ -138,11 +138,11 @@ impl AuthState {
     ///
     /// auth_state.mark_authenticated("charlie");
     /// let username = auth_state.username().unwrap();
-    /// assert_eq!(username.as_ref(), "charlie");
+    /// assert_eq!(username, "charlie");
     ///
     /// // Cloning is cheap (Arc reference count bump)
     /// let username2 = username.clone();
-    /// assert_eq!(username2.as_ref(), "charlie");
+    /// assert_eq!(username2, "charlie");
     /// ```
     #[inline]
     #[must_use]

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -201,8 +201,11 @@ impl ClientSession {
                 // For single-line 430, find boundary and save leftover
                 if !is_multiline && let Some(pos) = memchr::memchr(b'\n', chunk) {
                     let end = pos + 1;
-                    if end < n {
-                        conn.stash_leftover(&chunk[end..])?;
+                    if end < n
+                        && let Err(e) = conn.stash_leftover(&chunk[end..])
+                    {
+                        provider.remove_with_cooldown(conn);
+                        return Err(e);
                     }
                 }
 
@@ -289,8 +292,11 @@ impl ClientSession {
                 // Single-line response - find boundary and save leftover
                 let write_len = if let Some(pos) = memchr::memchr(b'\n', chunk) {
                     let end = pos + 1;
-                    if end < n {
-                        conn.stash_leftover(&chunk[end..])?;
+                    if end < n
+                        && let Err(e) = conn.stash_leftover(&chunk[end..])
+                    {
+                        provider.remove_with_cooldown(conn);
+                        return Err(e);
                     }
                     end
                 } else {

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -323,6 +323,18 @@ impl ClientSession {
             }
         }
 
+        if conn.has_leftover() {
+            warn!(
+                client = %self.client_addr,
+                backend = ?backend_id,
+                leftover_bytes = conn.leftover_len(),
+                "Batch article execution ended with buffered bytes; retiring connection to avoid cross-borrow desync"
+            );
+            provider.remove_with_cooldown(conn);
+            guard.complete();
+            return Ok(());
+        }
+
         // Connection healthy — conn drops here, returning to pool automatically
         guard.complete();
         Ok(())

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -92,7 +92,6 @@ impl ClientSession {
         // Phase 2: Read and stream responses in order
         // Acquire buffer once before loop (reused across responses)
         let mut buffer = self.buffer_pool.acquire().await;
-        let mut leftover = bytes::BytesMut::new(); // Tracks data from previous response
         let mut chunk_data = bytes::BytesMut::new(); // Holds leftover + new read combined
 
         for (i, command) in commands.iter().enumerate() {
@@ -100,54 +99,47 @@ impl ClientSession {
 
             // Get first chunk of this response
             chunk_data.clear();
-            let n = if !leftover.is_empty() {
-                // Use leftover data from previous response
-                chunk_data.extend_from_slice(&leftover);
-                leftover.clear();
-                chunk_data.len()
-            } else {
-                match buffer.read_from(&mut *conn).await {
-                    Ok(bytes_read) if bytes_read > 0 => {
-                        chunk_data.extend_from_slice(&buffer[..bytes_read]);
-                        bytes_read
+            let n = match buffer.read_from(&mut *conn).await {
+                Ok(bytes_read) if bytes_read > 0 => {
+                    chunk_data.extend_from_slice(&buffer[..bytes_read]);
+                    bytes_read
+                }
+                Ok(_) => {
+                    warn!(
+                        client = %self.client_addr,
+                        backend = ?backend_id,
+                        response_index = i + 1,
+                        total_commands = commands.len(),
+                        "Backend EOF during batch read, sending 430 for remaining commands"
+                    );
+                    // Send 430 for remaining commands to maintain protocol sync
+                    for remaining in &commands[i..] {
+                        self.send_430_to_client(client_write, backend_to_client_bytes)
+                            .await?;
+                        *client_to_backend_bytes = client_to_backend_bytes.add(remaining.len());
                     }
-                    Ok(_) => {
-                        warn!(
-                            client = %self.client_addr,
-                            backend = ?backend_id,
-                            response_index = i + 1,
-                            total_commands = commands.len(),
-                            "Backend EOF during batch read, sending 430 for remaining commands"
-                        );
-                        // Send 430 for remaining commands to maintain protocol sync
-                        for remaining in &commands[i..] {
-                            self.send_430_to_client(client_write, backend_to_client_bytes)
-                                .await?;
-                            *client_to_backend_bytes = client_to_backend_bytes.add(remaining.len());
-                        }
-                        provider.remove_with_cooldown(conn);
-                        guard.complete();
-                        return Ok(());
+                    provider.remove_with_cooldown(conn);
+                    guard.complete();
+                    return Ok(());
+                }
+                Err(e) => {
+                    warn!(
+                        client = %self.client_addr,
+                        backend = ?backend_id,
+                        response_index = i + 1,
+                        total_commands = commands.len(),
+                        error = %e,
+                        "Backend read error during batch, sending 430 for remaining commands"
+                    );
+                    // Send 430 for remaining commands to maintain protocol sync
+                    for remaining in &commands[i..] {
+                        self.send_430_to_client(client_write, backend_to_client_bytes)
+                            .await?;
+                        *client_to_backend_bytes = client_to_backend_bytes.add(remaining.len());
                     }
-                    Err(e) => {
-                        warn!(
-                            client = %self.client_addr,
-                            backend = ?backend_id,
-                            response_index = i + 1,
-                            total_commands = commands.len(),
-                            error = %e,
-                            "Backend read error during batch, sending 430 for remaining commands"
-                        );
-                        // Send 430 for remaining commands to maintain protocol sync
-                        for remaining in &commands[i..] {
-                            self.send_430_to_client(client_write, backend_to_client_bytes)
-                                .await?;
-                            *client_to_backend_bytes = client_to_backend_bytes.add(remaining.len());
-                        }
-                        provider.remove_with_cooldown(conn);
-                        guard.complete();
-                        return Ok(());
-                    }
+                    provider.remove_with_cooldown(conn);
+                    guard.complete();
+                    return Ok(());
                 }
             };
 
@@ -210,7 +202,7 @@ impl ClientSession {
                 if !is_multiline && let Some(pos) = memchr::memchr(b'\n', chunk) {
                     let end = pos + 1;
                     if end < n {
-                        leftover.extend_from_slice(&chunk[end..]);
+                        conn.stash_leftover(&chunk[end..])?;
                     }
                 }
 
@@ -257,14 +249,13 @@ impl ClientSession {
 
             let bytes_written = if is_multiline {
                 match streaming::stream_multiline_response_pipelined(
-                    &mut *conn,
+                    &mut conn,
                     client_write,
                     chunk,
                     n,
                     self.client_addr,
                     backend_id,
                     &self.buffer_pool,
-                    &mut leftover,
                 )
                 .await
                 {
@@ -299,7 +290,7 @@ impl ClientSession {
                 let write_len = if let Some(pos) = memchr::memchr(b'\n', chunk) {
                     let end = pos + 1;
                     if end < n {
-                        leftover.extend_from_slice(&chunk[end..]);
+                        conn.stash_leftover(&chunk[end..])?;
                     }
                     end
                 } else {

--- a/src/session/handlers/pipeline_worker.rs
+++ b/src/session/handlers/pipeline_worker.rs
@@ -52,7 +52,6 @@ pub async fn backend_pipeline_worker(
     );
 
     // Hoist buffers to worker lifetime (reused across batches)
-    let mut leftover = bytes::BytesMut::new();
     let mut result_buf = bytes::BytesMut::with_capacity(4096);
 
     loop {
@@ -66,7 +65,6 @@ pub async fn backend_pipeline_worker(
         );
 
         // Clear buffers for this batch
-        leftover.clear();
         result_buf.clear();
 
         // Acquire a connection from the pool
@@ -90,7 +88,6 @@ pub async fn backend_pipeline_worker(
             batch,
             &metrics,
             &buffer_pool,
-            &mut leftover,
             &mut result_buf,
         )
         .await;
@@ -116,7 +113,6 @@ async fn execute_pipeline_batch(
     batch: Vec<QueuedRequest>,
     metrics: &MetricsCollector,
     buffer_pool: &BufferPool,
-    leftover: &mut bytes::BytesMut,
     result_buf: &mut bytes::BytesMut,
 ) -> bool {
     let batch_len = batch.len();
@@ -157,7 +153,7 @@ async fn execute_pipeline_batch(
     let mut batch_iter = batch.into_iter().enumerate();
     while let Some((i, req)) = batch_iter.next() {
         // Read the response for this command
-        match read_full_response(&mut buffer, conn, leftover, result_buf).await {
+        match read_full_response(&mut buffer, conn, result_buf).await {
             Ok((data, status_code)) => {
                 metrics.record_command(backend_id);
                 let data_len = data.len();
@@ -178,7 +174,7 @@ async fn execute_pipeline_batch(
                     batch_size = batch_len,
                     command = %req.command.trim(),
                     error = %e,
-                    leftover_bytes = leftover.len(),
+                    leftover_bytes = conn.leftover_len(),
                     "Pipeline worker read failed"
                 );
 
@@ -211,7 +207,7 @@ async fn execute_pipeline_batch(
     //
     // Explicit health check: Verify leftover is reasonable
     debug_assert!(
-        leftover.len() <= crate::constants::buffer::MAX_LEFTOVER_BYTES,
+        conn.leftover_len() <= crate::constants::buffer::MAX_LEFTOVER_BYTES,
         "Leftover buffer should never exceed MAX_LEFTOVER_BYTES after successful batch"
     );
 
@@ -221,13 +217,11 @@ async fn execute_pipeline_batch(
 /// Read a complete NNTP response (status line + multiline body if applicable).
 ///
 /// Returns the full response as `Bytes` and the parsed status code.
-/// If leftover bytes from a previous response are provided, they are processed first.
 ///
 /// `result_buf` is cleared and reused for each response to avoid per-response allocations.
 async fn read_full_response(
     buffer: &mut crate::pool::PooledBuffer,
     conn: &mut crate::stream::ConnectionStream,
-    leftover: &mut bytes::BytesMut,
     result_buf: &mut bytes::BytesMut,
 ) -> Result<(bytes::Bytes, crate::protocol::StatusCode)> {
     use crate::session::streaming::tail_buffer::TailBuffer;
@@ -236,16 +230,11 @@ async fn read_full_response(
     result_buf.clear(); // Reuse buffer from previous response
 
     // Get first data directly into result_buf (no intermediate Vec)
-    if !leftover.is_empty() {
-        result_buf.extend_from_slice(leftover);
-        leftover.clear();
-    } else {
-        let n = buffer.read_from(conn).await?;
-        if n == 0 {
-            anyhow::bail!("Backend connection closed unexpectedly");
-        }
-        result_buf.extend_from_slice(&buffer[..n]);
+    let n = buffer.read_from(conn).await?;
+    if n == 0 {
+        anyhow::bail!("Backend connection closed unexpectedly");
     }
+    result_buf.extend_from_slice(&buffer[..n]);
 
     // H5: If leftover was too short to validate, read more data
     if result_buf.len() < crate::protocol::MIN_RESPONSE_LENGTH {
@@ -282,7 +271,7 @@ async fn read_full_response(
                     crate::constants::buffer::MAX_LEFTOVER_BYTES,
                     remainder.len()
                 );
-                leftover.extend_from_slice(remainder);
+                conn.stash_leftover(remainder)?;
                 result_buf.truncate(end);
             }
         }
@@ -302,7 +291,7 @@ async fn read_full_response(
             crate::constants::buffer::MAX_LEFTOVER_BYTES,
             remainder.len()
         );
-        leftover.extend_from_slice(remainder);
+        conn.stash_leftover(remainder)?;
         result_buf.truncate(write_len);
     }
 
@@ -333,7 +322,7 @@ async fn read_full_response(
                         crate::constants::buffer::MAX_LEFTOVER_BYTES,
                         remainder.len()
                     );
-                    leftover.extend_from_slice(remainder);
+                    conn.stash_leftover(remainder)?;
                 }
                 break;
             }
@@ -376,7 +365,7 @@ mod tests {
         });
 
         let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        ConnectionStream::Plain(stream)
+        ConnectionStream::plain(stream)
     }
 
     /// Helper: create a TCP pair where the server writes `chunks` with delays.
@@ -396,7 +385,7 @@ mod tests {
         });
 
         let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        ConnectionStream::Plain(stream)
+        ConnectionStream::plain(stream)
     }
 
     // ─── read_full_response unit tests ───────────────────────────────────────
@@ -405,46 +394,41 @@ mod tests {
     async fn test_read_full_response_single_line() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut leftover = BytesMut::new();
         let mut result_buf = BytesMut::with_capacity(4096);
 
         let mut conn = mock_backend_conn(b"430 No such article\r\n").await;
 
-        let (data, status) =
-            read_full_response(&mut buffer, &mut conn, &mut leftover, &mut result_buf)
-                .await
-                .expect("should parse single-line response");
+        let (data, status) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+            .await
+            .expect("should parse single-line response");
 
         assert_eq!(status.as_u16(), 430);
         assert_eq!(&data[..], b"430 No such article\r\n");
-        assert!(leftover.is_empty());
+        assert!(!conn.has_leftover());
     }
 
     #[tokio::test]
     async fn test_read_full_response_multiline() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut leftover = BytesMut::new();
         let mut result_buf = BytesMut::with_capacity(4096);
 
         let response = b"220 0 <msg@id> article\r\nSubject: test\r\n\r\nBody line\r\n.\r\n";
         let mut conn = mock_backend_conn(response).await;
 
-        let (data, status) =
-            read_full_response(&mut buffer, &mut conn, &mut leftover, &mut result_buf)
-                .await
-                .expect("should parse multiline response");
+        let (data, status) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+            .await
+            .expect("should parse multiline response");
 
         assert_eq!(status.as_u16(), 220);
         assert_eq!(&data[..], &response[..]);
-        assert!(leftover.is_empty());
+        assert!(!conn.has_leftover());
     }
 
     #[tokio::test]
     async fn test_read_full_response_multiline_across_chunks() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut leftover = BytesMut::new();
         let mut result_buf = BytesMut::with_capacity(4096);
 
         // Split the terminator \r\n.\r\n across two chunks
@@ -453,24 +437,22 @@ mod tests {
 
         let mut conn = mock_backend_conn_chunked(vec![chunk1, chunk2]).await;
 
-        let (data, status) =
-            read_full_response(&mut buffer, &mut conn, &mut leftover, &mut result_buf)
-                .await
-                .expect("should detect terminator across chunks");
+        let (data, status) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+            .await
+            .expect("should detect terminator across chunks");
 
         assert_eq!(status.as_u16(), 220);
         assert!(
             data.ends_with(b"\r\n.\r\n"),
             "response should end with terminator"
         );
-        assert!(leftover.is_empty());
+        assert!(!conn.has_leftover());
     }
 
     #[tokio::test]
     async fn test_read_full_response_with_leftover() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut leftover = BytesMut::new();
         let mut result_buf = BytesMut::with_capacity(4096);
 
         // Two responses packed together
@@ -478,23 +460,21 @@ mod tests {
         let mut conn = mock_backend_conn(packed).await;
 
         // First read should get the multiline response and save leftover
-        let (data1, status1) =
-            read_full_response(&mut buffer, &mut conn, &mut leftover, &mut result_buf)
-                .await
-                .expect("should parse first response");
+        let (data1, status1) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+            .await
+            .expect("should parse first response");
 
         assert_eq!(status1.as_u16(), 220);
         assert!(data1.ends_with(b"\r\n.\r\n"));
         assert!(
-            !leftover.is_empty(),
+            conn.has_leftover(),
             "should have leftover from second response"
         );
 
         // Second read should consume leftover and return the 430
-        let (data2, status2) =
-            read_full_response(&mut buffer, &mut conn, &mut leftover, &mut result_buf)
-                .await
-                .expect("should parse second response from leftover");
+        let (data2, status2) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+            .await
+            .expect("should parse second response from leftover");
 
         assert_eq!(status2.as_u16(), 430);
         assert_eq!(&data2[..], b"430 No such article\r\n");
@@ -504,14 +484,12 @@ mod tests {
     async fn test_read_full_response_eof_mid_stream() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut leftover = BytesMut::new();
         let mut result_buf = BytesMut::with_capacity(4096);
 
         // Multiline response without terminator — server disconnects
         let mut conn = mock_backend_conn(b"220 0 <a@b> article\r\nBody line\r\n").await;
 
-        let result =
-            read_full_response(&mut buffer, &mut conn, &mut leftover, &mut result_buf).await;
+        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf).await;
         assert!(result.is_err(), "EOF before terminator should be an error");
         let err = result.unwrap_err().to_string();
         assert!(
@@ -524,13 +502,11 @@ mod tests {
     async fn test_read_full_response_invalid_status() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut leftover = BytesMut::new();
         let mut result_buf = BytesMut::with_capacity(4096);
 
         let mut conn = mock_backend_conn(b"garbage data here\r\n").await;
 
-        let result =
-            read_full_response(&mut buffer, &mut conn, &mut leftover, &mut result_buf).await;
+        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf).await;
         assert!(result.is_err(), "Invalid status code should be an error");
     }
 
@@ -540,16 +516,14 @@ mod tests {
         let mut buffer = pool.acquire().await;
         let mut result_buf = BytesMut::with_capacity(4096);
 
-        // Leftover is only 2 bytes — too short to validate, triggers H5 additional read
-        let mut leftover = BytesMut::from(&b"43"[..]);
-
         // Backend will provide the rest of the response
         let mut conn = mock_backend_conn(b"0 No such article\r\n").await;
+        // Leftover is only 2 bytes — too short to validate, triggers H5 additional read
+        conn.stash_leftover(b"43").unwrap();
 
-        let (data, status) =
-            read_full_response(&mut buffer, &mut conn, &mut leftover, &mut result_buf)
-                .await
-                .expect("short leftover + read should produce valid response");
+        let (data, status) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+            .await
+            .expect("short leftover + read should produce valid response");
 
         assert_eq!(status.as_u16(), 430);
         assert!(data.starts_with(b"430"));
@@ -559,14 +533,12 @@ mod tests {
     async fn test_read_full_response_empty_connection() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut leftover = BytesMut::new();
         let mut result_buf = BytesMut::with_capacity(4096);
 
         // Server immediately closes
         let mut conn = mock_backend_conn(b"").await;
 
-        let result =
-            read_full_response(&mut buffer, &mut conn, &mut leftover, &mut result_buf).await;
+        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf).await;
         assert!(result.is_err(), "Empty connection should be an error");
     }
 
@@ -643,7 +615,7 @@ mod tests {
         });
 
         let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let mut conn: crate::stream::ConnectionStream = ConnectionStream::Plain(stream);
+        let mut conn: crate::stream::ConnectionStream = ConnectionStream::plain(stream);
 
         let (tx, rx) = tokio::sync::oneshot::channel();
         let batch = vec![QueuedRequest {
@@ -651,7 +623,6 @@ mod tests {
             response_tx: tx,
         }];
 
-        let mut leftover = bytes::BytesMut::new();
         let mut result_buf = bytes::BytesMut::with_capacity(4096);
 
         let success = execute_pipeline_batch(
@@ -660,7 +631,6 @@ mod tests {
             batch,
             &metrics,
             &pool,
-            &mut leftover,
             &mut result_buf,
         )
         .await;
@@ -699,7 +669,7 @@ mod tests {
         });
 
         let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let mut conn = ConnectionStream::Plain(stream);
+        let mut conn = ConnectionStream::plain(stream);
 
         let (tx1, rx1) = tokio::sync::oneshot::channel();
         let (tx2, rx2) = tokio::sync::oneshot::channel();
@@ -714,7 +684,6 @@ mod tests {
             },
         ];
 
-        let mut leftover = bytes::BytesMut::new();
         let mut result_buf = bytes::BytesMut::with_capacity(4096);
 
         let success = execute_pipeline_batch(
@@ -723,7 +692,6 @@ mod tests {
             batch,
             &metrics,
             &pool,
-            &mut leftover,
             &mut result_buf,
         )
         .await;
@@ -764,7 +732,7 @@ mod tests {
         });
 
         let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let mut conn = ConnectionStream::Plain(stream);
+        let mut conn = ConnectionStream::plain(stream);
 
         let (tx1, rx1) = tokio::sync::oneshot::channel();
         let (tx2, rx2) = tokio::sync::oneshot::channel();
@@ -779,7 +747,6 @@ mod tests {
             },
         ];
 
-        let mut leftover = bytes::BytesMut::new();
         let mut result_buf = bytes::BytesMut::with_capacity(4096);
 
         let success = execute_pipeline_batch(
@@ -788,7 +755,6 @@ mod tests {
             batch,
             &metrics,
             &pool,
-            &mut leftover,
             &mut result_buf,
         )
         .await;
@@ -824,7 +790,6 @@ mod tests {
 
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut leftover = BytesMut::new();
         let mut result_buf = BytesMut::with_capacity(4096);
 
         // Create a multiline response that accumulates in result_buf across chunks,
@@ -856,8 +821,7 @@ mod tests {
 
         let mut conn = mock_backend_conn_chunked(chunks).await;
 
-        let result =
-            read_full_response(&mut buffer, &mut conn, &mut leftover, &mut result_buf).await;
+        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf).await;
 
         // Should fail with bounds check error (if TCP delivers enough data in one read)
         assert!(
@@ -877,7 +841,6 @@ mod tests {
 
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut leftover = BytesMut::new();
         let mut result_buf = BytesMut::with_capacity(4096);
 
         // Create a response where leftover is within bounds (< MAX_LEFTOVER_BYTES)
@@ -888,8 +851,7 @@ mod tests {
 
         let mut conn = mock_backend_conn(&normal_data).await;
 
-        let result =
-            read_full_response(&mut buffer, &mut conn, &mut leftover, &mut result_buf).await;
+        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf).await;
 
         // Should succeed
         assert!(
@@ -897,11 +859,11 @@ mod tests {
             "Should succeed when leftover is within max size"
         );
         assert!(
-            !leftover.is_empty(),
+            conn.has_leftover(),
             "Should have leftover from second response"
         );
         assert!(
-            leftover.len() < MAX_LEFTOVER_BYTES,
+            conn.leftover_len() < MAX_LEFTOVER_BYTES,
             "Leftover should be under limit"
         );
     }

--- a/src/session/handlers/pipeline_worker.rs
+++ b/src/session/handlers/pipeline_worker.rs
@@ -197,19 +197,23 @@ async fn execute_pipeline_batch(
         }
     }
 
-    // All responses processed successfully — connection healthy
-    //
-    // Health validation: Successful reading of all responses (including
-    // terminators) serves as an implicit health check. If the connection
-    // was in a bad state, read_full_response would have failed. The leftover
-    // buffer bounds are enforced in read_full_response (MAX_LEFTOVER_BYTES),
-    // preventing protocol desync from leaving the connection unusable.
-    //
-    // Explicit health check: Verify leftover is reasonable
+    // All responses processed successfully. Leftover is valid only while there
+    // are more already-sent responses remaining in this borrow. If bytes remain
+    // after the final expected response, returning the connection to the pool
+    // would leak stale backend data into the next borrower.
     debug_assert!(
         conn.leftover_len() <= crate::constants::buffer::MAX_LEFTOVER_BYTES,
         "Leftover buffer should never exceed MAX_LEFTOVER_BYTES after successful batch"
     );
+
+    if conn.has_leftover() {
+        warn!(
+            backend = ?backend_id,
+            leftover_bytes = conn.leftover_len(),
+            "Pipeline batch ended with buffered bytes; retiring connection to avoid cross-borrow desync"
+        );
+        return false;
+    }
 
     true
 }
@@ -348,6 +352,7 @@ mod tests {
     use crate::pool::BufferPool;
     use crate::stream::ConnectionStream;
     use bytes::BytesMut;
+    use proptest::prelude::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
 
@@ -386,6 +391,78 @@ mod tests {
 
         let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
         ConnectionStream::plain(stream)
+    }
+
+    async fn run_single_line_pipeline_batch(
+        responses: &[Vec<u8>],
+        extra_tail: &[u8],
+    ) -> (bool, Vec<PipelineResponse>, bool, usize) {
+        use tokio::io::AsyncReadExt;
+
+        let pool = BufferPool::for_tests();
+        let metrics = MetricsCollector::new(responses.len());
+        let backend_id = BackendId::from_index(0);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let wire_data = {
+            let mut data = Vec::new();
+            for response in responses {
+                data.extend_from_slice(response);
+            }
+            data.extend_from_slice(extra_tail);
+            data
+        };
+
+        let mut batch = Vec::with_capacity(responses.len());
+        let mut rxs = Vec::with_capacity(responses.len());
+        let mut expected_command_bytes = 0usize;
+        for idx in 0..responses.len() {
+            let (tx, rx) = tokio::sync::oneshot::channel();
+            let command = format!("STAT <msg{idx}@example.com>\r\n");
+            expected_command_bytes += command.len();
+            batch.push(QueuedRequest {
+                command: Arc::from(command),
+                response_tx: tx,
+            });
+            rxs.push(rx);
+        }
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 1024];
+            let mut received = 0usize;
+            while received < expected_command_bytes {
+                match stream.read(&mut buf).await {
+                    Ok(0) => break,
+                    Ok(n) => received += n,
+                    Err(_) => break,
+                }
+            }
+            stream.write_all(&wire_data).await.unwrap();
+            stream.shutdown().await.unwrap();
+        });
+
+        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let mut conn = ConnectionStream::plain(stream);
+
+        let mut result_buf = bytes::BytesMut::with_capacity(4096);
+        let success = execute_pipeline_batch(
+            backend_id,
+            &mut conn,
+            batch,
+            &metrics,
+            &pool,
+            &mut result_buf,
+        )
+        .await;
+
+        let mut results = Vec::with_capacity(rxs.len());
+        for rx in rxs {
+            results.push(rx.await.unwrap());
+        }
+
+        (success, results, conn.has_leftover(), conn.leftover_len())
     }
 
     // ─── read_full_response unit tests ───────────────────────────────────────
@@ -771,6 +848,171 @@ mod tests {
         match rx2.await.unwrap() {
             PipelineResponse::Error(_) => {} // Expected
             other => panic!("Expected error for second, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pipeline_batch_retires_connection_with_leftover_after_final_response() {
+        use tokio::io::AsyncReadExt;
+
+        let pool = BufferPool::for_tests();
+        let metrics = MetricsCollector::new(2);
+        let backend_id = BackendId::from_index(0);
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut buf = [0u8; 512];
+            let _ = stream.read(&mut buf).await;
+            stream
+                .write_all(b"223 0 <a@b> status\r\n430 No such article\r\n111 20260411120000\r\n")
+                .await
+                .unwrap();
+            stream.shutdown().await.unwrap();
+        });
+
+        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+        let mut conn = ConnectionStream::plain(stream);
+
+        let (tx1, rx1) = tokio::sync::oneshot::channel();
+        let (tx2, rx2) = tokio::sync::oneshot::channel();
+        let batch = vec![
+            QueuedRequest {
+                command: Arc::from("STAT <a@b>\r\n"),
+                response_tx: tx1,
+            },
+            QueuedRequest {
+                command: Arc::from("STAT <c@d>\r\n"),
+                response_tx: tx2,
+            },
+        ];
+
+        let mut result_buf = bytes::BytesMut::with_capacity(4096);
+
+        let success = execute_pipeline_batch(
+            backend_id,
+            &mut conn,
+            batch,
+            &metrics,
+            &pool,
+            &mut result_buf,
+        )
+        .await;
+
+        assert!(
+            !success,
+            "leftover after the final expected response should retire the connection"
+        );
+        assert!(
+            conn.has_leftover(),
+            "unexpected extra response bytes should remain buffered until the connection is retired"
+        );
+
+        match rx1.await.unwrap() {
+            PipelineResponse::Success { status_code, .. } => {
+                assert_eq!(status_code.as_u16(), 223);
+            }
+            other => panic!("Expected 223 Success, got {other:?}"),
+        }
+        match rx2.await.unwrap() {
+            PipelineResponse::Success { status_code, .. } => {
+                assert_eq!(status_code.as_u16(), 430);
+            }
+            other => panic!("Expected 430 Success, got {other:?}"),
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn prop_read_full_response_preserves_intra_batch_single_line_framing(
+            // RFC 3977 command/response model:
+            // - client may pipeline multiple commands on one TCP stream
+            // - server processes them in order and sends responses in that order
+            //   (RFC 3977 §3.5)
+            //
+            // These generated responses are intentionally single-line so the end
+            // of each response is the first CRLF, matching the framing rule we
+            // use before handing any remainder to the next already-sent command.
+            // 223 STAT success and 430/500 errors are all single-line responses
+            // under RFC 3977.
+            codes in prop::collection::vec(prop_oneof![Just(223u16), Just(430u16), Just(500u16)], 1..6),
+            suffix in prop::collection::vec(any::<u8>(), 0..16),
+        ) {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(async {
+                let pool = BufferPool::for_tests();
+                let mut buffer = pool.acquire().await;
+                let mut result_buf = BytesMut::with_capacity(4096);
+
+                let responses: Vec<Vec<u8>> = codes
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, code)| format!("{code} resp{idx}\r\n").into_bytes())
+                    .collect();
+
+                let mut wire = Vec::new();
+                for response in &responses {
+                    wire.extend_from_slice(response);
+                }
+                wire.extend_from_slice(&suffix);
+
+                let mut conn = mock_backend_conn(&wire).await;
+
+                for (idx, expected) in responses.iter().enumerate() {
+                    let (data, status) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+                        .await
+                        .expect("packed single-line response should parse");
+
+                    prop_assert_eq!(&data[..], expected.as_slice());
+                    prop_assert_eq!(status.as_u16(), codes[idx]);
+                }
+
+                prop_assert_eq!(conn.leftover_len(), suffix.len());
+                Ok(())
+            })?;
+        }
+
+        #[test]
+        fn prop_execute_pipeline_batch_reuses_connection_only_when_final_tail_is_empty(
+            // RFC 3977 §3.5 allows pipelining, but the server still only sends
+            // data in response to client commands and must process them in order.
+            // So leftover bytes are valid only while there are more already-sent
+            // commands remaining in the current borrow. After the final expected
+            // response, any buffered bytes must retire the connection instead of
+            // crossing a pool borrow boundary.
+            codes in prop::collection::vec(prop_oneof![Just(223u16), Just(430u16), Just(500u16)], 1..5),
+            extra_tail in prop::collection::vec(any::<u8>(), 0..24),
+        ) {
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(async {
+                let responses: Vec<Vec<u8>> = codes
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, code)| format!("{code} batch{idx}\r\n").into_bytes())
+                    .collect();
+
+                let (success, results, has_leftover, leftover_len) =
+                    run_single_line_pipeline_batch(&responses, &extra_tail).await;
+
+                prop_assert_eq!(results.len(), responses.len());
+                for (idx, result) in results.into_iter().enumerate() {
+                    match result {
+                        PipelineResponse::Success { status_code, data, .. } => {
+                            prop_assert_eq!(status_code.as_u16(), codes[idx]);
+                            prop_assert_eq!(&data[..], responses[idx].as_slice());
+                        }
+                        other => prop_assert!(false, "expected success response, got {other:?}"),
+                    }
+                }
+
+                let expect_reuse = extra_tail.is_empty();
+                prop_assert_eq!(success, expect_reuse);
+                prop_assert_eq!(has_leftover, !extra_tail.is_empty());
+                prop_assert_eq!(leftover_len, extra_tail.len());
+                Ok(())
+            })?;
         }
     }
 

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -122,7 +122,14 @@ async fn execute_backend_query(
                         tail.update(&response);
                         loop {
                             match conn.as_mut().read(buffer.as_mut_slice()).await {
-                                Ok(0) | Err(_) => break,
+                                Ok(0) => {
+                                    crate::pool::remove_from_pool(conn);
+                                    return Err(());
+                                }
+                                Err(_) => {
+                                    crate::pool::remove_from_pool(conn);
+                                    return Err(());
+                                }
                                 Ok(n) => match tail.detect_terminator(&buffer[..n]) {
                                     TerminatorStatus::FoundAt(pos) => {
                                         if pos < n && conn.stash_leftover(&buffer[pos..n]).is_err()
@@ -389,6 +396,8 @@ pub fn spawn_background_precheck(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::time::Duration;
 
     #[test]
     fn summarize_finds_first() {
@@ -421,5 +430,71 @@ mod tests {
         let (found, avail) = summarize(vec![]);
         assert!(found.is_none());
         assert_eq!(avail.checked_bits(), 0);
+    }
+
+    async fn spawn_truncated_precheck_server() -> std::net::SocketAddr {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            loop {
+                if let Ok((mut stream, _)) = listener.accept().await {
+                    tokio::spawn(async move {
+                        let _ = stream.write_all(b"200 mock\r\n").await;
+                        let mut buf = [0u8; 1024];
+                        let _ = stream.read(&mut buf).await;
+                        let _ = stream
+                            .write_all(b"220 0 <test@example.com>\r\npartial body")
+                            .await;
+                        let _ = stream.shutdown().await;
+                    });
+                }
+            }
+        });
+
+        addr
+    }
+
+    #[tokio::test]
+    async fn query_backend_returns_error_on_truncated_multiline_response() {
+        use crate::cache::UnifiedCache;
+        use crate::metrics::MetricsCollector;
+        use crate::pool::{BufferPool, DeadpoolConnectionProvider};
+        use crate::router::BackendSelector;
+        use crate::types::{BackendId, BufferSize, ServerName};
+
+        let addr = spawn_truncated_precheck_server().await;
+
+        let mut selector = BackendSelector::new();
+        let backend_id = BackendId::from_index(0);
+        let provider = DeadpoolConnectionProvider::new(
+            "127.0.0.1".to_string(),
+            addr.port(),
+            "test".to_string(),
+            2,
+            None,
+            None,
+        );
+        selector.add_backend(
+            backend_id,
+            ServerName::try_new("test-server".to_string()).unwrap(),
+            provider,
+            0,
+            None,
+        );
+
+        let deps = OwnedDeps {
+            router: Arc::new(selector),
+            cache: Arc::new(UnifiedCache::memory(100, Duration::from_secs(60), true)),
+            buffer_pool: BufferPool::new(BufferSize::try_new(4096).unwrap(), 2),
+            metrics: MetricsCollector::new(1),
+            cache_articles: true,
+        };
+
+        let result = query_backend(&deps, backend_id, "ARTICLE <test@example.com>\r\n", true).await;
+        assert_eq!(result, QueryResult::Error(backend_id));
     }
 }

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -107,11 +107,31 @@ async fn execute_backend_query(
             // For multiline responses, read remaining data until we have the full terminator
             let mut response = buffer[..cmd_response.bytes_read].to_vec();
             if multiline && cmd_response.is_multiline {
-                // Read until we have the complete NNTP terminator \r\n.\r\n
-                while !crate::protocol::has_multiline_terminator(&response) {
-                    match conn.as_mut().read(buffer.as_mut_slice()).await {
-                        Ok(0) | Err(_) => break,
-                        Ok(n) => response.extend_from_slice(&buffer[..n]),
+                use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
+                let mut tail = TailBuffer::default();
+                match tail.detect_terminator(&response) {
+                    TerminatorStatus::FoundAt(pos) => {
+                        // First chunk already contains terminator; drop any bytes after it
+                        response.truncate(pos);
+                    }
+                    TerminatorStatus::NotFound => {
+                        tail.update(&response);
+                        loop {
+                            match conn.as_mut().read(buffer.as_mut_slice()).await {
+                                Ok(0) | Err(_) => break,
+                                Ok(n) => match tail.detect_terminator(&buffer[..n]) {
+                                    TerminatorStatus::FoundAt(pos) => {
+                                        // Only extend up to terminator end; discard leftover bytes
+                                        response.extend_from_slice(&buffer[..pos]);
+                                        break;
+                                    }
+                                    TerminatorStatus::NotFound => {
+                                        tail.update(&buffer[..n]);
+                                        response.extend_from_slice(&buffer[..n]);
+                                    }
+                                },
+                            }
+                        }
                     }
                 }
             }

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -106,12 +106,18 @@ async fn execute_backend_query(
 
             // For multiline responses, read remaining data until we have the full terminator
             let mut response = buffer[..cmd_response.bytes_read].to_vec();
+            let mut conn_desynced = false;
             if multiline && cmd_response.is_multiline {
                 use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
                 let mut tail = TailBuffer::default();
                 match tail.detect_terminator(&response) {
                     TerminatorStatus::FoundAt(pos) => {
-                        // First chunk already contains terminator; drop any bytes after it
+                        // Terminator found in first chunk; truncate to terminator end.
+                        // If pos < response.len(), extra bytes were already consumed from
+                        // the socket — connection is desynchronized and must not be reused.
+                        if pos < response.len() {
+                            conn_desynced = true;
+                        }
                         response.truncate(pos);
                     }
                     TerminatorStatus::NotFound => {
@@ -121,7 +127,11 @@ async fn execute_backend_query(
                                 Ok(0) | Err(_) => break,
                                 Ok(n) => match tail.detect_terminator(&buffer[..n]) {
                                     TerminatorStatus::FoundAt(pos) => {
-                                        // Only extend up to terminator end; discard leftover bytes
+                                        // Only extend up to terminator end.
+                                        // If pos < n, leftover bytes already consumed from socket.
+                                        if pos < n {
+                                            conn_desynced = true;
+                                        }
                                         response.extend_from_slice(&buffer[..pos]);
                                         break;
                                     }
@@ -136,7 +146,7 @@ async fn execute_backend_query(
                 }
             }
 
-            Ok(match status_code.as_u16() {
+            let query_result = match status_code.as_u16() {
                 220..=223 => {
                     // Record successful command and timing
                     tracing::debug!(
@@ -162,7 +172,12 @@ async fn execute_backend_query(
                     QueryResult::Missing(backend_id)
                 }
                 _ => QueryResult::Error(backend_id),
-            })
+            };
+
+            if conn_desynced {
+                crate::pool::remove_from_pool(conn);
+            }
+            Ok(query_result)
         }
         Err(_) => {
             // Connection error - remove stale connection from pool

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -106,18 +106,13 @@ async fn execute_backend_query(
 
             // For multiline responses, read remaining data until we have the full terminator
             let mut response = buffer[..cmd_response.bytes_read].to_vec();
-            let mut conn_desynced = false;
             if multiline && cmd_response.is_multiline {
                 use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
                 let mut tail = TailBuffer::default();
                 match tail.detect_terminator(&response) {
                     TerminatorStatus::FoundAt(pos) => {
-                        // Terminator found in first chunk; truncate to terminator end.
-                        // If pos < response.len(), extra bytes were already consumed from
-                        // the socket — connection is desynchronized and must not be reused.
-                        if pos < response.len() {
-                            conn_desynced = true;
-                        }
+                        // pos is the position after the terminator (terminator included).
+                        // Truncate response to pos; discard any bytes read past the terminator.
                         response.truncate(pos);
                     }
                     TerminatorStatus::NotFound => {
@@ -127,11 +122,7 @@ async fn execute_backend_query(
                                 Ok(0) | Err(_) => break,
                                 Ok(n) => match tail.detect_terminator(&buffer[..n]) {
                                     TerminatorStatus::FoundAt(pos) => {
-                                        // Only extend up to terminator end.
-                                        // If pos < n, leftover bytes already consumed from socket.
-                                        if pos < n {
-                                            conn_desynced = true;
-                                        }
+                                        // pos is after the terminator (terminator included).
                                         response.extend_from_slice(&buffer[..pos]);
                                         break;
                                     }
@@ -174,9 +165,6 @@ async fn execute_backend_query(
                 _ => QueryResult::Error(backend_id),
             };
 
-            if conn_desynced {
-                crate::pool::remove_from_pool(conn);
-            }
             Ok(query_result)
         }
         Err(_) => {

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -111,8 +111,7 @@ async fn execute_backend_query(
                 let mut tail = TailBuffer::default();
                 match tail.detect_terminator(&response) {
                     TerminatorStatus::FoundAt(pos) => {
-                        // pos is the position after the terminator (terminator included).
-                        // Truncate response to pos; discard any bytes read past the terminator.
+                        // pos is after the terminator (terminator included in [..pos])
                         response.truncate(pos);
                     }
                     TerminatorStatus::NotFound => {
@@ -122,7 +121,6 @@ async fn execute_backend_query(
                                 Ok(0) | Err(_) => break,
                                 Ok(n) => match tail.detect_terminator(&buffer[..n]) {
                                     TerminatorStatus::FoundAt(pos) => {
-                                        // pos is after the terminator (terminator included).
                                         response.extend_from_slice(&buffer[..pos]);
                                         break;
                                     }

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -5,8 +5,6 @@
 
 use std::sync::Arc;
 
-use tokio::io::AsyncReadExt;
-
 use crate::cache::{ArticleAvailability, ArticleEntry, UnifiedCache};
 use crate::metrics::MetricsCollector;
 use crate::pool::BufferPool;
@@ -121,7 +119,7 @@ async fn execute_backend_query(
                     TerminatorStatus::NotFound => {
                         tail.update(&response);
                         loop {
-                            match conn.as_mut().read(buffer.as_mut_slice()).await {
+                            match buffer.read_from(conn.as_mut()).await {
                                 Ok(0) => {
                                     crate::pool::remove_from_pool(conn);
                                     return Err(());

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -112,6 +112,10 @@ async fn execute_backend_query(
                 match tail.detect_terminator(&response) {
                     TerminatorStatus::FoundAt(pos) => {
                         // pos is after the terminator (terminator included in [..pos])
+                        if pos < response.len() && conn.stash_leftover(&response[pos..]).is_err() {
+                            crate::pool::remove_from_pool(conn);
+                            return Err(());
+                        }
                         response.truncate(pos);
                     }
                     TerminatorStatus::NotFound => {
@@ -121,6 +125,11 @@ async fn execute_backend_query(
                                 Ok(0) | Err(_) => break,
                                 Ok(n) => match tail.detect_terminator(&buffer[..n]) {
                                     TerminatorStatus::FoundAt(pos) => {
+                                        if pos < n && conn.stash_leftover(&buffer[pos..n]).is_err()
+                                        {
+                                            crate::pool::remove_from_pool(conn);
+                                            return Err(());
+                                        }
                                         response.extend_from_slice(&buffer[..pos]);
                                         break;
                                     }

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -183,21 +183,20 @@ where
 /// Like `stream_multiline_response`, but captures leftover bytes after the terminator
 /// into `leftover` for use as the start of the next response in the pipeline.
 #[allow(clippy::too_many_arguments)]
-pub async fn stream_multiline_response_pipelined<R, W>(
-    backend_read: &mut R,
+pub async fn stream_multiline_response_pipelined<W>(
+    backend_read: &mut crate::stream::ConnectionStream,
     client_write: &mut W,
     first_chunk: &[u8],
     first_n: usize,
     client_addr: crate::types::ClientAddress,
     backend_id: crate::types::BackendId,
     buffer_pool: &crate::pool::BufferPool,
-    leftover: &mut bytes::BytesMut,
 ) -> Result<u64>
 where
-    R: AsyncReadExt + Unpin,
     W: AsyncWriteExt + Unpin,
 {
-    stream_multiline_response_impl(
+    let mut leftover = bytes::BytesMut::new();
+    let total = stream_multiline_response_impl(
         backend_read,
         client_write,
         first_chunk,
@@ -206,9 +205,13 @@ where
         backend_id,
         buffer_pool,
         None,
-        Some(leftover),
+        Some(&mut leftover),
     )
-    .await
+    .await?;
+    if !leftover.is_empty() {
+        backend_read.stash_leftover(&leftover)?;
+    }
+    Ok(total)
 }
 
 /// Result of processing a single chunk in the streaming pipeline
@@ -693,7 +696,7 @@ mod tests {
         let backend_id = crate::types::BackendId::from_index(1);
         let buffer_pool = crate::pool::BufferPool::new(BufferSize::try_new(65536).unwrap(), 2);
 
-        let result = stream_multiline_response_pipelined(
+        let result = stream_multiline_response_impl(
             &mut reader,
             &mut writer,
             &combined,
@@ -701,7 +704,8 @@ mod tests {
             client_addr,
             backend_id,
             &buffer_pool,
-            &mut leftover,
+            None,
+            Some(&mut leftover),
         )
         .await;
 
@@ -729,7 +733,7 @@ mod tests {
         let backend_id = crate::types::BackendId::from_index(1);
         let buffer_pool = crate::pool::BufferPool::new(BufferSize::try_new(65536).unwrap(), 2);
 
-        let result = stream_multiline_response_pipelined(
+        let result = stream_multiline_response_impl(
             &mut reader,
             &mut writer,
             first_chunk,
@@ -737,7 +741,8 @@ mod tests {
             client_addr,
             backend_id,
             &buffer_pool,
-            &mut leftover,
+            None,
+            Some(&mut leftover),
         )
         .await;
 
@@ -768,7 +773,7 @@ mod tests {
         let backend_id = crate::types::BackendId::from_index(1);
         let buffer_pool = crate::pool::BufferPool::new(BufferSize::try_new(65536).unwrap(), 2);
 
-        let result = stream_multiline_response_pipelined(
+        let result = stream_multiline_response_impl(
             &mut reader,
             &mut writer,
             response,
@@ -776,7 +781,8 @@ mod tests {
             client_addr,
             backend_id,
             &buffer_pool,
-            &mut leftover,
+            None,
+            Some(&mut leftover),
         )
         .await;
 
@@ -807,7 +813,7 @@ mod tests {
         let backend_id = crate::types::BackendId::from_index(1);
         let buffer_pool = crate::pool::BufferPool::new(BufferSize::try_new(65536).unwrap(), 2);
 
-        let result = stream_multiline_response_pipelined(
+        let result = stream_multiline_response_impl(
             &mut reader,
             &mut writer,
             &combined,
@@ -815,7 +821,8 @@ mod tests {
             client_addr,
             backend_id,
             &buffer_pool,
-            &mut leftover,
+            None,
+            Some(&mut leftover),
         )
         .await;
 

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -183,7 +183,7 @@ where
 /// Like `stream_multiline_response`, but captures leftover bytes after the terminator
 /// into `leftover` for use as the start of the next response in the pipeline.
 #[allow(clippy::too_many_arguments)]
-pub async fn stream_multiline_response_pipelined<W>(
+pub(crate) async fn stream_multiline_response_pipelined<W>(
     backend_read: &mut crate::stream::ConnectionStream,
     client_write: &mut W,
     first_chunk: &[u8],

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -197,13 +197,14 @@ where
 {
     let mut total_bytes = 0u64;
     let mut tail = TailBuffer::default();
+    let mut capture = None;
 
     let data = &first_chunk[..first_n];
     match process_chunk(
         data,
         first_n,
         &mut tail,
-        &mut None,
+        &mut capture,
         client_write,
         backend_read,
         &mut total_bytes,
@@ -250,7 +251,7 @@ where
             data,
             n,
             &mut tail,
-            &mut None,
+            &mut capture,
             client_write,
             backend_read,
             &mut total_bytes,

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -195,8 +195,110 @@ pub async fn stream_multiline_response_pipelined<W>(
 where
     W: AsyncWriteExt + Unpin,
 {
-    let mut leftover = bytes::BytesMut::new();
-    let total = stream_multiline_response_impl(
+    let mut total_bytes = 0u64;
+    let mut tail = TailBuffer::default();
+
+    let data = &first_chunk[..first_n];
+    match process_chunk(
+        data,
+        first_n,
+        &mut tail,
+        &mut None,
+        client_write,
+        backend_read,
+        &mut total_bytes,
+        client_addr,
+        backend_id,
+        buffer_pool,
+    )
+    .await?
+    {
+        ChunkResult::Done { write_len } => {
+            if write_len < first_n {
+                backend_read.stash_leftover(&first_chunk[write_len..first_n])?;
+            }
+            debug!(
+                "Client {} multiline response complete ({})",
+                client_addr,
+                crate::formatting::format_bytes(total_bytes)
+            );
+            return Ok(total_bytes);
+        }
+        ChunkResult::Continue => {}
+    }
+
+    let mut buffers = [buffer_pool.acquire().await, buffer_pool.acquire().await];
+    let mut idx: usize = 0;
+
+    loop {
+        let n = buffers[idx]
+            .read_from(backend_read)
+            .await
+            .context("Failed to read next chunk from backend")?;
+
+        if n == 0 {
+            debug!(
+                "Client {} multiline streaming complete ({}, EOF)",
+                client_addr,
+                crate::formatting::format_bytes(total_bytes)
+            );
+            break;
+        }
+
+        let data = &buffers[idx][..n];
+        match process_chunk(
+            data,
+            n,
+            &mut tail,
+            &mut None,
+            client_write,
+            backend_read,
+            &mut total_bytes,
+            client_addr,
+            backend_id,
+            buffer_pool,
+        )
+        .await?
+        {
+            ChunkResult::Done { write_len } => {
+                if write_len < n {
+                    backend_read.stash_leftover(&buffers[idx][write_len..n])?;
+                }
+                debug!(
+                    "Client {} multiline response complete ({})",
+                    client_addr,
+                    crate::formatting::format_bytes(total_bytes)
+                );
+                return Ok(total_bytes);
+            }
+            ChunkResult::Continue => {}
+        }
+
+        idx ^= 1;
+    }
+
+    Ok(total_bytes)
+}
+
+/// Stream multiline response from backend to client during pipelined batch execution.
+///
+/// Like `stream_multiline_response`, but captures leftover bytes after the terminator
+/// into `leftover` for use as the start of the next response in the pipeline.
+#[allow(clippy::too_many_arguments)]
+pub async fn stream_multiline_response_pipelined_for_test<W>(
+    backend_read: &mut crate::stream::ConnectionStream,
+    client_write: &mut W,
+    first_chunk: &[u8],
+    first_n: usize,
+    client_addr: crate::types::ClientAddress,
+    backend_id: crate::types::BackendId,
+    buffer_pool: &crate::pool::BufferPool,
+    leftover: &mut bytes::BytesMut,
+) -> Result<u64>
+where
+    W: AsyncWriteExt + Unpin,
+{
+    stream_multiline_response_impl(
         backend_read,
         client_write,
         first_chunk,
@@ -205,13 +307,9 @@ where
         backend_id,
         buffer_pool,
         None,
-        Some(&mut leftover),
+        Some(leftover),
     )
-    .await?;
-    if !leftover.is_empty() {
-        backend_read.stash_leftover(&leftover)?;
-    }
-    Ok(total)
+    .await
 }
 
 /// Result of processing a single chunk in the streaming pipeline

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -284,8 +284,9 @@ where
 ///
 /// Like `stream_multiline_response`, but captures leftover bytes after the terminator
 /// into `leftover` for use as the start of the next response in the pipeline.
-#[allow(clippy::too_many_arguments)]
-pub async fn stream_multiline_response_pipelined_for_test<W>(
+#[cfg(test)]
+#[allow(clippy::too_many_arguments, dead_code)]
+pub(crate) async fn stream_multiline_response_pipelined_for_test<W>(
     backend_read: &mut crate::stream::ConnectionStream,
     client_write: &mut W,
     first_chunk: &[u8],

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -238,12 +238,12 @@ where
             .context("Failed to read next chunk from backend")?;
 
         if n == 0 {
-            debug!(
-                "Client {} multiline streaming complete ({}, EOF)",
+            anyhow::bail!(
+                "Backend EOF before multiline terminator while streaming to client {} from backend {:?} (received {})",
                 client_addr,
+                backend_id,
                 crate::formatting::format_bytes(total_bytes)
             );
-            break;
         }
 
         let data = &buffers[idx][..n];
@@ -277,8 +277,6 @@ where
 
         idx ^= 1;
     }
-
-    Ok(total_bytes)
 }
 
 /// Stream multiline response from backend to client during pipelined batch execution.
@@ -456,12 +454,12 @@ where
             .context("Failed to read next chunk from backend")?;
 
         if n == 0 {
-            debug!(
-                "Client {} multiline streaming complete ({}, EOF)",
+            anyhow::bail!(
+                "Backend EOF before multiline terminator while streaming to client {} from backend {:?} (received {})",
                 client_addr,
+                backend_id,
                 crate::formatting::format_bytes(total_bytes)
             );
-            break;
         }
 
         let data = &buffers[idx][..n];
@@ -503,8 +501,6 @@ where
 
         idx ^= 1; // Toggle buffer index
     }
-
-    Ok(total_bytes)
 }
 
 #[cfg(test)]
@@ -686,6 +682,39 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), full_response.len() as u64);
         assert_eq!(&writer[..], &full_response[..]);
+    }
+
+    #[tokio::test]
+    async fn test_stream_multiline_response_errors_on_truncated_response() {
+        use crate::types::BufferSize;
+
+        let first_chunk = b"220 Article follows\r\npartial body\r\n";
+        let mut reader = Cursor::new(b"" as &[u8]);
+        let mut writer = Vec::new();
+        let socket_addr: std::net::SocketAddr = "127.0.0.1:8000".parse().unwrap();
+        let client_addr = crate::types::ClientAddress::from(socket_addr);
+        let backend_id = crate::types::BackendId::from_index(1);
+        let buffer_pool = crate::pool::BufferPool::new(BufferSize::try_new(65536).unwrap(), 2);
+
+        let result = stream_multiline_response(
+            &mut reader,
+            &mut writer,
+            first_chunk,
+            first_chunk.len(),
+            client_addr,
+            backend_id,
+            &buffer_pool,
+        )
+        .await;
+
+        assert!(result.is_err(), "truncated multiline response must fail");
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("Backend EOF before multiline terminator")
+        );
+        assert_eq!(&writer[..], first_chunk);
     }
 
     #[tokio::test]

--- a/src/session/streaming/tail_buffer.rs
+++ b/src/session/streaming/tail_buffer.rs
@@ -38,14 +38,31 @@ pub struct TailBuffer {
 
 impl TailBuffer {
     /// Update tail with the last bytes from a chunk
+    ///
+    /// Maintains the last `TERMINATOR_TAIL_SIZE` bytes of the concatenation of
+    /// all prior chunks. When `chunk` is smaller than `TERMINATOR_TAIL_SIZE`,
+    /// the prior tail bytes are shifted to preserve the rolling window — not
+    /// overwritten — so terminators split across three or more tiny reads
+    /// (e.g. `\r\n`, `.`, `\r\n`) are correctly detected.
     pub fn update(&mut self, chunk: &[u8]) {
         if chunk.len() >= TERMINATOR_TAIL_SIZE {
+            // Chunk alone fills the window — take its last N bytes
             self.data
                 .copy_from_slice(&chunk[chunk.len() - TERMINATOR_TAIL_SIZE..]);
             self.len = TERMINATOR_TAIL_SIZE;
         } else if !chunk.is_empty() {
-            self.data[..chunk.len()].copy_from_slice(chunk);
-            self.len = chunk.len();
+            let combined_len = self.len + chunk.len();
+            if combined_len >= TERMINATOR_TAIL_SIZE {
+                // Shift prior tail left to keep window full, then append chunk
+                let keep = TERMINATOR_TAIL_SIZE - chunk.len();
+                self.data.copy_within(self.len - keep..self.len, 0);
+                self.data[keep..keep + chunk.len()].copy_from_slice(chunk);
+                self.len = TERMINATOR_TAIL_SIZE;
+            } else {
+                // Combined bytes still fit — just append
+                self.data[self.len..self.len + chunk.len()].copy_from_slice(chunk);
+                self.len = combined_len;
+            }
         }
     }
     /// Get the tail data as a slice
@@ -234,6 +251,27 @@ mod tests {
 
         assert_eq!(tail.len(), 3);
         assert_eq!(tail.as_slice(), b".\r\n");
+    }
+
+    /// Regression test: update() with successive small chunks must maintain the
+    /// rolling window — not overwrite it — so terminators split across 3+ reads work.
+    #[test]
+    fn test_tail_buffer_update_successive_small_chunks() {
+        // Terminator "\r\n.\r\n" split as: ["\r\n"] ["."] ["\r\n"]
+        let mut tail = TailBuffer::default();
+
+        tail.update(b"\r\n"); // len=2, tail=['\r','\n']
+        assert_eq!(tail.as_slice(), b"\r\n");
+
+        tail.update(b"."); // len=3, tail=['\r','\n','.']
+        assert_eq!(tail.as_slice(), b"\r\n.");
+
+        // Now detect_terminator on the final chunk should find spanning match
+        let status = tail.detect_terminator(b"\r\n");
+        assert!(
+            status.is_found(),
+            "TailBuffer must detect terminator split across 3 reads"
+        );
     }
 
     #[test]

--- a/src/stream/connection_stream.rs
+++ b/src/stream/connection_stream.rs
@@ -327,16 +327,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_connection_stream_tcp_access() {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let std_stream = std::net::TcpStream::connect(addr).unwrap();
-        let (server_stream, _) = listener.accept().unwrap();
+        let client_handle = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client_stream = client_handle.await.unwrap();
 
-        let tokio_stream = TcpStream::from_std(server_stream).unwrap();
-        let _client_stream = TcpStream::from_std(std_stream).unwrap();
-
-        let mut conn_stream = ConnectionStream::plain(tokio_stream);
+        let mut conn_stream = ConnectionStream::plain(server_stream);
 
         assert!(conn_stream.is_unencrypted());
         assert!(conn_stream.as_tcp_stream().is_some());
@@ -350,16 +348,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_plain_connection_type_checks() {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let std_stream = std::net::TcpStream::connect(addr).unwrap();
-        let (server_stream, _) = listener.accept().unwrap();
+        let client_handle = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client = client_handle.await.unwrap();
 
-        let stream = TcpStream::from_std(server_stream).unwrap();
-        let _client = TcpStream::from_std(std_stream).unwrap();
-
-        let conn = ConnectionStream::plain(stream);
+        let conn = ConnectionStream::plain(server_stream);
 
         assert_eq!(conn.connection_type(), "TCP");
         assert!(conn.is_unencrypted());
@@ -369,16 +365,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_tcp_access_methods_work() {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let std_stream = std::net::TcpStream::connect(addr).unwrap();
-        let (server_stream, _) = listener.accept().unwrap();
+        let client_handle = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client = client_handle.await.unwrap();
 
-        let stream = TcpStream::from_std(server_stream).unwrap();
-        let _client = TcpStream::from_std(std_stream).unwrap();
-
-        let conn = ConnectionStream::plain(stream);
+        let conn = ConnectionStream::plain(server_stream);
 
         assert!(conn.as_tcp_stream().is_some());
         assert!(conn.as_tls_stream().is_none());
@@ -386,16 +380,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_mutable_tcp_access_methods_work() {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let std_stream = std::net::TcpStream::connect(addr).unwrap();
-        let (server_stream, _) = listener.accept().unwrap();
+        let client_handle = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client = client_handle.await.unwrap();
 
-        let stream = TcpStream::from_std(server_stream).unwrap();
-        let _client = TcpStream::from_std(std_stream).unwrap();
-
-        let mut conn = ConnectionStream::plain(stream);
+        let mut conn = ConnectionStream::plain(server_stream);
 
         assert!(conn.as_tcp_stream_mut().is_some());
         assert!(conn.as_tls_stream_mut().is_none());
@@ -406,16 +398,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_constructor_creates_plain_variant() {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let std_stream = std::net::TcpStream::connect(addr).unwrap();
-        let (server_stream, _) = listener.accept().unwrap();
+        let client_handle = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client = client_handle.await.unwrap();
 
-        let stream = TcpStream::from_std(server_stream).unwrap();
-        let _client = TcpStream::from_std(std_stream).unwrap();
-
-        let plain_conn = ConnectionStream::plain(stream);
+        let plain_conn = ConnectionStream::plain(server_stream);
 
         assert_eq!(plain_conn.connection_type(), "TCP");
         assert!(plain_conn.is_unencrypted());
@@ -447,18 +437,16 @@ mod tests {
         assert_eq!(&buf, b"socket");
     }
 
-    #[test]
-    fn test_stash_leftover_rejects_oversize() {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    #[tokio::test]
+    async fn test_stash_leftover_rejects_oversize() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let std_stream = std::net::TcpStream::connect(addr).unwrap();
-        let (server_stream, _) = listener.accept().unwrap();
+        let client_handle = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client = client_handle.await.unwrap();
 
-        let stream = TcpStream::from_std(server_stream).unwrap();
-        let _client = TcpStream::from_std(std_stream).unwrap();
-
-        let mut conn = ConnectionStream::plain(stream);
+        let mut conn = ConnectionStream::plain(server_stream);
         let oversized = vec![b'x'; MAX_LEFTOVER_BYTES + 1];
         assert!(conn.stash_leftover(&oversized).is_err());
     }

--- a/src/stream/connection_stream.rs
+++ b/src/stream/connection_stream.rs
@@ -3,7 +3,10 @@
 //! This module provides abstractions for handling different stream types (TCP, TLS, etc.)
 //! in a unified way. This is preparation for adding SSL/TLS support to backend connections.
 
+use bytes::BytesMut;
+
 use crate::compression::DecompressStream;
+use crate::constants::buffer::MAX_LEFTOVER_BYTES;
 use crate::tls::TlsStream;
 use std::io;
 use std::pin::Pin;
@@ -21,13 +24,8 @@ pub trait AsyncStream: AsyncRead + AsyncWrite + Unpin + Send {}
 // Blanket implementation for all types that meet the requirements
 impl<T> AsyncStream for T where T: AsyncRead + AsyncWrite + Unpin + Send {}
 
-/// Unified stream type that can represent different connection types
-///
-/// This enum allows the proxy to handle both plain TCP and TLS connections
-/// through a single type, avoiding the need for trait objects and their associated
-/// heap allocation overhead.
 #[derive(Debug)]
-pub enum ConnectionStream {
+enum ConnectionTransport {
     /// Plain TCP connection
     Plain(TcpStream),
     /// TLS-encrypted connection
@@ -38,35 +36,76 @@ pub enum ConnectionStream {
     CompressedTls(Box<DecompressStream<TlsStream<TcpStream>>>),
 }
 
+/// Unified stream type that can represent different connection types.
+///
+/// The stream also owns a small read-ahead buffer used to preserve bytes that
+/// were already consumed from the socket but belong to the next NNTP response.
+#[derive(Debug)]
+pub struct ConnectionStream {
+    transport: ConnectionTransport,
+    leftover: BytesMut,
+}
+
 impl ConnectionStream {
     /// Create a new plain TCP connection stream
     pub fn plain(stream: TcpStream) -> Self {
-        Self::Plain(stream)
+        Self::new(ConnectionTransport::Plain(stream))
     }
 
     /// Create a new TLS-encrypted connection stream
     pub fn tls(stream: TlsStream<TcpStream>) -> Self {
-        Self::Tls(Box::new(stream))
+        Self::new(ConnectionTransport::Tls(Box::new(stream)))
     }
 
     /// Create a compressed plain TCP connection stream
     pub fn compressed_plain(stream: TcpStream) -> Self {
-        Self::CompressedPlain(Box::new(DecompressStream::new(stream)))
+        Self::new(ConnectionTransport::CompressedPlain(Box::new(
+            DecompressStream::new(stream),
+        )))
     }
 
     /// Create a compressed TLS connection stream
     pub fn compressed_tls(stream: TlsStream<TcpStream>) -> Self {
-        Self::CompressedTls(Box::new(DecompressStream::new(stream)))
+        Self::new(ConnectionTransport::CompressedTls(Box::new(
+            DecompressStream::new(stream),
+        )))
+    }
+
+    fn new(transport: ConnectionTransport) -> Self {
+        Self {
+            transport,
+            leftover: BytesMut::new(),
+        }
+    }
+
+    /// Wrap the current transport in a decompressor, preserving any read-ahead bytes.
+    pub fn into_compressed(self, level: u32) -> Self {
+        let transport = match self.transport {
+            ConnectionTransport::Plain(tcp) => ConnectionTransport::CompressedPlain(Box::new(
+                DecompressStream::with_level(tcp, level),
+            )),
+            ConnectionTransport::Tls(tls) => ConnectionTransport::CompressedTls(Box::new(
+                DecompressStream::with_level(*tls, level),
+            )),
+            ConnectionTransport::CompressedPlain(_) | ConnectionTransport::CompressedTls(_) => {
+                unreachable!("fresh connections are never already compressed")
+            }
+        };
+
+        Self {
+            transport,
+            leftover: self.leftover,
+        }
     }
 
     /// Returns the connection type as a string for logging/debugging
     #[must_use]
     pub fn connection_type(&self) -> &'static str {
-        match self {
-            Self::Plain(_) => "TCP",
-            Self::Tls(_) => "TLS",
-            Self::CompressedPlain(_) => "TCP+COMPRESS",
-            Self::CompressedTls(_) => "TLS+COMPRESS",
+        match &self.transport {
+            ConnectionTransport::Plain(_) => "TCP",
+            ConnectionTransport::Tls(_) => "TLS",
+            ConnectionTransport::CompressedPlain(_) => "TCP+COMPRESS",
+            ConnectionTransport::CompressedTls(_) => "TLS+COMPRESS",
         }
     }
 
@@ -74,21 +113,30 @@ impl ConnectionStream {
     #[inline]
     #[must_use]
     pub const fn is_encrypted(&self) -> bool {
-        matches!(self, Self::Tls(_) | Self::CompressedTls(_))
+        matches!(
+            self.transport,
+            ConnectionTransport::Tls(_) | ConnectionTransport::CompressedTls(_)
+        )
     }
 
     /// Returns true if this connection is unencrypted (plain TCP)
     #[inline]
     #[must_use]
     pub const fn is_unencrypted(&self) -> bool {
-        matches!(self, Self::Plain(_) | Self::CompressedPlain(_))
+        matches!(
+            self.transport,
+            ConnectionTransport::Plain(_) | ConnectionTransport::CompressedPlain(_)
+        )
     }
 
     /// Returns true if this connection uses wire compression
     #[inline]
     #[must_use]
     pub const fn is_compressed(&self) -> bool {
-        matches!(self, Self::CompressedPlain(_) | Self::CompressedTls(_))
+        matches!(
+            self.transport,
+            ConnectionTransport::CompressedPlain(_) | ConnectionTransport::CompressedTls(_)
+        )
     }
 
     /// Get a reference to the underlying TCP stream (if plain, uncompressed TCP)
@@ -97,16 +145,16 @@ impl ConnectionStream {
     /// Useful for socket optimization that requires direct TCP access.
     #[must_use]
     pub fn as_tcp_stream(&self) -> Option<&TcpStream> {
-        match self {
-            Self::Plain(tcp) => Some(tcp),
+        match &self.transport {
+            ConnectionTransport::Plain(tcp) => Some(tcp),
             _ => None,
         }
     }
 
     /// Get a mutable reference to the underlying TCP stream (if plain, uncompressed TCP)
     pub fn as_tcp_stream_mut(&mut self) -> Option<&mut TcpStream> {
-        match self {
-            Self::Plain(tcp) => Some(tcp),
+        match &mut self.transport {
+            ConnectionTransport::Plain(tcp) => Some(tcp),
             _ => None,
         }
     }
@@ -114,16 +162,16 @@ impl ConnectionStream {
     /// Get a reference to the TLS stream (if uncompressed TLS connection)
     #[must_use]
     pub fn as_tls_stream(&self) -> Option<&TlsStream<TcpStream>> {
-        match self {
-            Self::Tls(tls) => Some(tls.as_ref()),
+        match &self.transport {
+            ConnectionTransport::Tls(tls) => Some(tls.as_ref()),
             _ => None,
         }
     }
 
     /// Get a mutable reference to the TLS stream (if uncompressed TLS connection)
     pub fn as_tls_stream_mut(&mut self) -> Option<&mut TlsStream<TcpStream>> {
-        match self {
-            Self::Tls(tls) => Some(tls.as_mut()),
+        match &mut self.transport {
+            ConnectionTransport::Tls(tls) => Some(tls.as_mut()),
             _ => None,
         }
     }
@@ -135,12 +183,39 @@ impl ConnectionStream {
     /// For compressed streams, returns the TCP stream from within the wrapper.
     #[must_use]
     pub fn underlying_tcp_stream(&self) -> &TcpStream {
-        match self {
-            Self::Plain(tcp) => tcp,
-            Self::Tls(tls) => tls.get_ref().0,
-            Self::CompressedPlain(cs) => cs.get_ref(),
-            Self::CompressedTls(cs) => cs.get_ref().get_ref().0,
+        match &self.transport {
+            ConnectionTransport::Plain(tcp) => tcp,
+            ConnectionTransport::Tls(tls) => tls.get_ref().0,
+            ConnectionTransport::CompressedPlain(cs) => cs.get_ref(),
+            ConnectionTransport::CompressedTls(cs) => cs.get_ref().get_ref().0,
         }
+    }
+
+    /// Stash bytes that were already read from the backend but belong to the next response.
+    pub fn stash_leftover(&mut self, bytes: &[u8]) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            self.leftover.len() + bytes.len() <= MAX_LEFTOVER_BYTES,
+            "Leftover exceeds {} bytes ({} bytes) — probable protocol desync",
+            MAX_LEFTOVER_BYTES,
+            self.leftover.len() + bytes.len()
+        );
+        self.leftover.extend_from_slice(bytes);
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn has_leftover(&self) -> bool {
+        !self.leftover.is_empty()
+    }
+
+    #[must_use]
+    pub fn leftover_len(&self) -> usize {
+        self.leftover.len()
+    }
+
+    #[cfg(test)]
+    pub fn clear_leftover(&mut self) {
+        self.leftover.clear();
     }
 }
 
@@ -150,11 +225,22 @@ impl AsyncRead for ConnectionStream {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        match &mut *self {
-            Self::Plain(stream) => Pin::new(stream).poll_read(cx, buf),
-            Self::Tls(stream) => Pin::new(stream.as_mut()).poll_read(cx, buf),
-            Self::CompressedPlain(stream) => Pin::new(stream.as_mut()).poll_read(cx, buf),
-            Self::CompressedTls(stream) => Pin::new(stream.as_mut()).poll_read(cx, buf),
+        if !self.leftover.is_empty() && buf.remaining() > 0 {
+            let n = self.leftover.len().min(buf.remaining());
+            let data = self.leftover.split_to(n);
+            buf.put_slice(&data);
+            return Poll::Ready(Ok(()));
+        }
+
+        match &mut self.transport {
+            ConnectionTransport::Plain(stream) => Pin::new(stream).poll_read(cx, buf),
+            ConnectionTransport::Tls(stream) => Pin::new(stream.as_mut()).poll_read(cx, buf),
+            ConnectionTransport::CompressedPlain(stream) => {
+                Pin::new(stream.as_mut()).poll_read(cx, buf)
+            }
+            ConnectionTransport::CompressedTls(stream) => {
+                Pin::new(stream.as_mut()).poll_read(cx, buf)
+            }
         }
     }
 }
@@ -165,29 +251,39 @@ impl AsyncWrite for ConnectionStream {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        match &mut *self {
-            Self::Plain(stream) => Pin::new(stream).poll_write(cx, buf),
-            Self::Tls(stream) => Pin::new(stream.as_mut()).poll_write(cx, buf),
-            Self::CompressedPlain(stream) => Pin::new(stream.as_mut()).poll_write(cx, buf),
-            Self::CompressedTls(stream) => Pin::new(stream.as_mut()).poll_write(cx, buf),
+        match &mut self.transport {
+            ConnectionTransport::Plain(stream) => Pin::new(stream).poll_write(cx, buf),
+            ConnectionTransport::Tls(stream) => Pin::new(stream.as_mut()).poll_write(cx, buf),
+            ConnectionTransport::CompressedPlain(stream) => {
+                Pin::new(stream.as_mut()).poll_write(cx, buf)
+            }
+            ConnectionTransport::CompressedTls(stream) => {
+                Pin::new(stream.as_mut()).poll_write(cx, buf)
+            }
         }
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        match &mut *self {
-            Self::Plain(stream) => Pin::new(stream).poll_flush(cx),
-            Self::Tls(stream) => Pin::new(stream.as_mut()).poll_flush(cx),
-            Self::CompressedPlain(stream) => Pin::new(stream.as_mut()).poll_flush(cx),
-            Self::CompressedTls(stream) => Pin::new(stream.as_mut()).poll_flush(cx),
+        match &mut self.transport {
+            ConnectionTransport::Plain(stream) => Pin::new(stream).poll_flush(cx),
+            ConnectionTransport::Tls(stream) => Pin::new(stream.as_mut()).poll_flush(cx),
+            ConnectionTransport::CompressedPlain(stream) => {
+                Pin::new(stream.as_mut()).poll_flush(cx)
+            }
+            ConnectionTransport::CompressedTls(stream) => Pin::new(stream.as_mut()).poll_flush(cx),
         }
     }
 
     fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-        match &mut *self {
-            Self::Plain(stream) => Pin::new(stream).poll_shutdown(cx),
-            Self::Tls(stream) => Pin::new(stream.as_mut()).poll_shutdown(cx),
-            Self::CompressedPlain(stream) => Pin::new(stream.as_mut()).poll_shutdown(cx),
-            Self::CompressedTls(stream) => Pin::new(stream.as_mut()).poll_shutdown(cx),
+        match &mut self.transport {
+            ConnectionTransport::Plain(stream) => Pin::new(stream).poll_shutdown(cx),
+            ConnectionTransport::Tls(stream) => Pin::new(stream.as_mut()).poll_shutdown(cx),
+            ConnectionTransport::CompressedPlain(stream) => {
+                Pin::new(stream.as_mut()).poll_shutdown(cx)
+            }
+            ConnectionTransport::CompressedTls(stream) => {
+                Pin::new(stream.as_mut()).poll_shutdown(cx)
+            }
         }
     }
 }
@@ -199,7 +295,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_connection_stream_plain_tcp() {
-        // Create a listener and client
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
 
@@ -208,18 +303,15 @@ mod tests {
         let (server_stream, _) = listener.accept().await.unwrap();
         let client_stream = client_handle.await.unwrap();
 
-        // Wrap in ConnectionStream
         let mut server_conn = ConnectionStream::plain(server_stream);
         let mut client_conn = ConnectionStream::plain(client_stream);
 
-        // Test writing and reading
         client_conn.write_all(b"Hello").await.unwrap();
 
         let mut buf = [0u8; 5];
         server_conn.read_exact(&mut buf).await.unwrap();
         assert_eq!(&buf, b"Hello");
 
-        // Test stream type checking
         assert!(client_conn.is_unencrypted());
         assert!(!client_conn.is_encrypted());
         assert_eq!(client_conn.connection_type(), "TCP");
@@ -228,7 +320,6 @@ mod tests {
 
     #[test]
     fn test_async_stream_trait() {
-        // Verify TcpStream implements AsyncStream
         fn assert_async_stream<T: AsyncStream>() {}
         assert_async_stream::<TcpStream>();
         assert_async_stream::<ConnectionStream>();
@@ -239,151 +330,136 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let tcp_stream = std::net::TcpStream::connect(addr).unwrap();
-        tcp_stream.set_nonblocking(true).unwrap();
-        let tokio_stream = TcpStream::from_std(tcp_stream).unwrap();
+        let std_stream = std::net::TcpStream::connect(addr).unwrap();
+        let (server_stream, _) = listener.accept().unwrap();
+
+        let tokio_stream = TcpStream::from_std(server_stream).unwrap();
+        let _client_stream = TcpStream::from_std(std_stream).unwrap();
 
         let mut conn_stream = ConnectionStream::plain(tokio_stream);
 
-        // Should be able to access underlying TCP stream
-        assert!(conn_stream.as_tcp_stream().is_some());
-        assert!(conn_stream.as_tcp_stream_mut().is_some());
-
-        // Test new API methods
         assert!(conn_stream.is_unencrypted());
-        assert!(!conn_stream.is_encrypted());
-        assert_eq!(conn_stream.connection_type(), "TCP");
+        assert!(conn_stream.as_tcp_stream().is_some());
+        assert!(conn_stream.as_tls_stream().is_none());
 
-        // Test underlying TCP access
         let _underlying = conn_stream.underlying_tcp_stream();
+
+        let tcp_mut = conn_stream.as_tcp_stream_mut().unwrap();
+        tcp_mut.set_nodelay(true).unwrap();
     }
 
     #[tokio::test]
-    async fn test_connection_type_methods() {
-        // Test that the new API names are more explicit and clear
-        use std::net::TcpListener;
-
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let tcp = std::net::TcpStream::connect(addr).unwrap();
-        tcp.set_nonblocking(true).unwrap();
-        let stream = TcpStream::from_std(tcp).unwrap();
-
-        let conn = ConnectionStream::plain(stream);
-
-        // New explicit method names
-        assert!(conn.is_unencrypted(), "Plain TCP should be unencrypted");
-        assert!(!conn.is_encrypted(), "Plain TCP should not be encrypted");
-        assert_eq!(conn.connection_type(), "TCP");
-    }
-
-    // TLS-specific tests - test type system without I/O
-    #[tokio::test]
-    async fn test_tls_connection_type_methods() {
-        // We can't easily create a real TLS connection in unit tests without a server,
-        // but we can test the code paths by examining what methods would return
-
-        // For Plain TCP
+    async fn test_plain_connection_type_checks() {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
-        let tcp = std::net::TcpStream::connect(addr).unwrap();
-        tcp.set_nonblocking(true).unwrap();
-        let stream = TcpStream::from_std(tcp).unwrap();
+
+        let std_stream = std::net::TcpStream::connect(addr).unwrap();
+        let (server_stream, _) = listener.accept().unwrap();
+
+        let stream = TcpStream::from_std(server_stream).unwrap();
+        let _client = TcpStream::from_std(std_stream).unwrap();
 
         let conn = ConnectionStream::plain(stream);
 
-        // Test Plain TCP type checks
+        assert_eq!(conn.connection_type(), "TCP");
         assert!(conn.is_unencrypted());
         assert!(!conn.is_encrypted());
-        assert_eq!(conn.connection_type(), "TCP");
+        assert!(!conn.is_compressed());
+    }
 
-        // Test Plain TCP stream access
+    #[tokio::test]
+    async fn test_tcp_access_methods_work() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let std_stream = std::net::TcpStream::connect(addr).unwrap();
+        let (server_stream, _) = listener.accept().unwrap();
+
+        let stream = TcpStream::from_std(server_stream).unwrap();
+        let _client = TcpStream::from_std(std_stream).unwrap();
+
+        let conn = ConnectionStream::plain(stream);
+
         assert!(conn.as_tcp_stream().is_some());
         assert!(conn.as_tls_stream().is_none());
     }
 
     #[tokio::test]
-    async fn test_plain_tcp_stream_accessors() {
+    async fn test_mutable_tcp_access_methods_work() {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let tcp = std::net::TcpStream::connect(addr).unwrap();
-        tcp.set_nonblocking(true).unwrap();
-        let stream = TcpStream::from_std(tcp).unwrap();
+        let std_stream = std::net::TcpStream::connect(addr).unwrap();
+        let (server_stream, _) = listener.accept().unwrap();
+
+        let stream = TcpStream::from_std(server_stream).unwrap();
+        let _client = TcpStream::from_std(std_stream).unwrap();
 
         let mut conn = ConnectionStream::plain(stream);
 
-        // Test immutable access
-        assert!(conn.as_tcp_stream().is_some());
-        assert!(conn.as_tls_stream().is_none());
-
-        // Test mutable access
         assert!(conn.as_tcp_stream_mut().is_some());
         assert!(conn.as_tls_stream_mut().is_none());
+        assert!(conn.as_tcp_stream().is_some());
 
-        // Test underlying TCP access (works for plain TCP)
         let _underlying = conn.underlying_tcp_stream();
     }
 
     #[tokio::test]
-    async fn test_connection_stream_enum_variants() {
-        // Test that ConnectionStream enum has the expected variants
-        // This ensures the type structure is correct
-
+    async fn test_constructor_creates_plain_variant() {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
-        let tcp = std::net::TcpStream::connect(addr).unwrap();
-        tcp.set_nonblocking(true).unwrap();
-        let stream = TcpStream::from_std(tcp).unwrap();
+
+        let std_stream = std::net::TcpStream::connect(addr).unwrap();
+        let (server_stream, _) = listener.accept().unwrap();
+
+        let stream = TcpStream::from_std(server_stream).unwrap();
+        let _client = TcpStream::from_std(std_stream).unwrap();
 
         let plain_conn = ConnectionStream::plain(stream);
 
-        // Match on the enum to ensure Plain variant exists
-        assert!(
-            matches!(plain_conn, ConnectionStream::Plain(_)),
-            "Should be Plain variant"
-        );
+        assert_eq!(plain_conn.connection_type(), "TCP");
+        assert!(plain_conn.is_unencrypted());
     }
 
     #[tokio::test]
-    async fn test_connection_type_string_values() {
+    async fn test_leftover_is_read_before_socket() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let client_handle = tokio::spawn(async move {
+            let mut client = TcpStream::connect(addr).await.unwrap();
+            client.write_all(b"socket").await.unwrap();
+            client
+        });
+
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client = client_handle.await.unwrap();
+
+        let mut conn = ConnectionStream::plain(server_stream);
+        conn.stash_leftover(b"left").unwrap();
+
+        let mut buf = [0u8; 4];
+        conn.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"left");
+
+        let mut buf = [0u8; 6];
+        conn.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"socket");
+    }
+
+    #[test]
+    fn test_stash_leftover_rejects_oversize() {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let tcp = std::net::TcpStream::connect(addr).unwrap();
-        tcp.set_nonblocking(true).unwrap();
-        let stream = TcpStream::from_std(tcp).unwrap();
+        let std_stream = std::net::TcpStream::connect(addr).unwrap();
+        let (server_stream, _) = listener.accept().unwrap();
 
-        let conn = ConnectionStream::plain(stream);
+        let stream = TcpStream::from_std(server_stream).unwrap();
+        let _client = TcpStream::from_std(std_stream).unwrap();
 
-        // Test connection_type returns correct string
-        assert_eq!(conn.connection_type(), "TCP");
-
-        // Verify it's the correct static string for logging
-        let type_str = conn.connection_type();
-        assert!(!type_str.is_empty());
-        assert!(type_str.len() < 10); // Reasonable length for logging
-    }
-
-    #[tokio::test]
-    async fn test_plain_connection_debug_format() {
-        use std::net::TcpListener;
-
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let tcp = std::net::TcpStream::connect(addr).unwrap();
-        tcp.set_nonblocking(true).unwrap();
-        let stream = TcpStream::from_std(tcp).unwrap();
-
-        let conn = ConnectionStream::plain(stream);
-
-        // Test Debug implementation
-        let debug_str = format!("{:?}", conn);
-        assert!(
-            debug_str.contains("Plain"),
-            "Debug output should indicate Plain TCP"
-        );
+        let mut conn = ConnectionStream::plain(stream);
+        let oversized = vec![b'x'; MAX_LEFTOVER_BYTES + 1];
+        assert!(conn.stash_leftover(&oversized).is_err());
     }
 }

--- a/src/stream/connection_stream.rs
+++ b/src/stream/connection_stream.rs
@@ -79,7 +79,7 @@ impl ConnectionStream {
     }
 
     /// Wrap the current transport in a decompressor, preserving any read-ahead bytes.
-    pub fn into_compressed(self, level: u32) -> Self {
+    pub(crate) fn into_compressed(self, level: u32) -> Self {
         let transport = match self.transport {
             ConnectionTransport::Plain(tcp) => ConnectionTransport::CompressedPlain(Box::new(
                 DecompressStream::with_level(tcp, level),

--- a/src/stream/connection_stream.rs
+++ b/src/stream/connection_stream.rs
@@ -114,7 +114,7 @@ impl ConnectionStream {
     #[must_use]
     pub const fn is_encrypted(&self) -> bool {
         matches!(
-            self.transport,
+            &self.transport,
             ConnectionTransport::Tls(_) | ConnectionTransport::CompressedTls(_)
         )
     }
@@ -124,7 +124,7 @@ impl ConnectionStream {
     #[must_use]
     pub const fn is_unencrypted(&self) -> bool {
         matches!(
-            self.transport,
+            &self.transport,
             ConnectionTransport::Plain(_) | ConnectionTransport::CompressedPlain(_)
         )
     }
@@ -134,7 +134,7 @@ impl ConnectionStream {
     #[must_use]
     pub const fn is_compressed(&self) -> bool {
         matches!(
-            self.transport,
+            &self.transport,
             ConnectionTransport::CompressedPlain(_) | ConnectionTransport::CompressedTls(_)
         )
     }

--- a/src/stream/connection_stream.rs
+++ b/src/stream/connection_stream.rs
@@ -79,7 +79,10 @@ impl ConnectionStream {
     }
 
     /// Wrap the current transport in a decompressor, preserving any read-ahead bytes.
-    pub(crate) fn into_compressed(self, level: u32) -> Self {
+    ///
+    /// Returns an error if compression is requested for a stream that is already compressed.
+    /// This keeps the state transition explicit instead of panicking on an invalid call.
+    pub(crate) fn into_compressed(self, level: u32) -> io::Result<Self> {
         let transport = match self.transport {
             ConnectionTransport::Plain(tcp) => ConnectionTransport::CompressedPlain(Box::new(
                 DecompressStream::with_level(tcp, level),
@@ -88,14 +91,17 @@ impl ConnectionStream {
                 DecompressStream::with_level(*tls, level),
             )),
             ConnectionTransport::CompressedPlain(_) | ConnectionTransport::CompressedTls(_) => {
-                unreachable!("fresh connections are never already compressed")
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "cannot enable compression on an already-compressed connection",
+                ));
             }
         };
 
-        Self {
+        Ok(Self {
             transport,
             leftover: self.leftover,
-        }
+        })
     }
 
     /// Returns the connection type as a string for logging/debugging
@@ -449,5 +455,50 @@ mod tests {
         let mut conn = ConnectionStream::plain(server_stream);
         let oversized = vec![b'x'; MAX_LEFTOVER_BYTES + 1];
         assert!(conn.stash_leftover(&oversized).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_into_compressed_preserves_leftover() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let client_handle = tokio::spawn(async move {
+            let mut client = TcpStream::connect(addr).await.unwrap();
+            client.write_all(b"socket").await.unwrap();
+            client
+        });
+
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client = client_handle.await.unwrap();
+
+        let mut conn = ConnectionStream::plain(server_stream);
+        conn.stash_leftover(b"left").unwrap();
+
+        let mut conn = conn.into_compressed(1).unwrap();
+        assert!(conn.is_compressed());
+        assert_eq!(conn.leftover_len(), 4);
+
+        let mut buf = [0u8; 4];
+        conn.read_exact(&mut buf).await.unwrap();
+        assert_eq!(&buf, b"left");
+    }
+
+    #[tokio::test]
+    async fn test_into_compressed_rejects_already_compressed_stream() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let client_handle = tokio::spawn(async move { TcpStream::connect(addr).await.unwrap() });
+        let (server_stream, _) = listener.accept().await.unwrap();
+        let _client = client_handle.await.unwrap();
+
+        let conn = ConnectionStream::compressed_plain(server_stream);
+        let err = conn.into_compressed(1).unwrap_err();
+
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(
+            err.to_string(),
+            "cannot enable compression on an already-compressed connection"
+        );
     }
 }

--- a/tests/proxy/metrics/health_checks.rs
+++ b/tests/proxy/metrics/health_checks.rs
@@ -30,7 +30,7 @@ async fn test_tcp_alive_check_healthy_connection() -> Result<()> {
 
     // Connect and check health
     let stream = TcpStream::connect(addr).await?;
-    let mut conn_stream = ConnectionStream::Plain(stream);
+    let mut conn_stream = ConnectionStream::plain(stream);
 
     // Should pass - connection is alive and idle
     let result = check_tcp_alive(&mut conn_stream);
@@ -61,7 +61,7 @@ async fn test_tcp_alive_check_closed_connection() -> Result<()> {
     // Wait for server to close
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let mut conn_stream = ConnectionStream::Plain(stream);
+    let mut conn_stream = ConnectionStream::plain(stream);
 
     // Should fail - connection is closed
     let result = check_tcp_alive(&mut conn_stream);
@@ -93,7 +93,7 @@ async fn test_tcp_alive_check_unexpected_data() -> Result<()> {
     // Give server time to send data
     tokio::time::sleep(Duration::from_millis(100)).await;
 
-    let mut conn_stream = ConnectionStream::Plain(stream);
+    let mut conn_stream = ConnectionStream::plain(stream);
 
     // Should fail - unexpected data in buffer
     let result = check_tcp_alive(&mut conn_stream);
@@ -128,7 +128,7 @@ async fn test_date_health_check_success() -> Result<()> {
     });
 
     let stream = TcpStream::connect(addr).await?;
-    let mut conn_stream = ConnectionStream::Plain(stream);
+    let mut conn_stream = ConnectionStream::plain(stream);
 
     // Should succeed
     let result = check_date_response(&mut conn_stream).await;
@@ -162,7 +162,7 @@ async fn test_date_health_check_invalid_response() -> Result<()> {
     });
 
     let stream = TcpStream::connect(addr).await?;
-    let mut conn_stream = ConnectionStream::Plain(stream);
+    let mut conn_stream = ConnectionStream::plain(stream);
 
     // Should fail - wrong response code
     let result = check_date_response(&mut conn_stream).await;
@@ -192,7 +192,7 @@ async fn test_date_health_check_timeout() -> Result<()> {
     });
 
     let stream = TcpStream::connect(addr).await?;
-    let mut conn_stream = ConnectionStream::Plain(stream);
+    let mut conn_stream = ConnectionStream::plain(stream);
 
     // Should timeout
     let result = timeout(
@@ -225,7 +225,7 @@ async fn test_date_health_check_connection_closed() -> Result<()> {
     });
 
     let stream = TcpStream::connect(addr).await?;
-    let mut conn_stream = ConnectionStream::Plain(stream);
+    let mut conn_stream = ConnectionStream::plain(stream);
 
     // Should fail - connection closed
     let result = check_date_response(&mut conn_stream).await;
@@ -337,7 +337,7 @@ async fn test_date_command_format() -> Result<()> {
     });
 
     let stream = TcpStream::connect(addr).await?;
-    let mut conn_stream = ConnectionStream::Plain(stream);
+    let mut conn_stream = ConnectionStream::plain(stream);
 
     let _ = check_date_response(&mut conn_stream).await;
 
@@ -367,7 +367,7 @@ async fn test_multiple_sequential_health_checks() -> Result<()> {
     });
 
     let stream = TcpStream::connect(addr).await?;
-    let mut conn_stream = ConnectionStream::Plain(stream);
+    let mut conn_stream = ConnectionStream::plain(stream);
 
     // Multiple checks should all pass
     for i in 0..3 {
@@ -398,7 +398,7 @@ async fn test_date_health_check_partial_response() -> Result<()> {
     });
 
     let stream = TcpStream::connect(addr).await?;
-    let mut conn_stream = ConnectionStream::Plain(stream);
+    let mut conn_stream = ConnectionStream::plain(stream);
 
     // Should eventually timeout or fail
     let result = timeout(
@@ -438,7 +438,7 @@ async fn test_date_health_check_malformed_response() -> Result<()> {
         });
 
         let stream = TcpStream::connect(addr).await?;
-        let mut conn_stream = ConnectionStream::Plain(stream);
+        let mut conn_stream = ConnectionStream::plain(stream);
 
         let result = check_date_response(&mut conn_stream).await;
         assert!(result.is_err(), "Malformed response {} should fail", i);
@@ -462,14 +462,14 @@ async fn test_tcp_alive_check_non_destructive() -> Result<()> {
     });
 
     let stream = TcpStream::connect(addr).await?;
-    let mut conn_stream = ConnectionStream::Plain(stream);
+    let mut conn_stream = ConnectionStream::plain(stream);
 
     // Check health
     let result = check_tcp_alive(&mut conn_stream);
     assert!(result.is_ok());
 
     // Try to write data - connection should still work
-    if let ConnectionStream::Plain(ref mut tcp) = conn_stream {
+    if let Some(tcp) = conn_stream.as_tcp_stream_mut() {
         let write_result = tcp.write_all(b"TEST\r\n").await;
         assert!(
             write_result.is_ok(),

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -125,6 +125,7 @@ impl MockNntpServer {
                     }
 
                     let mut authenticated = !require_auth;
+                    let mut pending = bytes::BytesMut::new();
                     let mut buffer = [0; 1024];
 
                     loop {
@@ -134,56 +135,64 @@ impl MockNntpServer {
                             Err(_) => break,
                         };
 
-                        let cmd_str = String::from_utf8_lossy(&buffer[..n]);
-                        let cmd_upper = cmd_str.trim().to_uppercase();
+                        pending.extend_from_slice(&buffer[..n]);
 
-                        // Handle QUIT
-                        if cmd_upper.starts_with("QUIT") {
-                            let _ = stream.write_all(b"205 Goodbye\r\n").await;
-                            break;
-                        }
+                        while let Some(line_end) = pending.windows(2).position(|w| w == b"\r\n") {
+                            let line = pending.split_to(line_end + 2);
+                            let cmd_str = String::from_utf8_lossy(&line);
+                            let cmd_upper = cmd_str.trim().to_uppercase();
 
-                        // Handle authentication
-                        if require_auth {
-                            if cmd_upper.starts_with("AUTHINFO USER") {
-                                if let Some((user, _)) = &credentials
-                                    && cmd_str.contains(user.as_str())
-                                {
-                                    let _ = stream.write_all(b"381 Password required\r\n").await;
-                                    continue;
-                                }
-                                let _ = stream.write_all(b"481 Authentication failed\r\n").await;
-                                continue;
-                            } else if cmd_upper.starts_with("AUTHINFO PASS") {
-                                if let Some((_, pass)) = &credentials
-                                    && cmd_str.contains(pass.as_str())
-                                {
-                                    authenticated = true;
+                            // Handle QUIT
+                            if cmd_upper.starts_with("QUIT") {
+                                let _ = stream.write_all(b"205 Goodbye\r\n").await;
+                                return;
+                            }
+
+                            // Handle authentication
+                            if require_auth {
+                                if cmd_upper.starts_with("AUTHINFO USER") {
+                                    if let Some((user, _)) = &credentials
+                                        && cmd_str.contains(user.as_str())
+                                    {
+                                        let _ =
+                                            stream.write_all(b"381 Password required\r\n").await;
+                                        continue;
+                                    }
                                     let _ =
-                                        stream.write_all(b"281 Authentication accepted\r\n").await;
+                                        stream.write_all(b"481 Authentication failed\r\n").await;
+                                    continue;
+                                } else if cmd_upper.starts_with("AUTHINFO PASS") {
+                                    if let Some((_, pass)) = &credentials
+                                        && cmd_str.contains(pass.as_str())
+                                    {
+                                        authenticated = true;
+                                        let _ = stream
+                                            .write_all(b"281 Authentication accepted\r\n")
+                                            .await;
+                                        continue;
+                                    }
+                                    let _ =
+                                        stream.write_all(b"481 Authentication failed\r\n").await;
+                                    continue;
+                                } else if !authenticated {
+                                    let _ =
+                                        stream.write_all(b"480 Authentication required\r\n").await;
                                     continue;
                                 }
-                                let _ = stream.write_all(b"481 Authentication failed\r\n").await;
-                                continue;
-                            } else if !authenticated {
-                                let _ = stream.write_all(b"480 Authentication required\r\n").await;
-                                continue;
                             }
-                        }
 
-                        // Check custom command handlers
-                        let mut handled = false;
-                        for (prefix, response) in &handlers {
-                            if cmd_upper.starts_with(prefix) {
-                                let _ = stream.write_all(response.as_bytes()).await;
-                                handled = true;
-                                break;
+                            let mut handled = false;
+                            for (prefix, response) in &handlers {
+                                if cmd_upper.starts_with(prefix) {
+                                    let _ = stream.write_all(response.as_bytes()).await;
+                                    handled = true;
+                                    break;
+                                }
                             }
-                        }
 
-                        // Default response
-                        if !handled {
-                            let _ = stream.write_all(b"200 OK\r\n").await;
+                            if !handled {
+                                let _ = stream.write_all(b"200 OK\r\n").await;
+                            }
                         }
                     }
                 }));
@@ -780,6 +789,34 @@ mod tests {
         let response = String::from_utf8_lossy(&buffer[..n]);
         assert!(response.contains("211"));
         assert!(response.contains("alt.test"));
+    }
+
+    #[tokio::test]
+    async fn test_mock_server_handles_multiple_commands_in_one_read() {
+        let port = get_available_port().await.unwrap();
+        let _handle = MockNntpServer::new(port)
+            .on_command("DATE", "111 20260410235959\r\n")
+            .on_command("HELP", "100 help follows\r\n.\r\n")
+            .spawn();
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
+            .await
+            .unwrap();
+
+        let mut buffer = [0; 1024];
+        let _ = stream.read(&mut buffer).await.unwrap();
+
+        stream.write_all(b"DATE\r\nHELP\r\n").await.unwrap();
+
+        let n = stream.read(&mut buffer).await.unwrap();
+        let response = String::from_utf8_lossy(&buffer[..n]);
+        assert!(response.contains("111 20260410235959"));
+
+        let n = stream.read(&mut buffer).await.unwrap();
+        let response = String::from_utf8_lossy(&buffer[..n]);
+        assert!(response.contains("100 help follows"));
     }
 
     #[tokio::test]

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -50,6 +50,96 @@ pub struct MockNntpServer {
 }
 
 impl MockNntpServer {
+    async fn run_on_listener(
+        listener: TcpListener,
+        name: String,
+        require_auth: bool,
+        credentials: Option<(String, String)>,
+        command_handlers: HashMap<String, String>,
+    ) {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let name = name.clone();
+            let credentials = credentials.clone();
+            let handlers = command_handlers.clone();
+
+            drop(tokio::spawn(async move {
+                let greeting = if require_auth {
+                    format!("200 {} Ready (auth required)\r\n", name)
+                } else {
+                    format!("200 {} Ready\r\n", name)
+                };
+                if stream.write_all(greeting.as_bytes()).await.is_err() {
+                    return;
+                }
+
+                let mut authenticated = !require_auth;
+                let mut pending = bytes::BytesMut::new();
+                let mut buffer = [0; 1024];
+
+                loop {
+                    let n = match stream.read(&mut buffer).await {
+                        Ok(0) => break,
+                        Ok(n) => n,
+                        Err(_) => break,
+                    };
+
+                    pending.extend_from_slice(&buffer[..n]);
+
+                    while let Some(line_end) = pending.windows(2).position(|w| w == b"\r\n") {
+                        let line = pending.split_to(line_end + 2);
+                        let cmd_str = String::from_utf8_lossy(&line);
+                        let cmd_upper = cmd_str.trim().to_uppercase();
+
+                        if cmd_upper.starts_with("QUIT") {
+                            let _ = stream.write_all(b"205 Goodbye\r\n").await;
+                            return;
+                        }
+
+                        if require_auth {
+                            if cmd_upper.starts_with("AUTHINFO USER") {
+                                if let Some((user, _)) = &credentials
+                                    && cmd_str.contains(user.as_str())
+                                {
+                                    let _ = stream.write_all(b"381 Password required\r\n").await;
+                                    continue;
+                                }
+                                let _ = stream.write_all(b"481 Authentication failed\r\n").await;
+                                continue;
+                            } else if cmd_upper.starts_with("AUTHINFO PASS") {
+                                if let Some((_, pass)) = &credentials
+                                    && cmd_str.contains(pass.as_str())
+                                {
+                                    authenticated = true;
+                                    let _ =
+                                        stream.write_all(b"281 Authentication accepted\r\n").await;
+                                    continue;
+                                }
+                                let _ = stream.write_all(b"481 Authentication failed\r\n").await;
+                                continue;
+                            } else if !authenticated {
+                                let _ = stream.write_all(b"480 Authentication required\r\n").await;
+                                continue;
+                            }
+                        }
+
+                        let mut handled = false;
+                        for (prefix, response) in &handlers {
+                            if cmd_upper.starts_with(prefix) {
+                                let _ = stream.write_all(response.as_bytes()).await;
+                                handled = true;
+                                break;
+                            }
+                        }
+
+                        if !handled {
+                            let _ = stream.write_all(b"200 OK\r\n").await;
+                        }
+                    }
+                }
+            }));
+        }
+    }
+
     /// Create a new mock server builder on the specified port
     pub fn new(port: u16) -> Self {
         Self {
@@ -83,22 +173,45 @@ impl MockNntpServer {
         self
     }
 
-    /// Spawn the mock server and return a handle to its background task
-    /// Spawn mock server and return AbortHandle for automatic cleanup
-    ///
-    /// When the AbortHandle is dropped, the background task is immediately cancelled.
-    /// This prevents tests from hanging during shutdown waiting for mock servers to exit.
-    pub fn spawn(self) -> AbortHandle {
+    fn spawn_with_listener(self, listener: TcpListener) -> AbortHandle {
         let Self {
-            port,
+            port: _,
             name,
             require_auth,
             credentials,
             command_handlers,
         } = self;
 
+        tokio::spawn(Self::run_on_listener(
+            listener,
+            name,
+            require_auth,
+            credentials,
+            command_handlers,
+        ))
+        .abort_handle()
+    }
+
+    pub fn spawn_on_listener(self, listener: TcpListener) -> AbortHandle {
+        self.spawn_with_listener(listener)
+    }
+
+    /// Spawn the mock server and return a handle to its background task
+    /// Spawn mock server and return AbortHandle for automatic cleanup
+    ///
+    /// When the AbortHandle is dropped, the background task is immediately cancelled.
+    /// This prevents tests from hanging during shutdown waiting for mock servers to exit.
+    pub fn spawn(self) -> AbortHandle {
+        let port = self.port;
+        let Self {
+            port: _,
+            name,
+            require_auth,
+            credentials,
+            command_handlers,
+        } = self;
+        let addr = format!("127.0.0.1:{port}");
         tokio::spawn(async move {
-            let addr = format!("127.0.0.1:{}", port);
             let listener = match TcpListener::bind(&addr).await {
                 Ok(l) => l,
                 Err(e) => {
@@ -106,97 +219,8 @@ impl MockNntpServer {
                     return;
                 }
             };
-
-            while let Ok((mut stream, _)) = listener.accept().await {
-                let name = name.clone();
-                let credentials = credentials.clone();
-                let handlers = command_handlers.clone();
-
-                // Spawn per-connection handler (explicitly drop handle)
-                drop(tokio::spawn(async move {
-                    // Send greeting
-                    let greeting = if require_auth {
-                        format!("200 {} Ready (auth required)\r\n", name)
-                    } else {
-                        format!("200 {} Ready\r\n", name)
-                    };
-                    if stream.write_all(greeting.as_bytes()).await.is_err() {
-                        return;
-                    }
-
-                    let mut authenticated = !require_auth;
-                    let mut pending = bytes::BytesMut::new();
-                    let mut buffer = [0; 1024];
-
-                    loop {
-                        let n = match stream.read(&mut buffer).await {
-                            Ok(0) => break, // Connection closed
-                            Ok(n) => n,
-                            Err(_) => break,
-                        };
-
-                        pending.extend_from_slice(&buffer[..n]);
-
-                        while let Some(line_end) = pending.windows(2).position(|w| w == b"\r\n") {
-                            let line = pending.split_to(line_end + 2);
-                            let cmd_str = String::from_utf8_lossy(&line);
-                            let cmd_upper = cmd_str.trim().to_uppercase();
-
-                            // Handle QUIT
-                            if cmd_upper.starts_with("QUIT") {
-                                let _ = stream.write_all(b"205 Goodbye\r\n").await;
-                                return;
-                            }
-
-                            // Handle authentication
-                            if require_auth {
-                                if cmd_upper.starts_with("AUTHINFO USER") {
-                                    if let Some((user, _)) = &credentials
-                                        && cmd_str.contains(user.as_str())
-                                    {
-                                        let _ =
-                                            stream.write_all(b"381 Password required\r\n").await;
-                                        continue;
-                                    }
-                                    let _ =
-                                        stream.write_all(b"481 Authentication failed\r\n").await;
-                                    continue;
-                                } else if cmd_upper.starts_with("AUTHINFO PASS") {
-                                    if let Some((_, pass)) = &credentials
-                                        && cmd_str.contains(pass.as_str())
-                                    {
-                                        authenticated = true;
-                                        let _ = stream
-                                            .write_all(b"281 Authentication accepted\r\n")
-                                            .await;
-                                        continue;
-                                    }
-                                    let _ =
-                                        stream.write_all(b"481 Authentication failed\r\n").await;
-                                    continue;
-                                } else if !authenticated {
-                                    let _ =
-                                        stream.write_all(b"480 Authentication required\r\n").await;
-                                    continue;
-                                }
-                            }
-
-                            let mut handled = false;
-                            for (prefix, response) in &handlers {
-                                if cmd_upper.starts_with(prefix) {
-                                    let _ = stream.write_all(response.as_bytes()).await;
-                                    handled = true;
-                                    break;
-                                }
-                            }
-
-                            if !handled {
-                                let _ = stream.write_all(b"200 OK\r\n").await;
-                            }
-                        }
-                    }
-                }));
-            }
+            Self::run_on_listener(listener, name, require_auth, credentials, command_handlers)
+                .await;
         })
         .abort_handle()
     }
@@ -681,11 +705,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_mock_server_basic() {
-        let port = get_available_port().await.unwrap();
-        let _handle = MockNntpServer::new(port).with_name("TestServer").spawn();
-
-        // Give server time to start
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let _handle = MockNntpServer::new(port)
+            .with_name("TestServer")
+            .spawn_on_listener(listener);
 
         // Connect and verify greeting
         let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
@@ -702,10 +726,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_mock_server_builder_basic() {
-        let port = get_available_port().await.unwrap();
-        let _handle = MockNntpServer::new(port).with_name("BuilderTest").spawn();
-
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let _handle = MockNntpServer::new(port)
+            .with_name("BuilderTest")
+            .spawn_on_listener(listener);
 
         let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
             .await
@@ -721,12 +746,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_mock_server_builder_with_auth() {
-        let port = get_available_port().await.unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
         let _handle = MockNntpServer::new(port)
             .with_auth("testuser", "testpass")
-            .spawn();
-
-        tokio::time::sleep(Duration::from_millis(100)).await;
+            .spawn_on_listener(listener);
 
         let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
             .await
@@ -766,13 +790,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_mock_server_builder_custom_commands() {
-        let port = get_available_port().await.unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
         let _handle = MockNntpServer::new(port)
             .on_command("LIST", "215 list follows\r\n.\r\n")
             .on_command("GROUP", "211 100 1 100 alt.test\r\n")
-            .spawn();
-
-        tokio::time::sleep(Duration::from_millis(100)).await;
+            .spawn_on_listener(listener);
 
         let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
             .await
@@ -799,13 +822,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_mock_server_handles_multiple_commands_in_one_read() {
-        let port = get_available_port().await.unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
         let _handle = MockNntpServer::new(port)
             .on_command("DATE", "111 20260410235959\r\n")
             .on_command("HELP", "100 help follows\r\n.\r\n")
-            .spawn();
-
-        tokio::time::sleep(Duration::from_millis(100)).await;
+            .spawn_on_listener(listener);
 
         let mut stream = tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port))
             .await

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -442,55 +442,12 @@ pub async fn setup_proxy_with_backends(
             "430 No such article\r\n"
         };
 
-        let name = (*name).to_string();
-        let response = response.to_string();
-        let handle = tokio::spawn(async move {
-            while let Ok((mut stream, _)) = listener.accept().await {
-                let name = name.clone();
-                let response = response.clone();
-
-                drop(tokio::spawn(async move {
-                    let greeting = format!("200 {} Ready\r\n", name);
-                    if stream.write_all(greeting.as_bytes()).await.is_err() {
-                        return;
-                    }
-
-                    let mut pending = bytes::BytesMut::new();
-                    let mut buffer = [0; 1024];
-                    loop {
-                        let n = match stream.read(&mut buffer).await {
-                            Ok(0) => break,
-                            Ok(n) => n,
-                            Err(_) => break,
-                        };
-
-                        pending.extend_from_slice(&buffer[..n]);
-
-                        while let Some(line_end) = pending.windows(2).position(|w| w == b"\r\n") {
-                            let line = pending.split_to(line_end + 2);
-                            let cmd_str = String::from_utf8_lossy(&line);
-                            let cmd_upper = cmd_str.trim().to_uppercase();
-
-                            if cmd_upper.starts_with("QUIT") {
-                                let _ = stream.write_all(b"205 Goodbye\r\n").await;
-                                return;
-                            }
-
-                            let reply = if cmd_upper.starts_with("DATE") {
-                                "111 20251203120000\r\n"
-                            } else if cmd_upper.starts_with("ARTICLE") {
-                                &response
-                            } else {
-                                "200 OK\r\n"
-                            };
-
-                            let _ = stream.write_all(reply.as_bytes()).await;
-                        }
-                    }
-                }));
-            }
-        })
-        .abort_handle();
+        let handle = MockNntpServer::new(listener.local_addr()?.port())
+            .with_name(*name)
+            .on_command("DATE", "111 20251203120000\r\n")
+            .on_command("QUIT", "205 Goodbye\r\n")
+            .on_command("ARTICLE", response)
+            .spawn_on_listener(listener);
         mock_handles.push(handle);
     }
 

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -404,8 +404,8 @@ pub async fn setup_proxy_with_backends(
         backend_listeners.push(listener);
     }
 
-    let proxy_port = get_available_port().await?;
-    let proxy_listener = TcpListener::bind(format!("127.0.0.1:{}", proxy_port)).await?;
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let proxy_port = proxy_listener.local_addr()?.port();
 
     // Start mock backends
     let mut mock_handles = Vec::new();
@@ -429,6 +429,7 @@ pub async fn setup_proxy_with_backends(
                         return;
                     }
 
+                    let mut pending = bytes::BytesMut::new();
                     let mut buffer = [0; 1024];
                     loop {
                         let n = match stream.read(&mut buffer).await {
@@ -437,23 +438,28 @@ pub async fn setup_proxy_with_backends(
                             Err(_) => break,
                         };
 
-                        let cmd_str = String::from_utf8_lossy(&buffer[..n]);
-                        let cmd_upper = cmd_str.trim().to_uppercase();
+                        pending.extend_from_slice(&buffer[..n]);
 
-                        if cmd_upper.starts_with("QUIT") {
-                            let _ = stream.write_all(b"205 Goodbye\r\n").await;
-                            break;
+                        while let Some(line_end) = pending.windows(2).position(|w| w == b"\r\n") {
+                            let line = pending.split_to(line_end + 2);
+                            let cmd_str = String::from_utf8_lossy(&line);
+                            let cmd_upper = cmd_str.trim().to_uppercase();
+
+                            if cmd_upper.starts_with("QUIT") {
+                                let _ = stream.write_all(b"205 Goodbye\r\n").await;
+                                return;
+                            }
+
+                            let reply = if cmd_upper.starts_with("DATE") {
+                                "111 20251203120000\r\n"
+                            } else if cmd_upper.starts_with("ARTICLE") {
+                                &response
+                            } else {
+                                "200 OK\r\n"
+                            };
+
+                            let _ = stream.write_all(reply.as_bytes()).await;
                         }
-
-                        let reply = if cmd_upper.starts_with("DATE") {
-                            "111 20251203120000\r\n"
-                        } else if cmd_upper.starts_with("ARTICLE") {
-                            &response
-                        } else {
-                            "200 OK\r\n"
-                        };
-
-                        let _ = stream.write_all(reply.as_bytes()).await;
                     }
                 }));
             }
@@ -810,12 +816,27 @@ mod tests {
 
         stream.write_all(b"DATE\r\nHELP\r\n").await.unwrap();
 
-        let n = stream.read(&mut buffer).await.unwrap();
-        let response = String::from_utf8_lossy(&buffer[..n]);
-        assert!(response.contains("111 20260410235959"));
+        let mut response_bytes = Vec::new();
+        loop {
+            let n = tokio::time::timeout(Duration::from_secs(1), stream.read(&mut buffer))
+                .await
+                .expect("timed out waiting for mock server responses")
+                .unwrap();
 
-        let n = stream.read(&mut buffer).await.unwrap();
-        let response = String::from_utf8_lossy(&buffer[..n]);
+            assert!(
+                n > 0,
+                "mock server closed connection before sending both responses"
+            );
+
+            response_bytes.extend_from_slice(&buffer[..n]);
+            let response = String::from_utf8_lossy(&response_bytes);
+            if response.contains("111 20260410235959") && response.contains("100 help follows") {
+                break;
+            }
+        }
+
+        let response = String::from_utf8_lossy(&response_bytes);
+        assert!(response.contains("111 20260410235959"));
         assert!(response.contains("100 help follows"));
     }
 

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -196,11 +196,13 @@ impl MockNntpServer {
         self.spawn_with_listener(listener)
     }
 
-    /// Spawn the mock server and return a handle to its background task
-    /// Spawn mock server and return AbortHandle for automatic cleanup
+    /// Spawn the mock server and return a handle to its background task.
     ///
-    /// When the AbortHandle is dropped, the background task is immediately cancelled.
-    /// This prevents tests from hanging during shutdown waiting for mock servers to exit.
+    /// The returned [`AbortHandle`] can be used to cancel the background task by
+    /// calling [`AbortHandle::abort`].
+    ///
+    /// Dropping the [`AbortHandle`] does not cancel the task; it only drops the
+    /// caller's ability to abort it later.
     pub fn spawn(self) -> AbortHandle {
         let port = self.port;
         let Self {

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -385,10 +385,14 @@ pub async fn setup_proxy_with_backends(
 ) -> Result<(u16, Vec<u16>, Vec<AbortHandle>)> {
     use nntp_proxy::NntpProxy;
 
-    // Allocate ports using helper
+    // Bind backend listeners up front so the ports cannot be stolen between
+    // "pick a port" and "start the mock server".
+    let mut backend_listeners = Vec::new();
     let mut backend_ports = Vec::new();
     for _ in 0..backend_configs.len() {
-        backend_ports.push(get_available_port().await?);
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        backend_ports.push(listener.local_addr()?.port());
+        backend_listeners.push(listener);
     }
 
     let proxy_port = get_available_port().await?;
@@ -396,21 +400,56 @@ pub async fn setup_proxy_with_backends(
 
     // Start mock backends
     let mut mock_handles = Vec::new();
-    for (i, (name, has_article)) in backend_configs.iter().enumerate() {
-        let port = backend_ports[i];
-
+    for ((name, has_article), listener) in backend_configs.iter().zip(backend_listeners) {
         let response = if *has_article {
             "220 0 <test@example.com>\r\nSubject: Test\r\n\r\nBody\r\n.\r\n"
         } else {
             "430 No such article\r\n"
         };
 
-        let handle = MockNntpServer::new(port)
-            .with_name(*name)
-            .on_command("DATE", "111 20251203120000\r\n")
-            .on_command("QUIT", "205 Goodbye\r\n")
-            .on_command("ARTICLE", response) // ARTICLE command (any message-ID)
-            .spawn();
+        let name = (*name).to_string();
+        let response = response.to_string();
+        let handle = tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                let name = name.clone();
+                let response = response.clone();
+
+                drop(tokio::spawn(async move {
+                    let greeting = format!("200 {} Ready\r\n", name);
+                    if stream.write_all(greeting.as_bytes()).await.is_err() {
+                        return;
+                    }
+
+                    let mut buffer = [0; 1024];
+                    loop {
+                        let n = match stream.read(&mut buffer).await {
+                            Ok(0) => break,
+                            Ok(n) => n,
+                            Err(_) => break,
+                        };
+
+                        let cmd_str = String::from_utf8_lossy(&buffer[..n]);
+                        let cmd_upper = cmd_str.trim().to_uppercase();
+
+                        if cmd_upper.starts_with("QUIT") {
+                            let _ = stream.write_all(b"205 Goodbye\r\n").await;
+                            break;
+                        }
+
+                        let reply = if cmd_upper.starts_with("DATE") {
+                            "111 20251203120000\r\n"
+                        } else if cmd_upper.starts_with("ARTICLE") {
+                            &response
+                        } else {
+                            "200 OK\r\n"
+                        };
+
+                        let _ = stream.write_all(reply.as_bytes()).await;
+                    }
+                }));
+            }
+        })
+        .abort_handle();
         mock_handles.push(handle);
     }
 


### PR DESCRIPTION
## Summary

This PR fixes several related backend connection correctness issues, with the main change being that pooled backend connections now preserve already-read bytes that belong to the next NNTP response instead of silently losing them.

### 1. Preserve backend read-ahead across pooled commands

The branch already fixed terminator detection so mid-chunk and cross-boundary terminators are detected correctly. The remaining bug was what happened after detection:

- if a read contained `...\r\n.\r\n` plus the start of the next response,
- the code truncated the current response at the terminator,
- but the extra bytes had already been consumed from the socket and were discarded.

That left pooled connections desynchronized.

**Fix:** `ConnectionStream` now owns a small leftover buffer and serves those bytes before reading the socket again. This keeps response-boundary handling inside the existing stream wrapper rather than adding a new connection wrapper.

The read-ahead path is now used by:

- `NntpClient` multiline fetches
- adaptive precheck multiline fetches
- pipeline response parsing
- pipelined multiline streaming
- single-line pipelined response splitting

If leftover preservation exceeds `MAX_LEFTOVER_BYTES`, the connection is treated as desynchronized and removed from the pool.

### 2. TailBuffer rolling-window correctness

`TailBuffer::update()` previously overwrote prior bytes when several small chunks were appended in a row. That broke detection of `\r\n.\r\n` when split across 3+ reads.

**Fix:** maintain a true rolling window for small chunks so spanning terminators are detected correctly.

### 3. Multiline drain / pool cleanup correctness

`drain_connection_async()` now distinguishes:

- terminator exactly at chunk end: connection is clean and can return to the pool
- terminator mid-chunk: bytes from the next response were already consumed, so the connection must not be reused unless those bytes are preserved

The direct client/precheck/pipeline paths now preserve those bytes on the connection. The explicit drain path still removes truly desynchronized connections.

### 4. Graceful shutdown timeouts

This branch also keeps the shutdown reliability fixes:

- timeout for `cache.close()` during graceful shutdown
- timeout for sending `QUIT` to idle pooled backend connections
- minimal timeout when acquiring idle connections during shutdown

## Implementation notes

Key changes:

- `ConnectionStream` now stores and replays read-ahead bytes
- backend command/response readers continue using the existing stream abstraction
- pipeline code no longer depends on a separate external leftover buffer for response replay
- compression setup preserves any read-ahead state already attached to the stream

## Test plan

Verified locally with:

- `cargo check`
- `cargo check --tests`
- `cargo test test_leftover_is_read_before_socket -- --nocapture`
- `cargo test test_read_full_response_with_leftover -- --nocapture`
- `cargo test test_drain_multiline_into_multi_read_spanning_terminator -- --nocapture`
- `cargo test test_drain_async_mid_chunk_terminator_removes_from_pool -- --nocapture`
- `cargo test test_stream_pipelined_leftover_in_first_chunk -- --nocapture`
