### PR TITLE
fix: fully buffer per-command multiline responses

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776548001,
-        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "lastModified": 1777268161,
+        "narHash": "sha256-bxrdOn8SCOv8tN4JbTF/TXq7kjo9ag4M+C8yzzIRYbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "rev": "1c3fe55ad329cbcb28471bb30f05c9827f724c76",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776827647,
-        "narHash": "sha256-sYixYhp5V8jCajO8TRorE4fzs7IkL4MZdfLTKgkPQBk=",
+        "lastModified": 1777605393,
+        "narHash": "sha256-Hjp0VOOHgHcTrX23iVvnfAudPcuCmfkfpQNFwv2v/ks=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "40e6ccc06e1245a4837cbbd6bdda64e21cc67379",
+        "rev": "ff88db34cfa486fc4964a6991cab1678d82eee8c",
         "type": "github"
       },
       "original": {

--- a/src/cache/article.rs
+++ b/src/cache/article.rs
@@ -439,21 +439,24 @@ impl ArticleCache {
     /// The tier is stored with the entry for tier-aware TTL calculation.
     ///
     /// CRITICAL: Always re-insert to refresh TTL, and mark backend as having the article.
-    pub async fn upsert(
+    pub async fn upsert<B>(
         &self,
         message_id: MessageId<'_>,
-        buffer: Vec<u8>,
+        buffer: B,
         backend_id: BackendId,
         tier: u8,
-    ) {
+    ) where
+        B: Into<super::CacheBuffer>,
+    {
+        let buffer = buffer.into();
         let key: Arc<str> = message_id.without_brackets().into();
         let cache_articles = self.cache_articles;
 
         // Prepare the new buffer outside the closure for stub extraction
         let new_buffer = if cache_articles {
-            buffer
+            buffer.into_vec()
         } else {
-            Self::create_minimal_stub(&buffer)
+            Self::create_minimal_stub(buffer)
         };
 
         // Wrap in Arc so we can efficiently share/move into closure without clone.
@@ -515,20 +518,28 @@ impl ArticleCache {
     ///
     /// Extracts the status code from the first line and creates a minimal stub.
     /// Falls back to "200\r\n" if parsing fails.
-    fn create_minimal_stub(buffer: &[u8]) -> Vec<u8> {
-        // Find first line (status code line)
-        if let Some(end) = buffer.iter().position(|&b| b == b'\n') {
-            // Extract status code (first 3 digits)
-            if end >= 3 {
-                let code = &buffer[..3];
-                // Verify it's actually digits
-                if code.iter().all(|&b| b.is_ascii_digit()) {
-                    return format!("{}\r\n", String::from_utf8_lossy(code)).into_bytes();
-                }
+    fn create_minimal_stub(buffer: super::CacheBuffer) -> Vec<u8> {
+        let status_line = match buffer {
+            super::CacheBuffer::Vec(buf) => super::entry_helpers::extract_status_line(&buf),
+            super::CacheBuffer::Pooled(buf) => {
+                super::entry_helpers::extract_status_line(buf.as_ref())
             }
-        }
-        // Fallback if we can't parse
-        b"200\r\n".to_vec()
+            super::CacheBuffer::Chunked(buf) => {
+                super::entry_helpers::extract_chunked_status_line(&buf)
+            }
+            super::CacheBuffer::Small(buf) => super::entry_helpers::extract_status_line(&buf),
+        };
+
+        status_line
+            .get(..3)
+            .filter(|digits| digits.iter().all(|b| b.is_ascii_digit()))
+            .map(|digits| {
+                let mut stub = Vec::with_capacity(5);
+                stub.extend_from_slice(digits);
+                stub.extend_from_slice(b"\r\n");
+                stub
+            })
+            .unwrap_or_else(|| b"200\r\n".to_vec())
     }
 
     /// Record that a backend returned 430 for this article - ATOMIC OPERATION

--- a/src/cache/entry_helpers.rs
+++ b/src/cache/entry_helpers.rs
@@ -4,7 +4,7 @@
 //! providing common logic used by both `ArticleEntry` (moka) and
 //! `HybridArticleEntry` (foyer) cache implementations.
 
-use crate::session::streaming::tail_buffer::TailBuffer;
+use crate::{pool::ChunkedResponse, session::streaming::tail_buffer::TailBuffer};
 use smallvec::SmallVec;
 
 /// Check if a buffer contains a valid NNTP multiline response
@@ -67,7 +67,7 @@ pub(super) fn response_for_command(
 ) -> Option<Vec<u8>> {
     match (status_code, cmd_verb) {
         // STAT just needs existence confirmation - synthesize response
-        (220..=222, "STAT") => Some(format!("223 0 {message_id}\r\n").into_bytes()),
+        (220..=222, "STAT") => Some(build_stat_response(message_id).into_vec()),
         // Direct match - return cached buffer if valid
         (220, "ARTICLE") | (222, "BODY") | (221, "HEAD") => {
             if is_valid_response(buffer) {
@@ -96,6 +96,16 @@ pub(super) fn response_for_command(
         }
         _ => None,
     }
+}
+
+/// Build a `223 0 <message-id>\r\n` response using stack-backed storage.
+#[must_use]
+pub fn build_stat_response(message_id: &str) -> SmallVec<[u8; 128]> {
+    let mut out = SmallVec::new();
+    out.extend_from_slice(b"223 0 ");
+    out.extend_from_slice(message_id.as_bytes());
+    out.extend_from_slice(b"\r\n");
+    out
 }
 
 /// Check if a status code can serve a given command verb
@@ -144,6 +154,14 @@ pub fn extract_status_line(buffer: &[u8]) -> SmallVec<[u8; 128]> {
     } else {
         SmallVec::from_slice(buffer)
     }
+}
+
+/// Extract the first status line from a chunked response without flattening.
+#[inline]
+pub fn extract_chunked_status_line(buffer: &ChunkedResponse) -> SmallVec<[u8; 128]> {
+    let mut prefix = SmallVec::<[u8; 128]>::new();
+    buffer.copy_prefix_into(buffer.len().min(128), &mut prefix);
+    extract_status_line(&prefix)
 }
 
 #[cfg(test)]
@@ -466,5 +484,17 @@ mod tests {
         let stub = extract_status_line(buf);
         // cr_pos = 8, end = min(10, 9) = 9
         assert_eq!(stub.as_slice(), b"220 test\r");
+    }
+
+    #[tokio::test]
+    async fn test_extract_chunked_status_line_across_chunks() {
+        let pool =
+            crate::pool::BufferPool::new(crate::types::BufferSize::try_new(1024).unwrap(), 1)
+                .with_capture_pool(8, 4);
+        let mut response = ChunkedResponse::default();
+        response.extend_from_slice(&pool, b"220 0 <test@example.com>\r\nBody\r\n.\r\n");
+
+        let stub = extract_chunked_status_line(&response);
+        assert_eq!(stub.as_slice(), b"220 0 <test@example.com>\r\n");
     }
 }

--- a/src/cache/hybrid.rs
+++ b/src/cache/hybrid.rs
@@ -350,15 +350,19 @@ impl HybridArticleCache {
     /// A cached full article (220/222 response) must not be replaced by a STAT stub.
     ///
     /// The tier is stored with the entry for tier-aware TTL calculation.
-    pub async fn upsert(
+    pub async fn upsert<B>(
         &self,
         message_id: MessageId<'_>,
-        buffer: Vec<u8>,
+        buffer: B,
         backend_id: BackendId,
         tier: u8,
-    ) {
+    ) where
+        B: Into<super::CacheBuffer>,
+    {
+        let buffer = buffer.into();
         let key = message_id.without_brackets().to_string();
         let buffer_len = buffer.len();
+        let buffer = buffer.into_vec();
 
         // Check for existing entry - don't overwrite larger buffers with smaller ones
         if let Ok(Some(existing)) = self.cache.get(&key).await {
@@ -484,17 +488,7 @@ impl HybridArticleCache {
 
     /// Create a minimal stub from a response buffer (for availability-only mode)
     fn create_stub(buffer: &[u8]) -> Vec<u8> {
-        // Extract just the status code line
-        if let Some(pos) = buffer.iter().position(|&b| b == b'\r') {
-            buffer[..pos + 2].to_vec() // Include \r\n
-        } else if buffer.len() >= 3 {
-            // Just the status code
-            let mut stub = buffer[..3].to_vec();
-            stub.extend_from_slice(b"\r\n");
-            stub
-        } else {
-            buffer.to_vec()
-        }
+        super::entry_helpers::extract_status_line(buffer).into_vec()
     }
 
     /// Get cache statistics

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -28,9 +28,124 @@ pub use hybrid::{HybridArticleCache, HybridCacheConfig, HybridCacheStats};
 pub use hybrid_codec::{CacheableStatusCode, HybridArticleEntry};
 
 // Internal helper re-exported for session handlers
-pub(crate) use entry_helpers::extract_status_line;
+pub(crate) use entry_helpers::{build_stat_response, extract_chunked_status_line};
 
 use crate::types::{BackendId, MessageId};
+use smallvec::SmallVec;
+
+/// Owned response storage passed across the async cache ingest boundary.
+///
+/// Hot-path code should hand off one of these owned forms directly instead of
+/// flattening into a fresh `Vec<u8>` before spawning cache work.
+#[derive(Debug)]
+pub enum CacheBuffer {
+    Vec(Vec<u8>),
+    Pooled(crate::pool::PooledBuffer),
+    Chunked(crate::pool::ChunkedResponse),
+    Small(SmallVec<[u8; 128]>),
+}
+
+impl CacheBuffer {
+    #[must_use]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::Vec(buf) => buf.len(),
+            Self::Pooled(buf) => buf.len(),
+            Self::Chunked(buf) => buf.len(),
+            Self::Small(buf) => buf.len(),
+        }
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Cold-path flattening for cache backends that still require contiguous bytes.
+    #[must_use]
+    pub fn into_vec(self) -> Vec<u8> {
+        match self {
+            Self::Vec(buf) => buf,
+            Self::Pooled(buf) => buf.as_ref().to_vec(),
+            Self::Chunked(buf) => buf.to_vec(),
+            Self::Small(buf) => buf.into_vec(),
+        }
+    }
+}
+
+impl PartialEq for CacheBuffer {
+    fn eq(&self, other: &Self) -> bool {
+        fn chunks<'a>(buf: &'a CacheBuffer) -> Box<dyn Iterator<Item = &'a [u8]> + 'a> {
+            match buf {
+                CacheBuffer::Vec(v) => Box::new(std::iter::once(v.as_slice())),
+                CacheBuffer::Pooled(v) => Box::new(std::iter::once(v.as_ref())),
+                CacheBuffer::Chunked(v) => Box::new(v.iter_chunks()),
+                CacheBuffer::Small(v) => Box::new(std::iter::once(v.as_slice())),
+            }
+        }
+
+        if self.len() != other.len() {
+            return false;
+        }
+
+        let left = chunks(self).flat_map(|chunk| chunk.iter().copied());
+        let mut right = chunks(other).flat_map(|chunk| chunk.iter().copied());
+        left.eq(&mut right)
+    }
+}
+
+impl Eq for CacheBuffer {}
+
+impl From<Vec<u8>> for CacheBuffer {
+    fn from(value: Vec<u8>) -> Self {
+        Self::Vec(value)
+    }
+}
+
+impl From<crate::pool::PooledBuffer> for CacheBuffer {
+    fn from(value: crate::pool::PooledBuffer) -> Self {
+        Self::Pooled(value)
+    }
+}
+
+impl From<crate::pool::ChunkedResponse> for CacheBuffer {
+    fn from(value: crate::pool::ChunkedResponse) -> Self {
+        Self::Chunked(value)
+    }
+}
+
+impl From<SmallVec<[u8; 128]>> for CacheBuffer {
+    fn from(value: SmallVec<[u8; 128]>) -> Self {
+        Self::Small(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn cache_buffer_equality_spans_storage_forms() {
+        let bytes = b"220 0 <test@example.com>\r\nBody\r\n.\r\n";
+        let pool =
+            crate::pool::BufferPool::new(crate::types::BufferSize::try_new(1024).unwrap(), 1)
+                .with_capture_pool(8, 4);
+
+        let mut pooled = pool.acquire().await;
+        pooled.copy_from_slice(bytes);
+
+        let mut chunked = crate::pool::ChunkedResponse::default();
+        chunked.extend_from_slice(&pool, bytes);
+
+        let small = SmallVec::<[u8; 128]>::from_slice(bytes);
+
+        assert_eq!(
+            CacheBuffer::Vec(bytes.to_vec()),
+            CacheBuffer::Pooled(pooled)
+        );
+        assert_eq!(CacheBuffer::Chunked(chunked), CacheBuffer::Small(small));
+    }
+}
 
 /// Statistics for cache display in TUI
 #[derive(Debug, Clone, Default)]
@@ -148,13 +263,16 @@ impl UnifiedCache {
     /// Upsert (insert or update) an article in the cache
     ///
     /// The tier is used for tier-aware TTL calculation (higher tier = longer TTL).
-    pub async fn upsert(
+    pub async fn upsert<B>(
         &self,
         message_id: MessageId<'_>,
-        buffer: Vec<u8>,
+        buffer: B,
         backend_id: BackendId,
         tier: u8,
-    ) {
+    ) where
+        B: Into<CacheBuffer>,
+    {
+        let buffer = buffer.into();
         match self {
             Self::Memory(cache) => cache.upsert(message_id, buffer, backend_id, tier).await,
             Self::Hybrid(cache) => cache.upsert(message_id, buffer, backend_id, tier).await,

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -28,7 +28,9 @@ pub use hybrid::{HybridArticleCache, HybridCacheConfig, HybridCacheStats};
 pub use hybrid_codec::{CacheableStatusCode, HybridArticleEntry};
 
 // Internal helper re-exported for session handlers
-pub(crate) use entry_helpers::{build_stat_response, extract_chunked_status_line};
+pub(crate) use entry_helpers::{
+    build_stat_response, extract_chunked_status_line, extract_status_line,
+};
 
 use crate::types::{BackendId, MessageId};
 use smallvec::SmallVec;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -30,10 +30,11 @@ pub mod buffer {
     /// This is a conservative default; increase via config for higher concurrency
     pub const POOL_COUNT: usize = 50;
 
-    /// Size of each capture buffer (768KB, page-aligned)
-    /// Sized to capture typical yEnc articles (~750KB) without reallocation
-    /// Larger than POOL to handle 99th percentile articles
-    pub const CAPTURE: usize = 768 * 1024;
+    /// Size of each capture buffer (772KB, page-aligned)
+    /// Sized to capture typical yEnc articles plus NNTP framing without
+    /// reallocation. The extra 4KB avoids needless growth when payloads are
+    /// near 768KB and only exceed it by status-line/terminator overhead.
+    pub const CAPTURE: usize = 772 * 1024;
 
     /// Default number of capture buffers in the pool.
     ///

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -26,6 +26,15 @@ pub struct PooledBuffer {
     max_pool_size: usize,
 }
 
+impl std::fmt::Debug for PooledBuffer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PooledBuffer")
+            .field("initialized", &self.initialized)
+            .field("capacity", &self.buffer.capacity())
+            .finish_non_exhaustive()
+    }
+}
+
 impl PooledBuffer {
     /// Get the full capacity of the buffer
     #[must_use]

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -723,6 +723,7 @@ impl BufferPool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tokio::io::AsyncWriteExt;
 
     #[tokio::test]
     async fn test_buffer_pool_creation() {
@@ -733,6 +734,126 @@ mod tests {
         assert_eq!(buffer1.capacity(), 8192);
         assert_eq!(buffer1.initialized(), 0); // No bytes initialized yet
         // Buffer automatically returned on drop
+    }
+
+    #[tokio::test]
+    async fn test_acquire_starts_empty_with_stable_capacity() {
+        let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
+
+        let capacity = {
+            let buffer = pool.acquire().await;
+            assert_eq!(buffer.initialized(), 0);
+            assert_eq!(buffer.len(), 0);
+            buffer.capacity()
+        };
+
+        let buffer = pool.acquire().await;
+        assert_eq!(buffer.initialized(), 0);
+        assert_eq!(buffer.len(), 0);
+        assert_eq!(buffer.capacity(), capacity);
+    }
+
+    #[tokio::test]
+    async fn test_read_from_sets_initialized_without_reducing_capacity() {
+        let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
+        let mut buffer = pool.acquire().await;
+        let capacity = buffer.capacity();
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+
+        writer.write_all(b"220 ready\r\n").await.unwrap();
+        drop(writer);
+
+        let read = buffer.read_from(&mut reader).await.unwrap();
+        assert_eq!(read, 11);
+        assert_eq!(buffer.initialized(), 11);
+        assert_eq!(&*buffer, b"220 ready\r\n");
+        assert_eq!(buffer.capacity(), capacity);
+    }
+
+    #[tokio::test]
+    async fn test_read_more_appends_after_initialized_bytes() {
+        let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
+        let mut buffer = pool.acquire().await;
+        buffer.copy_from_slice(b"22");
+
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        writer.write_all(b"0 ready\r\n").await.unwrap();
+        drop(writer);
+
+        let read = buffer.read_more(&mut reader).await.unwrap();
+        assert_eq!(read, 9);
+        assert_eq!(buffer.initialized(), 11);
+        assert_eq!(&*buffer, b"220 ready\r\n");
+    }
+
+    #[tokio::test]
+    async fn test_copy_from_slice_overwrites_and_allows_up_to_capacity() {
+        let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
+        let mut buffer = pool.acquire().await;
+        let capacity = buffer.capacity();
+
+        buffer.copy_from_slice(b"previous bytes");
+        assert_eq!(&*buffer, b"previous bytes");
+
+        let data = vec![b'X'; capacity];
+        buffer.copy_from_slice(&data);
+        assert_eq!(buffer.initialized(), capacity);
+        assert_eq!(&buffer[..4], b"XXXX");
+        assert_eq!(buffer.capacity(), capacity);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "data exceeds buffer capacity")]
+    async fn test_copy_from_slice_rejects_larger_than_capacity() {
+        let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
+        let mut buffer = pool.acquire().await;
+        let too_large = vec![b'X'; buffer.capacity() + 1];
+
+        buffer.copy_from_slice(&too_large);
+    }
+
+    #[tokio::test]
+    async fn test_clear_and_truncate_only_change_initialized_length() {
+        let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
+        let mut buffer = pool.acquire().await;
+        let capacity = buffer.capacity();
+
+        buffer.copy_from_slice(b"abcdef");
+        buffer.truncate(3);
+        assert_eq!(buffer.initialized(), 3);
+        assert_eq!(&*buffer, b"abc");
+        assert_eq!(buffer.capacity(), capacity);
+
+        buffer.clear();
+        assert_eq!(buffer.initialized(), 0);
+        assert_eq!(buffer.len(), 0);
+        assert_eq!(buffer.capacity(), capacity);
+    }
+
+    #[tokio::test]
+    async fn test_resized_buffers_are_discarded_instead_of_repooled() {
+        let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1).with_capture_pool(8, 1);
+
+        let normal_capacity = {
+            let mut buffer = pool.acquire().await;
+            let capacity = buffer.capacity();
+            buffer.extend_from_slice(&vec![b'N'; capacity + 1]);
+            assert!(buffer.capacity() > capacity);
+            capacity
+        };
+
+        let buffer = pool.acquire().await;
+        assert_eq!(buffer.capacity(), normal_capacity);
+        drop(buffer);
+
+        {
+            let mut capture = pool.acquire_capture().await;
+            capture.extend_from_slice(&vec![b'C'; 9]);
+            assert!(capture.capacity() > 8);
+        }
+
+        let capture = pool.acquire_capture().await;
+        assert_eq!(capture.capacity(), 8);
     }
 
     #[tokio::test]

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -74,12 +74,45 @@ impl PooledBuffer {
     /// Panics if `data.len()` > capacity
     #[inline]
     pub fn copy_from_slice(&mut self, data: &[u8]) {
-        assert!(
-            data.len() <= self.buffer.len(),
-            "data exceeds buffer capacity"
-        );
+        if self.buffer.is_empty() {
+            assert!(
+                data.len() <= self.buffer.capacity(),
+                "data exceeds buffer capacity"
+            );
+            if self.buffer.len() < data.len() {
+                self.buffer.resize(data.len(), 0);
+            }
+        } else {
+            assert!(
+                data.len() <= self.buffer.len(),
+                "data exceeds buffer capacity"
+            );
+        }
         self.buffer[..data.len()].copy_from_slice(data);
         self.initialized = data.len();
+    }
+
+    /// Reset the logical contents of the buffer without changing its backing allocation.
+    ///
+    /// This is safe for both fixed-size I/O buffers and accumulator-style capture buffers:
+    /// callers see an empty initialized slice afterwards, while the underlying allocation
+    /// stays available for reuse.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.initialized = 0;
+    }
+
+    /// Shorten the logical initialized length without changing the backing allocation.
+    ///
+    /// Used by response framing helpers when a read contains bytes beyond the current
+    /// response boundary and the remainder is stashed as leftover for the next response.
+    #[inline]
+    pub fn truncate(&mut self, len: usize) {
+        assert!(
+            len <= self.initialized,
+            "truncate length exceeds initialized bytes"
+        );
+        self.initialized = len;
     }
 
     /// Get mutable access to the full buffer capacity
@@ -125,18 +158,21 @@ impl PooledBuffer {
     /// After calling this, `.len()` (via Deref) returns the total accumulated length.
     #[inline]
     pub fn extend_from_slice(&mut self, data: &[u8]) {
+        let needed = self.initialized + data.len();
         // Warn if we need to grow beyond pre-allocated capacity (rare for typical articles)
-        if self.buffer.len() + data.len() > self.buffer.capacity() {
+        if needed > self.buffer.capacity() {
             tracing::warn!(
                 "Capture buffer growing: {} + {} > {} capacity (will allocate)",
-                self.buffer.len(),
+                self.initialized,
                 data.len(),
                 self.buffer.capacity()
             );
         }
-        // Always extend - never truncate to prevent caching partial/corrupt data
-        self.buffer.extend_from_slice(data);
-        self.initialized = self.buffer.len();
+        if self.buffer.len() < needed {
+            self.buffer.resize(needed, 0);
+        }
+        self.buffer[self.initialized..needed].copy_from_slice(data);
+        self.initialized = needed;
     }
 }
 

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -24,6 +24,8 @@ pub struct PooledBuffer {
     pool: Arc<SegQueue<Vec<u8>>>,
     pool_size: Arc<AtomicUsize>,
     max_pool_size: usize,
+    expected_capacity: usize,
+    reset_len: usize,
 }
 
 impl std::fmt::Debug for PooledBuffer {
@@ -36,11 +38,11 @@ impl std::fmt::Debug for PooledBuffer {
 }
 
 impl PooledBuffer {
-    /// Get the full capacity of the buffer
+    /// Get the backing allocation capacity of the buffer.
     #[must_use]
     #[inline]
     pub const fn capacity(&self) -> usize {
-        self.buffer.len()
+        self.buffer.capacity()
     }
 
     /// Get the number of initialized bytes
@@ -207,6 +209,19 @@ impl AsRef<[u8]> for PooledBuffer {
 
 impl Drop for PooledBuffer {
     fn drop(&mut self) {
+        if self.buffer.capacity() != self.expected_capacity {
+            debug!(
+                "Dropping resized pooled buffer instead of returning it to the pool (capacity {} != expected {})",
+                self.buffer.capacity(),
+                self.expected_capacity
+            );
+            return;
+        }
+
+        if self.buffer.len() != self.reset_len {
+            self.buffer.resize(self.reset_len, 0);
+        }
+
         // Atomically return buffer to pool if pool is not full
         let mut current_size = self.pool_size.load(Ordering::Relaxed);
         while current_size < self.max_pool_size {
@@ -459,11 +474,13 @@ impl BufferPool {
         };
 
         PooledBuffer {
+            expected_capacity: buffer.capacity(),
             buffer,
             initialized: 0, // Start with 0 bytes safe to read
             pool: Arc::clone(&self.pool),
             pool_size: Arc::clone(&self.pool_size),
             max_pool_size: self.max_pool_size,
+            reset_len: self.buffer_size.get(),
         }
     }
 
@@ -496,11 +513,13 @@ impl BufferPool {
         };
 
         PooledBuffer {
+            expected_capacity: buffer.capacity(),
             buffer,
             initialized: 0,
             pool: Arc::clone(&self.capture_pool),
             pool_size: Arc::clone(&self.capture_pool_size),
             max_pool_size: self.max_capture_pool_size,
+            reset_len: 0,
         }
     }
 }
@@ -550,12 +569,26 @@ mod tests {
 
         // Pool is exhausted, should create new buffer
         let buf3 = pool.acquire().await;
-        assert_eq!(buf3.capacity(), 1024);
+        assert_eq!(buf3.capacity(), 4096);
 
         // Drop buffers (automatically returned)
         drop(buf1);
         drop(buf2);
         drop(buf3);
+    }
+
+    #[tokio::test]
+    async fn test_oversized_capture_buffer_is_not_reused() {
+        let pool =
+            BufferPool::new(BufferSize::try_new(1024).unwrap(), 1).with_capture_pool(8192, 1);
+
+        let mut capture = pool.acquire_capture().await;
+        capture.extend_from_slice(&vec![b'X'; 8193]);
+        assert!(capture.capacity() > 8192);
+        drop(capture);
+
+        let capture2 = pool.acquire_capture().await;
+        assert_eq!(capture2.capacity(), 8192);
     }
 
     #[tokio::test]
@@ -569,7 +602,7 @@ mod tests {
             let pool_clone = pool.clone();
             let handle = tokio::spawn(async move {
                 let buffer = pool_clone.acquire().await;
-                assert_eq!(buffer.capacity(), 2048);
+                assert_eq!(buffer.capacity(), 4096);
                 // Simulate some work
                 tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
             });
@@ -609,7 +642,7 @@ mod tests {
 
         // Get it again - may contain old data (performance optimization)
         let buffer2 = pool.acquire().await;
-        assert_eq!(buffer2.capacity(), 1024);
+        assert_eq!(buffer2.capacity(), 4096);
         // Note: buffer may contain previous data - callers must use &buf[..n] pattern
     }
 
@@ -640,7 +673,7 @@ mod tests {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 2);
 
         let buffer = pool.acquire().await;
-        assert_eq!(buffer.capacity(), 1024);
+        assert_eq!(buffer.capacity(), 4096);
 
         // PooledBuffer auto-returns on drop with correct size enforcement in Drop impl
         drop(buffer);
@@ -681,7 +714,7 @@ mod tests {
         let medium_buf = medium_pool.acquire().await;
         let large_buf = large_pool.acquire().await;
 
-        assert_eq!(small_buf.capacity(), 1024);
+        assert_eq!(small_buf.capacity(), 4096);
         assert_eq!(medium_buf.capacity(), 8192);
         assert_eq!(large_buf.capacity(), 65536);
 
@@ -854,12 +887,12 @@ mod tests {
         {
             let mut buffer = pool.acquire().await;
             buffer.copy_from_slice(b"test");
-            assert_eq!(buffer.capacity(), 2048);
+            assert_eq!(buffer.capacity(), 4096);
         } // Drop returns to pool
 
         let buffer2 = pool.acquire().await;
         // Should have same capacity when reused
-        assert_eq!(buffer2.capacity(), 2048);
+        assert_eq!(buffer2.capacity(), 4096);
     }
 
     #[test]

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -10,10 +10,11 @@ use tracing::{debug, info};
 
 /// A pooled buffer that automatically returns to the pool when dropped
 ///
-/// # Safety and Uninitialized Memory
+/// # Safety and Initialized Bytes
 ///
-/// Buffers contain **uninitialized memory** for performance (no zeroing overhead).
-/// The type tracks initialized bytes and only exposes that portion, preventing UB.
+/// The backing allocation is pre-faulted and then kept logically empty until
+/// bytes are read or copied into it. `BytesMut::len()` is the initialized length,
+/// and immutable access only exposes that initialized portion.
 ///
 /// ## Usage
 /// ```ignore
@@ -118,16 +119,16 @@ impl PooledBuffer {
         self.buffer.truncate(len);
     }
 
-    /// Get mutable access to the full buffer capacity
+    /// Get mutable access to the fixed I/O writable region.
     ///
-    /// Returns a mutable slice of the entire buffer. After writing to this slice,
-    /// you must manually track how many bytes were initialized (e.g., using the
-    /// return value from `read()` and accessing via `&buffer[..n]`).
+    /// This compatibility API is for callers that still perform manual reads
+    /// into a borrowed slice. It does not update the logical initialized length;
+    /// callers must use the read byte count directly.
     ///
     /// # Safety Note
-    /// The returned slice contains **uninitialized memory**. Only access bytes
-    /// that you've written to. This method is primarily for use with I/O
-    /// operations like `AsyncRead::read()`.
+    /// Only bytes written by the caller's I/O operation should be read. Prefer
+    /// `read_from()` or `read_more()` when possible because those update the
+    /// initialized length automatically.
     ///
     /// # Examples
     /// ```ignore
@@ -155,7 +156,7 @@ impl PooledBuffer {
     /// pages are pre-faulted. As long as total accumulated data fits within
     /// capacity, this operation performs NO allocations or page faults.
     ///
-    /// If data exceeds capacity, the Vec will grow automatically (with allocation).
+    /// If data exceeds capacity, the `BytesMut` will grow automatically (with allocation).
     /// This ensures complete data is always captured rather than truncating, which
     /// would corrupt cached responses.
     ///
@@ -165,7 +166,7 @@ impl PooledBuffer {
     #[inline]
     pub fn extend_from_slice(&mut self, data: &[u8]) {
         let needed = self.buffer.len() + data.len();
-        // Warn if we need to grow beyond pre-allocated capacity (rare for typical articles)
+        // Accumulator/capture mode may grow; resized buffers are discarded on drop.
         if needed > self.buffer.capacity() {
             tracing::warn!(
                 "Capture buffer growing: {} + {} > {} capacity (will allocate)",
@@ -615,10 +616,8 @@ impl BufferPool {
     ///
     /// # Safety Notes
     ///
-    /// The buffer may contain old data, but this is safe because:
-    /// - Callers use `AsyncRead` which writes into the buffer
-    /// - They get back `n` bytes written and access only `&buf[..n]`
-    /// - Stale data beyond `n` is never accessed
+    /// The buffer may contain old bytes outside its logical length, but immutable
+    /// access only exposes `BytesMut::len()` initialized bytes.
     fn acquire_now(&self) -> PooledBuffer {
         let buffer = if let Some(buffer) = self.pool.pop() {
             self.pool_size.fetch_sub(1, Ordering::Relaxed);
@@ -844,8 +843,7 @@ mod tests {
         assert_eq!(buffer.capacity(), 4096);
         assert_eq!(buffer.initialized(), 0);
 
-        // Buffer contains uninitialized data - this is intentional for performance
-        // Callers will write to it via AsyncRead before accessing
+        // Callers see an empty initialized slice until data is read or copied in.
 
         // Drop it (automatically returns to pool)
         drop(buffer);
@@ -967,7 +965,7 @@ mod tests {
         // Get it again - may contain old data (performance optimization)
         let buffer2 = pool.acquire().await;
         assert_eq!(buffer2.capacity(), 4096);
-        // Note: buffer may contain previous data - callers must use &buf[..n] pattern
+        // Note: buffer may contain previous bytes outside the initialized range.
     }
 
     #[tokio::test]
@@ -1059,7 +1057,7 @@ mod tests {
         slice[1] = b'i';
         slice[2] = b'!';
 
-        // Can write to the full capacity
+        // Can write to the fixed I/O writable region
         for (i, byte) in slice.iter_mut().enumerate() {
             *byte = (i % 256) as u8;
         }
@@ -1188,7 +1186,7 @@ mod tests {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 5);
         let mut buffer = pool.acquire().await;
 
-        // as_mut_slice should return full capacity
+        // as_mut_slice should return the fixed I/O writable region
         let slice = buffer.as_mut_slice();
         assert_eq!(slice.len(), 1024);
     }

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -55,13 +55,22 @@ impl PooledBuffer {
         self.buffer.len()
     }
 
+    #[inline]
+    fn read_limit(&self) -> usize {
+        if self.writable_len == 0 {
+            self.buffer.capacity()
+        } else {
+            self.writable_len
+        }
+    }
+
     /// Read from an `AsyncRead` source, automatically tracking initialized bytes
     pub async fn read_from<R>(&mut self, reader: &mut R) -> std::io::Result<usize>
     where
         R: AsyncRead + Unpin,
     {
         self.buffer.clear();
-        let limit = self.buffer.capacity();
+        let limit = self.read_limit();
         let n = reader.take(limit as u64).read_buf(&mut self.buffer).await?;
         Ok(n)
     }
@@ -77,7 +86,7 @@ impl PooledBuffer {
     where
         R: AsyncRead + Unpin,
     {
-        let limit = self.buffer.capacity().saturating_sub(self.buffer.len());
+        let limit = self.read_limit().saturating_sub(self.buffer.len());
         let n = reader.take(limit as u64).read_buf(&mut self.buffer).await?;
         Ok(n)
     }
@@ -749,6 +758,25 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_read_from_is_limited_to_fixed_writable_region() {
+        let pool = BufferPool::new(BufferSize::try_new(8).unwrap(), 1);
+        let mut buffer = pool.acquire().await;
+        assert!(buffer.capacity() > buffer.as_mut_slice().len());
+
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        writer
+            .write_all(b"220 long response over eight bytes\r\n")
+            .await
+            .unwrap();
+        drop(writer);
+
+        let read = buffer.read_from(&mut reader).await.unwrap();
+        assert_eq!(read, 8);
+        assert_eq!(buffer.initialized(), 8);
+        assert_eq!(buffer.as_mut_slice()[..read].len(), read);
+    }
+
+    #[tokio::test]
     async fn test_read_more_appends_after_initialized_bytes() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
         let mut buffer = pool.acquire().await;
@@ -762,6 +790,22 @@ mod tests {
         assert_eq!(read, 9);
         assert_eq!(buffer.initialized(), 11);
         assert_eq!(&*buffer, b"220 ready\r\n");
+    }
+
+    #[tokio::test]
+    async fn test_read_more_is_limited_to_remaining_fixed_writable_region() {
+        let pool = BufferPool::new(BufferSize::try_new(8).unwrap(), 1);
+        let mut buffer = pool.acquire().await;
+        buffer.copy_from_slice(b"22");
+
+        let (mut writer, mut reader) = tokio::io::duplex(64);
+        writer.write_all(b"0 long response\r\n").await.unwrap();
+        drop(writer);
+
+        let read = buffer.read_more(&mut reader).await.unwrap();
+        assert_eq!(read, 6);
+        assert_eq!(buffer.initialized(), 8);
+        assert_eq!(&*buffer, b"220 long");
     }
 
     #[tokio::test]

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -1,5 +1,6 @@
 use crate::types::BufferSize;
 use crossbeam::queue::SegQueue;
+use smallvec::SmallVec;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -337,12 +338,31 @@ impl ChunkedResponse {
         self.chunks.first().map(AsRef::as_ref)
     }
 
+    /// Iterate buffered chunks without flattening.
+    pub fn iter_chunks(&self) -> impl Iterator<Item = &[u8]> {
+        self.chunks.iter().map(AsRef::as_ref)
+    }
+
+    /// Copy up to `len` bytes from the front of the response into a small stack-backed buffer.
+    pub fn copy_prefix_into(&self, len: usize, out: &mut SmallVec<[u8; 128]>) {
+        out.clear();
+        let mut remaining = len.min(self.len);
+        for chunk in self.iter_chunks() {
+            if remaining == 0 {
+                break;
+            }
+            let take = remaining.min(chunk.len());
+            out.extend_from_slice(&chunk[..take]);
+            remaining -= take;
+        }
+    }
+
     /// Copy the buffered response into a contiguous `Vec<u8>`.
     #[must_use]
     pub fn to_vec(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(self.len);
-        for chunk in &self.chunks {
-            out.extend_from_slice(chunk.as_ref());
+        for chunk in self.iter_chunks() {
+            out.extend_from_slice(chunk);
         }
         out
     }
@@ -378,8 +398,22 @@ impl ChunkedResponse {
             return false;
         }
 
-        let tail = self.to_vec();
-        tail.ends_with(suffix)
+        let mut remaining = suffix.len();
+        for chunk in self.chunks.iter().rev() {
+            if remaining == 0 {
+                return true;
+            }
+            let data = chunk.as_ref();
+            let take = remaining.min(data.len());
+            let suffix_start = remaining - take;
+            let data_start = data.len() - take;
+            if data[data_start..] != suffix[suffix_start..remaining] {
+                return false;
+            }
+            remaining -= take;
+        }
+
+        remaining == 0
     }
 
     /// Write all buffered chunks to a sink in order.
@@ -387,8 +421,8 @@ impl ChunkedResponse {
     where
         W: AsyncWriteExt + Unpin,
     {
-        for chunk in &self.chunks {
-            writer.write_all(chunk.as_ref()).await?;
+        for chunk in self.iter_chunks() {
+            writer.write_all(chunk).await?;
         }
         Ok(())
     }
@@ -751,6 +785,34 @@ mod tests {
 
         let capture2 = pool.acquire_capture().await;
         assert_eq!(capture2.capacity(), 8192);
+    }
+
+    #[tokio::test]
+    async fn test_chunked_response_helpers_without_flattening() {
+        let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1).with_capture_pool(8, 4);
+        let mut response = ChunkedResponse::default();
+        response.extend_from_slice(&pool, b"220 0 <id>\r\nBody\r\n.\r\n");
+
+        let chunks: Vec<&[u8]> = response.iter_chunks().collect();
+        assert!(chunks.len() > 1, "test requires multi-chunk buffering");
+        assert_eq!(chunks.concat(), b"220 0 <id>\r\nBody\r\n.\r\n");
+        assert!(response.starts_with(b"220 0 "));
+        assert!(response.ends_with(b"\r\n.\r\n"));
+
+        let mut prefix = SmallVec::<[u8; 128]>::new();
+        response.copy_prefix_into(12, &mut prefix);
+        assert_eq!(&prefix[..], b"220 0 <id>\r\n");
+    }
+
+    #[tokio::test]
+    async fn test_chunked_response_copy_prefix_clamps_to_length() {
+        let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1).with_capture_pool(8, 4);
+        let mut response = ChunkedResponse::default();
+        response.extend_from_slice(&pool, b"430\r\n");
+
+        let mut prefix = SmallVec::<[u8; 128]>::new();
+        response.copy_prefix_into(64, &mut prefix);
+        assert_eq!(&prefix[..], b"430\r\n");
     }
 
     #[tokio::test]

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -3,6 +3,7 @@ use crossbeam::queue::SegQueue;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use tokio::io::AsyncWriteExt;
 use tracing::{debug, info};
 
 /// A pooled buffer that automatically returns to the pool when dropped
@@ -245,6 +246,154 @@ impl Drop for PooledBuffer {
     }
 }
 
+/// Buffered response assembled from one or more pooled capture buffers.
+///
+/// This avoids reallocating or growing a single `Vec` on the hot path when
+/// a multiline response is larger than the typical capture size.
+#[derive(Debug, Default)]
+pub struct ChunkedResponse {
+    chunks: Vec<PooledBuffer>,
+    len: usize,
+}
+
+impl ChunkedResponse {
+    /// Total buffered length across all chunks.
+    #[must_use]
+    #[inline]
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns true when no bytes are buffered.
+    #[must_use]
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Remove all buffered data, returning chunks to the pool on drop.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.chunks.clear();
+        self.len = 0;
+    }
+
+    /// Append bytes using one or more pooled capture buffers.
+    pub fn extend_from_slice(&mut self, pool: &BufferPool, mut data: &[u8]) {
+        while !data.is_empty() {
+            let need_new_chunk = self
+                .chunks
+                .last()
+                .is_none_or(|chunk| chunk.initialized() == chunk.capacity());
+
+            if need_new_chunk {
+                self.chunks.push(pool.acquire_capture_now());
+            }
+
+            let chunk = self
+                .chunks
+                .last_mut()
+                .expect("chunk just pushed or already existed");
+            let available = chunk.capacity().saturating_sub(chunk.initialized());
+            debug_assert!(available > 0, "chunk must have space after allocation");
+
+            let take = available.min(data.len());
+            chunk.extend_from_slice(&data[..take]);
+            self.len += take;
+            data = &data[take..];
+        }
+    }
+
+    /// Truncate the buffered response to the given absolute length.
+    pub fn truncate(&mut self, len: usize) {
+        assert!(len <= self.len, "truncate length exceeds buffered bytes");
+        if len == self.len {
+            return;
+        }
+
+        let mut remaining = len;
+        let mut keep_chunks = 0;
+
+        for chunk in &mut self.chunks {
+            let chunk_len = chunk.initialized();
+            if remaining >= chunk_len {
+                remaining -= chunk_len;
+                keep_chunks += 1;
+                continue;
+            }
+
+            chunk.truncate(remaining);
+            keep_chunks += 1;
+            break;
+        }
+
+        self.chunks.truncate(keep_chunks);
+        self.len = len;
+    }
+
+    /// First chunk of buffered data, if any.
+    #[must_use]
+    pub fn first_chunk(&self) -> Option<&[u8]> {
+        self.chunks.first().map(AsRef::as_ref)
+    }
+
+    /// Copy the buffered response into a contiguous `Vec<u8>`.
+    #[must_use]
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.len);
+        for chunk in &self.chunks {
+            out.extend_from_slice(chunk.as_ref());
+        }
+        out
+    }
+
+    /// Returns true if buffered bytes begin with `prefix`.
+    #[must_use]
+    pub fn starts_with(&self, prefix: &[u8]) -> bool {
+        if prefix.len() > self.len {
+            return false;
+        }
+
+        let mut remaining = prefix;
+        for chunk in &self.chunks {
+            if remaining.is_empty() {
+                return true;
+            }
+
+            let data = chunk.as_ref();
+            let take = data.len().min(remaining.len());
+            if data[..take] != remaining[..take] {
+                return false;
+            }
+            remaining = &remaining[take..];
+        }
+
+        remaining.is_empty()
+    }
+
+    /// Returns true if buffered bytes end with `suffix`.
+    #[must_use]
+    pub fn ends_with(&self, suffix: &[u8]) -> bool {
+        if suffix.len() > self.len {
+            return false;
+        }
+
+        let tail = self.to_vec();
+        tail.ends_with(suffix)
+    }
+
+    /// Write all buffered chunks to a sink in order.
+    pub async fn write_all_to<W>(&self, writer: &mut W) -> std::io::Result<()>
+    where
+        W: AsyncWriteExt + Unpin,
+    {
+        for chunk in &self.chunks {
+            writer.write_all(chunk.as_ref()).await?;
+        }
+        Ok(())
+    }
+}
+
 /// Lock-free buffer pool for reusing large I/O buffers
 /// Uses crossbeam's `SegQueue` for lock-free operations
 #[derive(Debug, Clone)]
@@ -456,8 +605,7 @@ impl BufferPool {
     /// - Callers use `AsyncRead` which writes into the buffer
     /// - They get back `n` bytes written and access only `&buf[..n]`
     /// - Stale data beyond `n` is never accessed
-    #[allow(clippy::unused_async)] // async for API consistency with acquire_capture and future pool implementations
-    pub async fn acquire(&self) -> PooledBuffer {
+    fn acquire_now(&self) -> PooledBuffer {
         let buffer = if let Some(buffer) = self.pool.pop() {
             self.pool_size.fetch_sub(1, Ordering::Relaxed);
             // Buffer from pool is already the correct size (enforced on return)
@@ -484,6 +632,11 @@ impl BufferPool {
         }
     }
 
+    #[allow(clippy::unused_async)] // async for API consistency with acquire_capture and future pool implementations
+    pub async fn acquire(&self) -> PooledBuffer {
+        self.acquire_now()
+    }
+
     /// Get a capture buffer from the capture pool
     ///
     /// Returns a `PooledBuffer` backed by a pre-faulted capture buffer.
@@ -491,8 +644,7 @@ impl BufferPool {
     ///
     /// Pages are pre-faulted to eliminate soft page faults during streaming,
     /// which profiling showed accounted for 96.75% of memmove time.
-    #[allow(clippy::unused_async)] // async for API consistency with acquire and future pool implementations
-    pub async fn acquire_capture(&self) -> PooledBuffer {
+    pub(crate) fn acquire_capture_now(&self) -> PooledBuffer {
         let buffer = if let Some(mut buffer) = self.capture_pool.pop() {
             self.capture_pool_size.fetch_sub(1, Ordering::Relaxed);
             // Clear but keep capacity (pages stay mapped)
@@ -507,7 +659,12 @@ impl BufferPool {
                 "Capture pool exhausted (allocating beyond pool size). In use: {}/{}",
                 in_use, self.max_capture_pool_size
             );
-            let mut buffer = Vec::with_capacity(self.capture_capacity);
+            let capacity = if self.capture_capacity > 0 {
+                self.capture_capacity
+            } else {
+                self.buffer_size.get()
+            };
+            let mut buffer = Vec::with_capacity(capacity);
             Self::prefault_pages(&mut buffer);
             buffer
         };
@@ -521,6 +678,11 @@ impl BufferPool {
             max_pool_size: self.max_capture_pool_size,
             reset_len: 0,
         }
+    }
+
+    #[allow(clippy::unused_async)] // async for API consistency with acquire and future pool implementations
+    pub async fn acquire_capture(&self) -> PooledBuffer {
+        self.acquire_capture_now()
     }
 }
 

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -1,10 +1,11 @@
 use crate::types::BufferSize;
+use bytes::BytesMut;
 use crossbeam::queue::SegQueue;
 use smallvec::SmallVec;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
-use tokio::io::AsyncWriteExt;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, info};
 
 /// A pooled buffer that automatically returns to the pool when dropped
@@ -21,19 +22,18 @@ use tracing::{debug, info};
 /// process(&*buffer);  // Deref returns only &buffer[..n]
 /// ```
 pub struct PooledBuffer {
-    buffer: Vec<u8>,
-    initialized: usize,
-    pool: Arc<SegQueue<Vec<u8>>>,
+    buffer: BytesMut,
+    pool: Arc<SegQueue<BytesMut>>,
     pool_size: Arc<AtomicUsize>,
     max_pool_size: usize,
     expected_capacity: usize,
-    reset_len: usize,
+    writable_len: usize,
 }
 
 impl std::fmt::Debug for PooledBuffer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PooledBuffer")
-            .field("initialized", &self.initialized)
+            .field("initialized", &self.buffer.len())
             .field("capacity", &self.buffer.capacity())
             .finish_non_exhaustive()
     }
@@ -43,24 +43,25 @@ impl PooledBuffer {
     /// Get the backing allocation capacity of the buffer.
     #[must_use]
     #[inline]
-    pub const fn capacity(&self) -> usize {
+    pub fn capacity(&self) -> usize {
         self.buffer.capacity()
     }
 
     /// Get the number of initialized bytes
     #[must_use]
     #[inline]
-    pub const fn initialized(&self) -> usize {
-        self.initialized
+    pub fn initialized(&self) -> usize {
+        self.buffer.len()
     }
 
     /// Read from an `AsyncRead` source, automatically tracking initialized bytes
     pub async fn read_from<R>(&mut self, reader: &mut R) -> std::io::Result<usize>
     where
-        R: tokio::io::AsyncReadExt + Unpin,
+        R: AsyncRead + Unpin,
     {
-        let n = reader.read(&mut self.buffer[..]).await?;
-        self.initialized = n;
+        self.buffer.clear();
+        let limit = self.buffer.capacity();
+        let n = reader.take(limit as u64).read_buf(&mut self.buffer).await?;
         Ok(n)
     }
 
@@ -73,11 +74,10 @@ impl PooledBuffer {
     /// Returns the number of NEW bytes read (not total).
     pub async fn read_more<R>(&mut self, reader: &mut R) -> std::io::Result<usize>
     where
-        R: tokio::io::AsyncReadExt + Unpin,
+        R: AsyncRead + Unpin,
     {
-        let offset = self.initialized;
-        let n = reader.read(&mut self.buffer[offset..]).await?;
-        self.initialized += n;
+        let limit = self.buffer.capacity().saturating_sub(self.buffer.len());
+        let n = reader.take(limit as u64).read_buf(&mut self.buffer).await?;
         Ok(n)
     }
 
@@ -87,22 +87,12 @@ impl PooledBuffer {
     /// Panics if `data.len()` > capacity
     #[inline]
     pub fn copy_from_slice(&mut self, data: &[u8]) {
-        if self.buffer.is_empty() {
-            assert!(
-                data.len() <= self.buffer.capacity(),
-                "data exceeds buffer capacity"
-            );
-            if self.buffer.len() < data.len() {
-                self.buffer.resize(data.len(), 0);
-            }
-        } else {
-            assert!(
-                data.len() <= self.buffer.len(),
-                "data exceeds buffer capacity"
-            );
-        }
-        self.buffer[..data.len()].copy_from_slice(data);
-        self.initialized = data.len();
+        assert!(
+            data.len() <= self.buffer.capacity(),
+            "data exceeds buffer capacity"
+        );
+        self.buffer.clear();
+        self.buffer.extend_from_slice(data);
     }
 
     /// Reset the logical contents of the buffer without changing its backing allocation.
@@ -112,7 +102,7 @@ impl PooledBuffer {
     /// stays available for reuse.
     #[inline]
     pub fn clear(&mut self) {
-        self.initialized = 0;
+        self.buffer.clear();
     }
 
     /// Shorten the logical initialized length without changing the backing allocation.
@@ -122,10 +112,10 @@ impl PooledBuffer {
     #[inline]
     pub fn truncate(&mut self, len: usize) {
         assert!(
-            len <= self.initialized,
+            len <= self.buffer.len(),
             "truncate length exceeds initialized bytes"
         );
-        self.initialized = len;
+        self.buffer.truncate(len);
     }
 
     /// Get mutable access to the full buffer capacity
@@ -148,7 +138,10 @@ impl PooledBuffer {
     #[must_use]
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        &mut self.buffer[..]
+        // `create_aligned_buffer` initializes the full writable region before
+        // clearing the logical length, so this preserves the old fixed-I/O API
+        // without making those bytes part of the initialized slice.
+        unsafe { std::slice::from_raw_parts_mut(self.buffer.as_mut_ptr(), self.writable_len) }
     }
 
     /// Append data to the buffer (accumulator mode)
@@ -171,21 +164,17 @@ impl PooledBuffer {
     /// After calling this, `.len()` (via Deref) returns the total accumulated length.
     #[inline]
     pub fn extend_from_slice(&mut self, data: &[u8]) {
-        let needed = self.initialized + data.len();
+        let needed = self.buffer.len() + data.len();
         // Warn if we need to grow beyond pre-allocated capacity (rare for typical articles)
         if needed > self.buffer.capacity() {
             tracing::warn!(
                 "Capture buffer growing: {} + {} > {} capacity (will allocate)",
-                self.initialized,
+                self.buffer.len(),
                 data.len(),
                 self.buffer.capacity()
             );
         }
-        if self.buffer.len() < needed {
-            self.buffer.resize(needed, 0);
-        }
-        self.buffer[self.initialized..needed].copy_from_slice(data);
-        self.initialized = needed;
+        self.buffer.extend_from_slice(data);
     }
 }
 
@@ -194,8 +183,7 @@ impl Deref for PooledBuffer {
 
     #[inline]
     fn deref(&self) -> &Self::Target {
-        // Immutable access only returns the initialized portion
-        &self.buffer[..self.initialized]
+        &self.buffer
     }
 }
 
@@ -204,8 +192,7 @@ impl Deref for PooledBuffer {
 impl AsRef<[u8]> for PooledBuffer {
     #[inline]
     fn as_ref(&self) -> &[u8] {
-        // Only return initialized portion
-        &self.buffer[..self.initialized]
+        &self.buffer
     }
 }
 
@@ -220,9 +207,7 @@ impl Drop for PooledBuffer {
             return;
         }
 
-        if self.buffer.len() != self.reset_len {
-            self.buffer.resize(self.reset_len, 0);
-        }
+        self.buffer.clear();
 
         // Atomically return buffer to pool if pool is not full
         let mut current_size = self.pool_size.load(Ordering::Relaxed);
@@ -432,12 +417,12 @@ impl ChunkedResponse {
 /// Uses crossbeam's `SegQueue` for lock-free operations
 #[derive(Debug, Clone)]
 pub struct BufferPool {
-    pool: Arc<SegQueue<Vec<u8>>>,
+    pool: Arc<SegQueue<BytesMut>>,
     buffer_size: BufferSize,
     max_pool_size: usize,
     pool_size: Arc<AtomicUsize>,
     // Capture buffer pool (for accumulating streaming data)
-    capture_pool: Arc<SegQueue<Vec<u8>>>,
+    capture_pool: Arc<SegQueue<BytesMut>>,
     capture_capacity: usize,
     max_capture_pool_size: usize,
     capture_pool_size: Arc<AtomicUsize>,
@@ -446,33 +431,26 @@ pub struct BufferPool {
 impl BufferPool {
     /// Create a page-aligned buffer for optimal DMA performance
     ///
-    /// Returns a raw Vec<u8> that will be wrapped in `PooledBuffer` by `acquire()`.
-    /// The buffer is NOT zero-initialized for performance.
+    /// Returns a raw `BytesMut` that will be wrapped in `PooledBuffer` by `acquire()`.
+    /// The buffer is pre-faulted, then cleared before it enters the pool.
     ///
     /// # Safety
     ///
     /// **INTERNAL USE ONLY.** This function is not exposed publicly and is only used
     /// within the buffer pool implementation where the safety contract is guaranteed.
     ///
-    /// The returned buffer contains uninitialized memory. Callers must ensure that the buffer
-    /// is only used with `AsyncRead`/`AsyncWrite` operations that fully initialize the bytes
-    /// before they are read. Only the initialized portion of the buffer (`&buf[..n]`, where `n`
-    /// is the number of bytes read or written) may be accessed. Accessing uninitialized bytes
-    /// is undefined behavior.
+    /// The returned buffer has initialized spare storage for the fixed I/O view, but a logical
+    /// length of zero. Only bytes added to the `BytesMut` logical length are exposed through the
+    /// public initialized slice APIs.
     ///
     /// The public API (`acquire()`) returns a `PooledBuffer` which is a safe wrapper that
     /// enforces this contract through the type system and usage patterns.
-    fn create_aligned_buffer(size: usize) -> Vec<u8> {
+    fn create_aligned_buffer(size: usize) -> BytesMut {
         // Align to page boundaries (4KB) for better memory performance
         let page_size = 4096;
         let aligned_size = size.div_ceil(page_size) * page_size;
 
-        // Pre-allocate with page-aligned capacity, then zero-initialize to `size`.
-        // prefault_pages then touches every page up to `capacity` (including alignment
-        // padding) to force physical page allocation upfront, eliminating page-fault
-        // latency during I/O.
-        let mut buffer = Vec::with_capacity(aligned_size);
-        buffer.resize(size, 0u8);
+        let mut buffer = BytesMut::with_capacity(aligned_size);
         Self::prefault_pages(&mut buffer);
         buffer
     }
@@ -489,8 +467,9 @@ impl BufferPool {
     /// `write_volatile` touches one byte per 4KB page to trigger the OS page fault
     /// at init time rather than during streaming I/O. Values are overwritten by
     /// actual I/O before being read.
-    fn prefault_pages(buf: &mut Vec<u8>) {
+    fn prefault_pages(buf: &mut BytesMut) {
         let cap = buf.capacity();
+        buf.resize(cap, 0);
         // SAFETY: We write within the buffer's allocated capacity.
         // Each write_volatile touches one byte per 4KB page to trigger page faults.
         // These sentinel values (1) are overwritten by real I/O data before being read.
@@ -500,6 +479,7 @@ impl BufferPool {
                 std::ptr::write_volatile(ptr.add(offset), 1);
             }
         }
+        buf.clear();
     }
 
     /// Create a new buffer pool with pre-allocated buffers
@@ -575,7 +555,7 @@ impl BufferPool {
         );
 
         for _ in 0..count {
-            let mut buffer = Vec::with_capacity(capacity);
+            let mut buffer = BytesMut::with_capacity(capacity);
             // Pre-fault all pages to map physical memory
             Self::prefault_pages(&mut buffer);
             self.capture_pool.push(buffer);
@@ -642,8 +622,9 @@ impl BufferPool {
     fn acquire_now(&self) -> PooledBuffer {
         let buffer = if let Some(buffer) = self.pool.pop() {
             self.pool_size.fetch_sub(1, Ordering::Relaxed);
-            // Buffer from pool is already the correct size (enforced on return)
-            debug_assert_eq!(buffer.len(), self.buffer_size.get());
+            // Buffer from pool is logically empty and has the expected allocation
+            // capacity (enforced on return).
+            debug_assert_eq!(buffer.len(), 0);
             buffer
         } else {
             // Create new page-aligned buffer for better DMA performance
@@ -658,11 +639,10 @@ impl BufferPool {
         PooledBuffer {
             expected_capacity: buffer.capacity(),
             buffer,
-            initialized: 0, // Start with 0 bytes safe to read
             pool: Arc::clone(&self.pool),
             pool_size: Arc::clone(&self.pool_size),
             max_pool_size: self.max_pool_size,
-            reset_len: self.buffer_size.get(),
+            writable_len: self.buffer_size.get(),
         }
     }
 
@@ -698,7 +678,7 @@ impl BufferPool {
             } else {
                 self.buffer_size.get()
             };
-            let mut buffer = Vec::with_capacity(capacity);
+            let mut buffer = BytesMut::with_capacity(capacity);
             Self::prefault_pages(&mut buffer);
             buffer
         };
@@ -706,11 +686,10 @@ impl BufferPool {
         PooledBuffer {
             expected_capacity: buffer.capacity(),
             buffer,
-            initialized: 0,
             pool: Arc::clone(&self.capture_pool),
             pool_size: Arc::clone(&self.capture_pool_size),
             max_pool_size: self.max_capture_pool_size,
-            reset_len: 0,
+            writable_len: 0,
         }
     }
 
@@ -848,7 +827,7 @@ mod tests {
 
         {
             let mut capture = pool.acquire_capture().await;
-            capture.extend_from_slice(&vec![b'C'; 9]);
+            capture.extend_from_slice(&[b'C'; 9]);
             assert!(capture.capacity() > 8);
         }
 
@@ -1162,7 +1141,7 @@ mod tests {
         let pool = BufferPool::new(BufferSize::try_new(10).unwrap(), 5);
         let mut buffer = pool.acquire().await;
 
-        let too_large = vec![0u8; 20];
+        let too_large = vec![0u8; buffer.capacity() + 1];
         buffer.copy_from_slice(&too_large); // Should panic
     }
 
@@ -1245,11 +1224,11 @@ mod tests {
         // Test that create_aligned_buffer aligns to page boundaries
         let buffer = BufferPool::create_aligned_buffer(1000);
         // Should be aligned to 4096
-        assert_eq!(buffer.len(), 1000);
+        assert_eq!(buffer.len(), 0);
         assert_eq!(buffer.capacity() % 4096, 0);
 
         let buffer2 = BufferPool::create_aligned_buffer(8192);
-        assert_eq!(buffer2.len(), 8192);
+        assert_eq!(buffer2.len(), 0);
         assert_eq!(buffer2.capacity() % 4096, 0);
     }
 }

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -10,7 +10,7 @@ pub mod health_check;
 pub mod prewarming;
 pub mod provider;
 
-pub use buffer::{BufferPool, PooledBuffer};
+pub use buffer::{BufferPool, ChunkedResponse, PooledBuffer};
 pub use connection_guard::{ConnectionGuard, salvage_with_health_check};
 pub use connection_trait::{ConnectionProvider, PoolStatus};
 pub use health_check::{HealthCheckError, HealthCheckMetrics};

--- a/src/router/backend_queue.rs
+++ b/src/router/backend_queue.rs
@@ -10,6 +10,7 @@
 //! `QueueFull` immediately rather than blocking the client session.
 
 use crossbeam::queue::SegQueue;
+use smallvec::SmallVec;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::{Notify, oneshot};
 
@@ -28,13 +29,83 @@ pub enum PipelineResponse {
         backend_id: BackendId,
     },
     /// Command failed (connection error, queue overflow, etc.)
-    Error(String),
+    Error(PipelineError),
+}
+
+/// Queue/worker failures reported back to the waiting session without heap allocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PipelineError {
+    ConnectionAcquire,
+    WriteFailed { index: usize, batch_len: usize },
+    FlushFailed,
+    ReadFailed,
+    ConnectionLost { completed: usize, batch_len: usize },
+}
+
+impl std::fmt::Display for PipelineError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConnectionAcquire => f.write_str("connection error"),
+            Self::WriteFailed { index, batch_len } => {
+                write!(f, "write failed at command {index}/{batch_len}")
+            }
+            Self::FlushFailed => f.write_str("flush failed"),
+            Self::ReadFailed => f.write_str("read error"),
+            Self::ConnectionLost {
+                completed,
+                batch_len,
+            } => write!(f, "connection lost after response {completed}/{batch_len}"),
+        }
+    }
+}
+
+/// Stack-backed queued command storage.
+#[derive(Clone, PartialEq, Eq)]
+pub struct QueuedCommand(SmallVec<[u8; 512]>);
+
+impl QueuedCommand {
+    #[must_use]
+    pub fn from_command(command: &str) -> Self {
+        Self(SmallVec::from_slice(command.as_bytes()))
+    }
+
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        std::str::from_utf8(&self.0).unwrap_or("")
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl From<&str> for QueuedCommand {
+    fn from(value: &str) -> Self {
+        Self::from_command(value)
+    }
+}
+
+impl From<String> for QueuedCommand {
+    fn from(value: String) -> Self {
+        Self(SmallVec::from_vec(value.into_bytes()))
+    }
 }
 
 /// A request queued for pipeline execution on a backend
 pub struct QueuedRequest {
     /// The full NNTP command string (including \r\n)
-    pub command: std::sync::Arc<str>,
+    pub command: QueuedCommand,
     /// Channel to send the response back to the waiting client session
     pub response_tx: oneshot::Sender<PipelineResponse>,
 }
@@ -188,7 +259,7 @@ impl BackendQueue {
 impl std::fmt::Debug for QueuedRequest {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QueuedRequest")
-            .field("command", &self.command)
+            .field("command", &self.command.as_str())
             .finish_non_exhaustive()
     }
 }
@@ -197,14 +268,13 @@ impl std::fmt::Debug for QueuedRequest {
 mod tests {
     use super::*;
     use std::sync::Arc;
-
     #[test]
     fn test_queue_enqueue_dequeue() {
         let queue = BackendQueue::new(10);
         let (tx, _rx) = oneshot::channel();
         queue
             .try_enqueue(QueuedRequest {
-                command: "ARTICLE <test@example.com>\r\n".into(),
+                command: QueuedCommand::from_command("ARTICLE <test@example.com>\r\n"),
                 response_tx: tx,
             })
             .unwrap();
@@ -218,14 +288,16 @@ mod tests {
             let (tx, _rx) = oneshot::channel();
             queue
                 .try_enqueue(QueuedRequest {
-                    command: format!("ARTICLE <test{i}@example.com>\r\n").into(),
+                    command: QueuedCommand::from_command(&format!(
+                        "ARTICLE <test{i}@example.com>\r\n"
+                    )),
                     response_tx: tx,
                 })
                 .unwrap();
         }
         let (tx, _rx) = oneshot::channel();
         let result = queue.try_enqueue(QueuedRequest {
-            command: "ARTICLE <overflow@example.com>\r\n".into(),
+            command: QueuedCommand::from_command("ARTICLE <overflow@example.com>\r\n"),
             response_tx: tx,
         });
         assert!(result.is_err());
@@ -245,7 +317,7 @@ mod tests {
             let (tx, _rx) = oneshot::channel();
             queue
                 .try_enqueue(QueuedRequest {
-                    command: format!("CMD {i}\r\n").into(),
+                    command: QueuedCommand::from_command(&format!("CMD {i}\r\n")),
                     response_tx: tx,
                 })
                 .unwrap();
@@ -282,5 +354,40 @@ mod tests {
 
         let batch = handle.await.unwrap();
         assert_eq!(batch.len(), 1);
+    }
+
+    #[test]
+    fn test_pipeline_error_display_messages() {
+        let cases = [
+            (PipelineError::ConnectionAcquire, "connection error"),
+            (
+                PipelineError::WriteFailed {
+                    index: 2,
+                    batch_len: 5,
+                },
+                "write failed at command 2/5",
+            ),
+            (PipelineError::FlushFailed, "flush failed"),
+            (PipelineError::ReadFailed, "read error"),
+            (
+                PipelineError::ConnectionLost {
+                    completed: 3,
+                    batch_len: 5,
+                },
+                "connection lost after response 3/5",
+            ),
+        ];
+
+        cases.into_iter().for_each(|(error, expected)| {
+            assert_eq!(error.to_string(), expected);
+        });
+    }
+
+    #[test]
+    fn test_queued_command_roundtrip_from_string() {
+        let command = QueuedCommand::from(String::from("STAT <test@example.com>\r\n"));
+        assert_eq!(command.as_bytes(), b"STAT <test@example.com>\r\n");
+        assert_eq!(command.as_str(), "STAT <test@example.com>\r\n");
+        assert_eq!(command.len(), 25);
     }
 }

--- a/src/router/backend_queue.rs
+++ b/src/router/backend_queue.rs
@@ -21,7 +21,7 @@ pub enum PipelineResponse {
     /// Command executed successfully; `data` is the complete response bytes
     Success {
         /// Complete response data (status line + multiline body if applicable)
-        data: bytes::Bytes,
+        data: crate::pool::PooledBuffer,
         /// Parsed status code from the response
         status_code: crate::protocol::StatusCode,
         /// Which backend handled this request

--- a/src/router/backend_queue.rs
+++ b/src/router/backend_queue.rs
@@ -21,7 +21,7 @@ pub enum PipelineResponse {
     /// Command executed successfully; `data` is the complete response bytes
     Success {
         /// Complete response data (status line + multiline body if applicable)
-        data: crate::pool::PooledBuffer,
+        data: crate::pool::ChunkedResponse,
         /// Parsed status code from the response
         status_code: crate::protocol::StatusCode,
         /// Which backend handled this request

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -3,7 +3,7 @@
 //! Handles routing article commands across backends, using `ArticleAvailability`
 //! to skip backends that have already returned 430 for a given article.
 
-use crate::router::backend_queue::{PipelineResponse, QueuedRequest};
+use crate::router::backend_queue::{PipelineResponse, QueuedCommand, QueuedRequest};
 use crate::router::{BackendSelector, CommandGuard};
 use crate::session::ClientSession;
 use crate::session::SessionError;
@@ -615,7 +615,7 @@ impl ClientSession {
 
                 let (tx, rx) = tokio::sync::oneshot::channel();
                 let request = QueuedRequest {
-                    command: std::sync::Arc::from(command),
+                    command: QueuedCommand::from_command(command),
                     response_tx: tx,
                 };
 

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -632,8 +632,7 @@ impl ClientSession {
                                 backend_id,
                             }) if status_code.as_u16() != 430 => {
                                 // Success - article found, return immediately
-                                client_write
-                                    .write_all(&data)
+                                data.write_all_to(client_write)
                                     .await
                                     .map_err(|e| SessionError::from(anyhow::Error::from(e)))?;
                                 *backend_to_client_bytes = backend_to_client_bytes.add(data.len());

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -23,8 +23,8 @@ use crate::session::precheck;
 pub(super) struct BatchPipelineState<'a> {
     pub client_to_backend_bytes: &'a mut ClientToBackendBytes,
     pub backend_to_client_bytes: &'a mut BackendToClientBytes,
-    pub leftover: &'a mut bytes::BytesMut,
-    pub chunk_data: &'a mut bytes::BytesMut,
+    pub leftover: &'a mut crate::pool::PooledBuffer,
+    pub chunk_data: &'a mut crate::pool::PooledBuffer,
 }
 
 /// Backend connection context for `process_batch_response`

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -23,8 +23,6 @@ use crate::session::precheck;
 pub(super) struct BatchPipelineState<'a> {
     pub client_to_backend_bytes: &'a mut ClientToBackendBytes,
     pub backend_to_client_bytes: &'a mut BackendToClientBytes,
-    pub leftover: &'a mut crate::pool::PooledBuffer,
-    pub chunk_data: &'a mut crate::pool::PooledBuffer,
 }
 
 /// Backend connection context for `process_batch_response`
@@ -35,6 +33,8 @@ struct BatchConnContext<'a> {
     conn: &'a mut deadpool::managed::Object<crate::pool::deadpool_connection::TcpManager>,
     backend_id: BackendId,
     buffer: &'a mut crate::pool::PooledBuffer,
+    leftover: &'a mut crate::pool::PooledBuffer,
+    chunk_data: &'a mut crate::pool::PooledBuffer,
 }
 
 /// Per-response outcome from `process_batch_response`
@@ -130,10 +130,10 @@ impl ClientSession {
 
         // Phase 2: Read and stream responses in order.
         // Buffer acquired once, reused across all responses.
-        // State buffers cleared here; they persist across batch_execute_articles calls.
+        // Scratch buffers are needed only while backend responses are being read.
         let mut buffer = self.buffer_pool.acquire().await;
-        state.leftover.clear();
-        state.chunk_data.clear();
+        let mut leftover = self.buffer_pool.acquire().await;
+        let mut chunk_data = self.buffer_pool.acquire().await;
         debug!(
             client = %self.client_addr,
             backend = ?backend_id,
@@ -147,6 +147,8 @@ impl ClientSession {
                 conn: &mut conn,
                 backend_id,
                 buffer: &mut buffer,
+                leftover: &mut leftover,
+                chunk_data: &mut chunk_data,
             };
             match self
                 .process_batch_response(batch, i, &mut bcc, client_write, &mut state)
@@ -217,15 +219,17 @@ impl ClientSession {
         let backend_id = bcc.backend_id;
         let command = batch.command(idx);
         let msg_id = crate::types::MessageId::extract_from_command_borrowed(command);
+        let leftover = &mut bcc.leftover;
+        let chunk_data = &mut bcc.chunk_data;
 
         // --- Read first chunk (from leftover or fresh read) ---
-        state.chunk_data.clear();
-        let from_leftover = !state.leftover.is_empty();
+        chunk_data.clear();
+        let from_leftover = !leftover.is_empty();
         let initial_chunk_len = if from_leftover {
-            let leftover_len = state.leftover.len();
-            let leftover_hex = crate::session::backend::format_hex_preview(state.leftover, 64);
-            state.chunk_data.extend_from_slice(state.leftover);
-            state.leftover.clear();
+            let leftover_len = leftover.len();
+            let leftover_hex = crate::session::backend::format_hex_preview(leftover, 64);
+            chunk_data.extend_from_slice(leftover);
+            leftover.clear();
             debug!(
                 client = %self.client_addr,
                 backend = ?backend_id,
@@ -234,13 +238,11 @@ impl ClientSession {
                 leftover_hex = %leftover_hex,
                 "Batch response starting from leftover bytes"
             );
-            state.chunk_data.len()
+            chunk_data.len()
         } else {
             match bcc.buffer.read_from(&mut **bcc.conn).await {
                 Ok(bytes_read) if bytes_read > 0 => {
-                    state
-                        .chunk_data
-                        .extend_from_slice(&bcc.buffer[..bytes_read]);
+                    chunk_data.extend_from_slice(&bcc.buffer[..bytes_read]);
                     bytes_read
                 }
                 Ok(_) => {
@@ -274,16 +276,14 @@ impl ClientSession {
         if initial_chunk_len < crate::protocol::MIN_RESPONSE_LENGTH {
             match bcc.buffer.read_from(&mut **bcc.conn).await {
                 Ok(bytes_read) if bytes_read > 0 => {
-                    state
-                        .chunk_data
-                        .extend_from_slice(&bcc.buffer[..bytes_read]);
+                    chunk_data.extend_from_slice(&bcc.buffer[..bytes_read]);
                 }
                 Ok(_) => {
                     warn!(
                         client = %self.client_addr,
                         backend = ?backend_id,
                         response_index = idx + 1,
-                        partial_bytes = state.chunk_data.len(),
+                        partial_bytes = chunk_data.len(),
                         "Backend EOF with partial status line, sending 430 for remaining commands"
                     );
                     // Backend dead — partial read means backend state unknown.
@@ -294,7 +294,7 @@ impl ClientSession {
                         client = %self.client_addr,
                         backend = ?backend_id,
                         response_index = idx + 1,
-                        partial_bytes = state.chunk_data.len(),
+                        partial_bytes = chunk_data.len(),
                         error = %e,
                         "Backend read error with partial status line, sending 430 for remaining commands"
                     );
@@ -304,7 +304,7 @@ impl ClientSession {
             }
         }
 
-        let chunk = &state.chunk_data[..];
+        let chunk = &chunk_data[..];
 
         // --- Validate response ---
         let validated = backend::validate_backend_response(
@@ -319,7 +319,7 @@ impl ClientSession {
         if response_code.is_430() {
             // Single-line 430: split at line boundary, saving the next response's prefix.
             if !is_multiline {
-                super::split_single_line_response(state.chunk_data, state.leftover);
+                super::split_single_line_response(chunk_data, leftover);
             }
 
             self.send_430_to_client(client_write, state.backend_to_client_bytes)
@@ -407,7 +407,7 @@ impl ClientSession {
                 client_write,
                 chunk,
                 &ctx,
-                state.leftover,
+                leftover,
             )
             .await
             {
@@ -417,8 +417,8 @@ impl ClientSession {
                         backend = ?backend_id,
                         idx = idx,
                         bytes_written = bytes,
-                        new_leftover_len = state.leftover.len(),
-                        new_leftover_hex = %crate::session::backend::format_hex_preview(state.leftover, 64),
+                        new_leftover_len = leftover.len(),
+                        new_leftover_hex = %crate::session::backend::format_hex_preview(leftover, 64),
                         "Batch multiline response streamed"
                     );
                     bytes
@@ -456,9 +456,9 @@ impl ClientSession {
             }
         } else {
             // Single-line response: split at line boundary, saving the next response's prefix.
-            super::split_single_line_response(state.chunk_data, state.leftover);
-            client_write.write_all(&state.chunk_data[..]).await?;
-            state.chunk_data.len() as u64
+            super::split_single_line_response(chunk_data, leftover);
+            client_write.write_all(&chunk_data[..]).await?;
+            chunk_data.len() as u64
         };
 
         *state.backend_to_client_bytes = state.backend_to_client_bytes.add(bytes_written as usize);

--- a/src/session/handlers/cache_operations.rs
+++ b/src/session/handlers/cache_operations.rs
@@ -166,6 +166,23 @@ impl ClientSession {
         });
     }
 
+    /// Spawn async cache upsert task with an owned buffer.
+    pub(super) fn spawn_cache_upsert_owned(
+        &self,
+        msg_id: &crate::types::MessageId<'_>,
+        buffer: Vec<u8>,
+        backend_id: crate::types::BackendId,
+        tier: u8,
+    ) {
+        let cache_clone = self.cache.clone();
+        let msg_id_owned = msg_id.to_owned();
+        tokio::spawn(async move {
+            cache_clone
+                .upsert(msg_id_owned, buffer, backend_id, tier)
+                .await;
+        });
+    }
+
     /// Get the tier for a backend, defaulting to 0 if router or backend not found.
     pub(super) fn tier_for_backend(&self, backend_id: BackendId) -> u8 {
         self.router

--- a/src/session/handlers/cache_operations.rs
+++ b/src/session/handlers/cache_operations.rs
@@ -117,8 +117,8 @@ impl ClientSession {
         // STAT: synthesize a small response (no buffer copy needed)
         // Direct serve: write directly from the Arc-backed buffer (zero-copy)
         let bytes_written = if cmd_verb.eq_ignore_ascii_case("STAT") {
-            let stat_response = format!("223 0 {}\r\n", msg_id_ref.as_str());
-            client_write.write_all(stat_response.as_bytes()).await?;
+            let stat_response = crate::cache::build_stat_response(msg_id_ref.as_str());
+            client_write.write_all(&stat_response).await?;
             stat_response.len()
         } else {
             // Validate before serving
@@ -156,21 +156,14 @@ impl ClientSession {
         backend_id: crate::types::BackendId,
         tier: u8,
     ) {
-        let cache_clone = self.cache.clone();
-        let msg_id_owned = msg_id.to_owned();
-        let buffer_owned = buffer.to_vec();
-        tokio::spawn(async move {
-            cache_clone
-                .upsert(msg_id_owned, buffer_owned, backend_id, tier)
-                .await;
-        });
+        self.spawn_cache_upsert_buffer(msg_id, buffer.to_vec().into(), backend_id, tier);
     }
 
-    /// Spawn async cache upsert task with an owned buffer.
-    pub(super) fn spawn_cache_upsert_owned(
+    /// Spawn async cache upsert task with owned hot-path storage.
+    pub(super) fn spawn_cache_upsert_buffer(
         &self,
         msg_id: &crate::types::MessageId<'_>,
-        buffer: Vec<u8>,
+        buffer: crate::cache::CacheBuffer,
         backend_id: crate::types::BackendId,
         tier: u8,
     ) {
@@ -182,7 +175,6 @@ impl ClientSession {
                 .await;
         });
     }
-
     /// Get the tier for a backend, defaulting to 0 if router or backend not found.
     pub(super) fn tier_for_backend(&self, backend_id: BackendId) -> u8 {
         self.router

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -50,6 +50,22 @@ struct ResponseStreamParams<'a> {
     first_chunk: &'a [u8],
 }
 
+/// Once multiline streaming has started, any backend-side failure means the client may
+/// already have received a partial response. Retrying on another backend would splice a
+/// second response onto that partial stream, corrupting the protocol.
+const fn must_close_client_after_streaming_error(
+    error: &StreamingError,
+    is_multiline: bool,
+) -> bool {
+    is_multiline
+        && matches!(
+            error,
+            StreamingError::BackendEof { .. }
+                | StreamingError::BackendDirty(_)
+                | StreamingError::Io(_)
+        )
+}
+
 impl ClientSession {
     /// Try executing command on next available backend
     ///
@@ -198,15 +214,10 @@ impl ClientSession {
                     // Client disconnect — backend was cleanly drained. Return to pool.
                     let _ = conn.release();
                 }
-                // BackendEof and BackendDirty mean Phase 1 already wrote the status line +
-                // partial body to the client. Retrying on the next backend would concatenate
-                // a second full article onto the partial first one, corrupting the stream.
-                // Signal ClientDisconnect so the session ends cleanly; nzbget/sabnzbd will
-                // retry the segment on their end.
-                if matches!(
-                    e,
-                    StreamingError::BackendEof { .. } | StreamingError::BackendDirty(_)
-                ) {
+                // Once multiline streaming starts, backend-side errors mean the client may
+                // already have a partial article. Retrying another backend would corrupt the
+                // stream, so close the client session and let the downloader retry cleanly.
+                if must_close_client_after_streaming_error(&e, cmd_response.is_multiline) {
                     warn!(
                         client = %self.client_addr,
                         backend = backend_id.as_index(),
@@ -485,5 +496,32 @@ impl ClientSession {
         self.metrics.user_bytes_sent(self.username(), cmd_bytes);
         self.metrics
             .user_bytes_received(self.username(), resp_bytes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::must_close_client_after_streaming_error;
+    use crate::session::streaming::StreamingError;
+
+    #[test]
+    fn multiline_backend_io_error_closes_client() {
+        let err = StreamingError::Io(anyhow::anyhow!("backend read failed mid-stream"));
+        assert!(must_close_client_after_streaming_error(&err, true));
+    }
+
+    #[test]
+    fn single_line_io_error_does_not_trigger_partial_stream_protection() {
+        let err = StreamingError::Io(anyhow::anyhow!("single-line client write failure"));
+        assert!(!must_close_client_after_streaming_error(&err, false));
+    }
+
+    #[test]
+    fn client_disconnect_never_uses_partial_stream_protection() {
+        let err = StreamingError::ClientDisconnect(std::io::Error::new(
+            std::io::ErrorKind::BrokenPipe,
+            "broken pipe",
+        ));
+        assert!(!must_close_client_after_streaming_error(&err, true));
     }
 }

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -9,7 +9,7 @@ use crate::session::retry::retry_once;
 use crate::session::routing::{
     CacheAction, MetricsAction, determine_cache_action, determine_metrics_action,
 };
-use crate::session::streaming::{StreamingError, classify_client_write_err};
+use crate::session::streaming::StreamingError;
 use crate::session::{ClientSession, backend, streaming};
 use crate::types::{BackendId, BackendToClientBytes, ClientToBackendBytes};
 use anyhow::Result;
@@ -48,6 +48,15 @@ struct ResponseStreamParams<'a> {
     response_code: &'a crate::protocol::NntpResponse,
     is_multiline: bool,
     first_chunk: &'a [u8],
+}
+
+/// Any client write failure after the full backend response is already buffered is terminal.
+///
+/// The backend connection is already clean at this point, but the client may have received a
+/// partial prefix of the response. Retrying another backend on the same client socket would
+/// splice responses together and corrupt NNTP framing.
+fn classify_buffered_response_write_err(e: std::io::Error) -> StreamingError {
+    StreamingError::ClientDisconnect(e)
 }
 
 impl ClientSession {
@@ -195,8 +204,20 @@ impl ClientSession {
                     self.metrics.record_error(backend_id);
                     self.metrics.user_error(self.username());
                 } else {
-                    // Client disconnect — backend was cleanly drained. Return to pool.
-                    let _ = conn.release();
+                    // Client disconnect after a fully buffered response keeps the backend
+                    // clean, but unexpected trailing bytes still make this pooled borrow
+                    // unsafe to reuse across sessions.
+                    if conn.has_leftover() {
+                        warn!(
+                            client = %self.client_addr,
+                            backend = backend_id.as_index(),
+                            command = %command.trim(),
+                            leftover_bytes = conn.leftover_len(),
+                            "Buffered direct-path response ended with trailing backend bytes; retiring connection"
+                        );
+                    } else {
+                        let _ = conn.release();
+                    }
                 }
                 // SessionError::from(StreamingError) preserves ClientDisconnect signal.
                 return Err(SessionError::from(e));
@@ -220,7 +241,17 @@ impl ClientSession {
 
         // Explicitly complete the guard on the success path
         guard.complete();
-        let _ = conn.release(); // streaming completed; connection healthy, return to pool
+        if conn.has_leftover() {
+            warn!(
+                client = %self.client_addr,
+                backend = backend_id.as_index(),
+                command = %command.trim(),
+                leftover_bytes = conn.leftover_len(),
+                "Direct per-command response left trailing backend bytes; retiring connection"
+            );
+        } else {
+            let _ = conn.release(); // streaming completed; connection healthy, return to pool
+        }
 
         Ok(BackendAttemptResult::Success {
             backend_id,
@@ -330,7 +361,7 @@ impl ClientSession {
                 client_write
                     .write_all(&captured)
                     .await
-                    .map_err(classify_client_write_err)?;
+                    .map_err(classify_buffered_response_write_err)?;
                 if let Some(msg_id_ref) = params.msg_id {
                     debug!(
                         "Client {} caching full article for {} ({} bytes captured)",
@@ -349,7 +380,7 @@ impl ClientSession {
                 client_write
                     .write_all(&captured)
                     .await
-                    .map_err(classify_client_write_err)?;
+                    .map_err(classify_buffered_response_write_err)?;
 
                 // Extract first status line (~30-80 bytes) instead of copying
                 // full response. The cache only needs the status
@@ -368,7 +399,7 @@ impl ClientSession {
                 client_write
                     .write_all(&captured)
                     .await
-                    .map_err(classify_client_write_err)?;
+                    .map_err(classify_buffered_response_write_err)?;
                 Ok(captured.len() as u64)
             }
             (false, CacheAction::TrackStat) => {
@@ -377,7 +408,7 @@ impl ClientSession {
                 client_write
                     .write_all(params.first_chunk)
                     .await
-                    .map_err(classify_client_write_err)?;
+                    .map_err(classify_buffered_response_write_err)?;
                 self.maybe_cache_upsert(params.msg_id, b"223\r\n", ctx.backend_id);
                 Ok(params.first_chunk.len() as u64)
             }
@@ -387,7 +418,7 @@ impl ClientSession {
                 client_write
                     .write_all(params.first_chunk)
                     .await
-                    .map_err(classify_client_write_err)?;
+                    .map_err(classify_buffered_response_write_err)?;
                 Ok(params.first_chunk.len() as u64)
             }
         }
@@ -462,5 +493,30 @@ impl ClientSession {
         self.metrics.user_bytes_sent(self.username(), cmd_bytes);
         self.metrics
             .user_bytes_received(self.username(), resp_bytes);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::classify_buffered_response_write_err;
+
+    #[test]
+    fn buffered_response_timeout_is_terminal_client_disconnect() {
+        let err = std::io::Error::new(std::io::ErrorKind::TimedOut, "timed out");
+        let classified = classify_buffered_response_write_err(err);
+        assert!(matches!(
+            classified,
+            crate::session::streaming::StreamingError::ClientDisconnect(_)
+        ));
+    }
+
+    #[test]
+    fn buffered_response_abort_is_terminal_client_disconnect() {
+        let err = std::io::Error::new(std::io::ErrorKind::ConnectionAborted, "aborted");
+        let classified = classify_buffered_response_write_err(err);
+        assert!(matches!(
+            classified,
+            crate::session::streaming::StreamingError::ClientDisconnect(_)
+        ));
     }
 }

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -375,33 +375,28 @@ impl ClientSession {
                 Ok(captured_len as u64)
             }
             (true, CacheAction::TrackAvailability) => {
-                let captured =
-                    streaming::buffer_multiline_response(pooled_conn, params.first_chunk, ctx)
-                        .await?;
-                captured
-                    .write_all_to(client_write)
-                    .await
-                    .map_err(classify_buffered_response_write_err)?;
-
-                // Extract first status line (~30-80 bytes) instead of copying
-                // full response. The cache only needs the status
-                // code to build an availability stub.
-                let stub = crate::cache::extract_chunked_status_line(&captured);
+                // Availability-only mode should not buffer the article body.
+                // Keep first-byte latency and memory bounded by streaming directly,
+                // then cache only the status-line stub after the terminator is seen.
+                let stub = crate::cache::extract_status_line(params.first_chunk);
+                let bytes = streaming::stream_multiline_response(
+                    &mut **pooled_conn,
+                    client_write,
+                    params.first_chunk,
+                    ctx,
+                )
+                .await?;
                 self.maybe_cache_upsert_buffer(params.msg_id, stub.into(), ctx.backend_id);
-                Ok(captured.len() as u64)
+                Ok(bytes)
             }
             (true, _) => {
-                // Multiline responses are fully buffered before any client write in
-                // per-command mode so the full terminator-validated response is known
-                // before forwarding.
-                let captured =
-                    streaming::buffer_multiline_response(pooled_conn, params.first_chunk, ctx)
-                        .await?;
-                captured
-                    .write_all_to(client_write)
-                    .await
-                    .map_err(classify_buffered_response_write_err)?;
-                Ok(captured.len() as u64)
+                streaming::stream_multiline_response(
+                    &mut **pooled_conn,
+                    client_write,
+                    params.first_chunk,
+                    ctx,
+                )
+                .await
             }
             (false, CacheAction::TrackStat) => {
                 // Single-line: backend already has complete response in first_chunk,

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -358,8 +358,8 @@ impl ClientSession {
                 let captured =
                     streaming::buffer_multiline_response(pooled_conn, params.first_chunk, ctx)
                         .await?;
-                client_write
-                    .write_all(&captured)
+                captured
+                    .write_all_to(client_write)
                     .await
                     .map_err(classify_buffered_response_write_err)?;
                 if let Some(msg_id_ref) = params.msg_id {
@@ -370,22 +370,22 @@ impl ClientSession {
                         captured.len()
                     );
                 }
-                self.maybe_cache_upsert(params.msg_id, &captured, ctx.backend_id);
+                self.maybe_cache_upsert_owned(params.msg_id, captured.to_vec(), ctx.backend_id);
                 Ok(captured.len() as u64)
             }
             (true, CacheAction::TrackAvailability) => {
                 let captured =
                     streaming::buffer_multiline_response(pooled_conn, params.first_chunk, ctx)
                         .await?;
-                client_write
-                    .write_all(&captured)
+                captured
+                    .write_all_to(client_write)
                     .await
                     .map_err(classify_buffered_response_write_err)?;
 
                 // Extract first status line (~30-80 bytes) instead of copying
                 // full response. The cache only needs the status
                 // code to build an availability stub.
-                let stub = crate::cache::extract_status_line(&captured);
+                let stub = crate::cache::extract_status_line(captured.first_chunk().unwrap_or(&[]));
                 self.maybe_cache_upsert(params.msg_id, &stub, ctx.backend_id);
                 Ok(captured.len() as u64)
             }
@@ -396,8 +396,8 @@ impl ClientSession {
                 let captured =
                     streaming::buffer_multiline_response(pooled_conn, params.first_chunk, ctx)
                         .await?;
-                client_write
-                    .write_all(&captured)
+                captured
+                    .write_all_to(client_write)
                     .await
                     .map_err(classify_buffered_response_write_err)?;
                 Ok(captured.len() as u64)
@@ -462,6 +462,19 @@ impl ClientSession {
         if let Some(msg_id_ref) = msg_id {
             let tier = self.tier_for_backend(backend_id);
             self.spawn_cache_upsert(msg_id_ref, data, backend_id, tier);
+        }
+    }
+
+    #[inline]
+    fn maybe_cache_upsert_owned(
+        &self,
+        msg_id: Option<&crate::types::MessageId<'_>>,
+        data: Vec<u8>,
+        backend_id: BackendId,
+    ) {
+        if let Some(msg_id_ref) = msg_id {
+            let tier = self.tier_for_backend(backend_id);
+            self.spawn_cache_upsert_owned(msg_id_ref, data, backend_id, tier);
         }
     }
 

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -50,22 +50,6 @@ struct ResponseStreamParams<'a> {
     first_chunk: &'a [u8],
 }
 
-/// Once multiline streaming has started, any backend-side failure means the client may
-/// already have received a partial response. Retrying on another backend would splice a
-/// second response onto that partial stream, corrupting the protocol.
-const fn must_close_client_after_streaming_error(
-    error: &StreamingError,
-    is_multiline: bool,
-) -> bool {
-    is_multiline
-        && matches!(
-            error,
-            StreamingError::BackendEof { .. }
-                | StreamingError::BackendDirty(_)
-                | StreamingError::Io(_)
-        )
-}
-
 impl ClientSession {
     /// Try executing command on next available backend
     ///
@@ -214,22 +198,6 @@ impl ClientSession {
                     // Client disconnect — backend was cleanly drained. Return to pool.
                     let _ = conn.release();
                 }
-                // Once multiline streaming starts, backend-side errors mean the client may
-                // already have a partial article. Retrying another backend would corrupt the
-                // stream, so close the client session and let the downloader retry cleanly.
-                if must_close_client_after_streaming_error(&e, cmd_response.is_multiline) {
-                    warn!(
-                        client = %self.client_addr,
-                        backend = backend_id.as_index(),
-                        command = %command.trim(),
-                        "Backend died mid-stream after partial data sent to client; \
-                         closing client connection to prevent protocol corruption"
-                    );
-                    return Err(SessionError::ClientDisconnect(std::io::Error::new(
-                        std::io::ErrorKind::BrokenPipe,
-                        "backend closed mid-stream; partial article already sent",
-                    )));
-                }
                 // SessionError::from(StreamingError) preserves ClientDisconnect signal.
                 return Err(SessionError::from(e));
             }
@@ -356,16 +324,16 @@ impl ClientSession {
 
         match (params.is_multiline, cache_action) {
             (true, CacheAction::CaptureArticle) => {
-                let mut captured = self.buffer_pool.acquire_capture().await;
-                let bytes = streaming::stream_and_capture_multiline_response(
+                let captured = streaming::buffer_multiline_response(
                     &mut **pooled_conn,
-                    client_write,
                     params.first_chunk,
                     ctx,
-                    &mut captured,
                 )
                 .await?;
-
+                client_write
+                    .write_all(&captured)
+                    .await
+                    .map_err(classify_client_write_err)?;
                 if let Some(msg_id_ref) = params.msg_id {
                     debug!(
                         "Client {} caching full article for {} ({} bytes captured)",
@@ -375,35 +343,42 @@ impl ClientSession {
                     );
                 }
                 self.maybe_cache_upsert(params.msg_id, &captured, ctx.backend_id);
-                Ok(bytes)
+                Ok(captured.len() as u64)
             }
             (true, CacheAction::TrackAvailability) => {
-                let bytes = streaming::stream_multiline_response(
+                let captured = streaming::buffer_multiline_response(
                     &mut **pooled_conn,
-                    client_write,
                     params.first_chunk,
                     ctx,
                 )
                 .await?;
+                client_write
+                    .write_all(&captured)
+                    .await
+                    .map_err(classify_client_write_err)?;
 
                 // Extract first status line (~30-80 bytes) instead of copying
-                // full first_chunk (8-64KB). The cache only needs the status
+                // full response. The cache only needs the status
                 // code to build an availability stub.
-                // SmallVec keeps small status lines on stack, avoiding heap allocation
-                // until the spawn boundary where .to_vec() happens inside spawn_cache_upsert.
-                let stub = crate::cache::extract_status_line(params.first_chunk);
+                let stub = crate::cache::extract_status_line(&captured);
                 self.maybe_cache_upsert(params.msg_id, &stub, ctx.backend_id);
-                Ok(bytes)
+                Ok(captured.len() as u64)
             }
             (true, _) => {
-                // Multiline but no caching
-                streaming::stream_multiline_response(
+                // Multiline responses are fully buffered before any client write in
+                // per-command mode so the full terminator-validated response is known
+                // before forwarding.
+                let captured = streaming::buffer_multiline_response(
                     &mut **pooled_conn,
-                    client_write,
                     params.first_chunk,
                     ctx,
                 )
-                .await
+                .await?;
+                client_write
+                    .write_all(&captured)
+                    .await
+                    .map_err(classify_client_write_err)?;
+                Ok(captured.len() as u64)
             }
             (false, CacheAction::TrackStat) => {
                 // Single-line: backend already has complete response in first_chunk,
@@ -496,32 +471,5 @@ impl ClientSession {
         self.metrics.user_bytes_sent(self.username(), cmd_bytes);
         self.metrics
             .user_bytes_received(self.username(), resp_bytes);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::must_close_client_after_streaming_error;
-    use crate::session::streaming::StreamingError;
-
-    #[test]
-    fn multiline_backend_io_error_closes_client() {
-        let err = StreamingError::Io(anyhow::anyhow!("backend read failed mid-stream"));
-        assert!(must_close_client_after_streaming_error(&err, true));
-    }
-
-    #[test]
-    fn single_line_io_error_does_not_trigger_partial_stream_protection() {
-        let err = StreamingError::Io(anyhow::anyhow!("single-line client write failure"));
-        assert!(!must_close_client_after_streaming_error(&err, false));
-    }
-
-    #[test]
-    fn client_disconnect_never_uses_partial_stream_protection() {
-        let err = StreamingError::ClientDisconnect(std::io::Error::new(
-            std::io::ErrorKind::BrokenPipe,
-            "broken pipe",
-        ));
-        assert!(!must_close_client_after_streaming_error(&err, true));
     }
 }

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -370,8 +370,9 @@ impl ClientSession {
                         captured.len()
                     );
                 }
-                self.maybe_cache_upsert_owned(params.msg_id, captured.to_vec(), ctx.backend_id);
-                Ok(captured.len() as u64)
+                let captured_len = captured.len();
+                self.maybe_cache_upsert_buffer(params.msg_id, captured.into(), ctx.backend_id);
+                Ok(captured_len as u64)
             }
             (true, CacheAction::TrackAvailability) => {
                 let captured =
@@ -385,8 +386,8 @@ impl ClientSession {
                 // Extract first status line (~30-80 bytes) instead of copying
                 // full response. The cache only needs the status
                 // code to build an availability stub.
-                let stub = crate::cache::extract_status_line(captured.first_chunk().unwrap_or(&[]));
-                self.maybe_cache_upsert(params.msg_id, &stub, ctx.backend_id);
+                let stub = crate::cache::extract_chunked_status_line(&captured);
+                self.maybe_cache_upsert_buffer(params.msg_id, stub.into(), ctx.backend_id);
                 Ok(captured.len() as u64)
             }
             (true, _) => {
@@ -464,17 +465,16 @@ impl ClientSession {
             self.spawn_cache_upsert(msg_id_ref, data, backend_id, tier);
         }
     }
-
     #[inline]
-    fn maybe_cache_upsert_owned(
+    fn maybe_cache_upsert_buffer(
         &self,
         msg_id: Option<&crate::types::MessageId<'_>>,
-        data: Vec<u8>,
+        data: crate::cache::CacheBuffer,
         backend_id: BackendId,
     ) {
         if let Some(msg_id_ref) = msg_id {
             let tier = self.tier_for_backend(backend_id);
-            self.spawn_cache_upsert_owned(msg_id_ref, data, backend_id, tier);
+            self.spawn_cache_upsert_buffer(msg_id_ref, data, backend_id, tier);
         }
     }
 

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -324,12 +324,9 @@ impl ClientSession {
 
         match (params.is_multiline, cache_action) {
             (true, CacheAction::CaptureArticle) => {
-                let captured = streaming::buffer_multiline_response(
-                    &mut **pooled_conn,
-                    params.first_chunk,
-                    ctx,
-                )
-                .await?;
+                let captured =
+                    streaming::buffer_multiline_response(pooled_conn, params.first_chunk, ctx)
+                        .await?;
                 client_write
                     .write_all(&captured)
                     .await
@@ -346,12 +343,9 @@ impl ClientSession {
                 Ok(captured.len() as u64)
             }
             (true, CacheAction::TrackAvailability) => {
-                let captured = streaming::buffer_multiline_response(
-                    &mut **pooled_conn,
-                    params.first_chunk,
-                    ctx,
-                )
-                .await?;
+                let captured =
+                    streaming::buffer_multiline_response(pooled_conn, params.first_chunk, ctx)
+                        .await?;
                 client_write
                     .write_all(&captured)
                     .await
@@ -368,12 +362,9 @@ impl ClientSession {
                 // Multiline responses are fully buffered before any client write in
                 // per-command mode so the full terminator-validated response is known
                 // before forwarding.
-                let captured = streaming::buffer_multiline_response(
-                    &mut **pooled_conn,
-                    params.first_chunk,
-                    ctx,
-                )
-                .await?;
+                let captured =
+                    streaming::buffer_multiline_response(pooled_conn, params.first_chunk, ctx)
+                        .await?;
                 client_write
                     .write_all(&captured)
                     .await

--- a/src/session/handlers/mod.rs
+++ b/src/session/handlers/mod.rs
@@ -25,8 +25,8 @@ mod article_retry;
 ///
 /// [`TailBuffer`]: crate::session::streaming::tail_buffer::TailBuffer
 pub(super) fn split_single_line_response(
-    response: &mut bytes::BytesMut,
-    leftover: &mut bytes::BytesMut,
+    response: &mut crate::pool::PooledBuffer,
+    leftover: &mut crate::pool::PooledBuffer,
 ) {
     if let Some(pos) = memchr::memchr(b'\n', response) {
         let end = pos + 1;

--- a/src/session/handlers/per_command.rs
+++ b/src/session/handlers/per_command.rs
@@ -300,10 +300,6 @@ impl ClientSession {
         let mut batch_buf = String::with_capacity(512 * 4); // ~2KB for typical 4-command batch
         let mut batch_offsets: smallvec::SmallVec<[usize; 4]> = smallvec::SmallVec::new();
 
-        // Pipelining buffers reused across batch_execute_articles calls
-        let mut batch_leftover = self.buffer_pool.acquire_capture().await;
-        let mut batch_chunk_data = self.buffer_pool.acquire_capture().await;
-
         // Process commands in batches (single commands fall through with zero overhead)
         'command_batch_loop: loop {
             let batch = match self
@@ -381,8 +377,6 @@ impl ClientSession {
                             crate::session::handlers::article_retry::BatchPipelineState {
                                 client_to_backend_bytes: &mut client_to_backend_bytes,
                                 backend_to_client_bytes: &mut backend_to_client_bytes,
-                                leftover: &mut batch_leftover,
-                                chunk_data: &mut batch_chunk_data,
                             },
                         )
                         .await

--- a/src/session/handlers/per_command.rs
+++ b/src/session/handlers/per_command.rs
@@ -301,8 +301,8 @@ impl ClientSession {
         let mut batch_offsets: smallvec::SmallVec<[usize; 4]> = smallvec::SmallVec::new();
 
         // Pipelining buffers reused across batch_execute_articles calls
-        let mut batch_leftover = self.buffer_pool.acquire().await;
-        let mut batch_chunk_data = self.buffer_pool.acquire().await;
+        let mut batch_leftover = self.buffer_pool.acquire_capture().await;
+        let mut batch_chunk_data = self.buffer_pool.acquire_capture().await;
 
         // Process commands in batches (single commands fall through with zero overhead)
         'command_batch_loop: loop {

--- a/src/session/handlers/per_command.rs
+++ b/src/session/handlers/per_command.rs
@@ -301,8 +301,8 @@ impl ClientSession {
         let mut batch_offsets: smallvec::SmallVec<[usize; 4]> = smallvec::SmallVec::new();
 
         // Pipelining buffers reused across batch_execute_articles calls
-        let mut batch_leftover = bytes::BytesMut::new();
-        let mut batch_chunk_data = bytes::BytesMut::new();
+        let mut batch_leftover = self.buffer_pool.acquire().await;
+        let mut batch_chunk_data = self.buffer_pool.acquire().await;
 
         // Process commands in batches (single commands fall through with zero overhead)
         'command_batch_loop: loop {

--- a/src/session/handlers/pipeline_worker.rs
+++ b/src/session/handlers/pipeline_worker.rs
@@ -172,7 +172,8 @@ async fn execute_pipeline_batch(
         .await
         .map_err(crate::session::streaming::StreamingError::into_anyhow)
         {
-            Ok((data, status_code)) => {
+            Ok(status_code) => {
+                let data = std::mem::replace(result_buf, buffer_pool.acquire_capture().await);
                 metrics.record_command(backend_id);
                 let data_len = data.len();
                 metrics.record_backend_to_client_bytes_for(backend_id, data_len as u64);
@@ -240,7 +241,7 @@ async fn execute_pipeline_batch(
 
 /// Read a complete NNTP response (status line + multiline body if applicable).
 ///
-/// Returns the full response as `Bytes` and the parsed status code.
+/// Fills `result_buf` with the full response bytes and returns the parsed status code.
 ///
 /// `result_buf` is cleared and reused for each response to avoid per-response allocations.
 #[cfg(test)]
@@ -248,7 +249,7 @@ async fn read_full_response(
     buffer: &mut crate::pool::PooledBuffer,
     conn: &mut crate::stream::ConnectionStream,
     result_buf: &mut crate::pool::PooledBuffer,
-) -> Result<(bytes::Bytes, crate::protocol::StatusCode)> {
+) -> Result<crate::protocol::StatusCode> {
     crate::session::streaming::read_full_response(
         buffer,
         conn,
@@ -401,12 +402,12 @@ mod tests {
 
         let mut conn = mock_backend_conn(b"430 No such article\r\n").await;
 
-        let (data, status) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+        let status = read_full_response(&mut buffer, &mut conn, &mut result_buf)
             .await
             .expect("should parse single-line response");
 
         assert_eq!(status.as_u16(), 430);
-        assert_eq!(&data[..], b"430 No such article\r\n");
+        assert_eq!(&result_buf[..], b"430 No such article\r\n");
         assert!(!conn.has_leftover());
     }
 
@@ -419,12 +420,12 @@ mod tests {
         let response = b"220 0 <msg@id> article\r\nSubject: test\r\n\r\nBody line\r\n.\r\n";
         let mut conn = mock_backend_conn(response).await;
 
-        let (data, status) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+        let status = read_full_response(&mut buffer, &mut conn, &mut result_buf)
             .await
             .expect("should parse multiline response");
 
         assert_eq!(status.as_u16(), 220);
-        assert_eq!(&data[..], &response[..]);
+        assert_eq!(&result_buf[..], &response[..]);
         assert!(!conn.has_leftover());
     }
 
@@ -440,13 +441,13 @@ mod tests {
 
         let mut conn = mock_backend_conn_chunked(vec![chunk1, chunk2]).await;
 
-        let (data, status) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+        let status = read_full_response(&mut buffer, &mut conn, &mut result_buf)
             .await
             .expect("should detect terminator across chunks");
 
         assert_eq!(status.as_u16(), 220);
         assert!(
-            data.ends_with(b"\r\n.\r\n"),
+            result_buf.ends_with(b"\r\n.\r\n"),
             "response should end with terminator"
         );
         assert!(!conn.has_leftover());
@@ -463,24 +464,24 @@ mod tests {
         let mut conn = mock_backend_conn(packed).await;
 
         // First read should get the multiline response and save leftover
-        let (data1, status1) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+        let status1 = read_full_response(&mut buffer, &mut conn, &mut result_buf)
             .await
             .expect("should parse first response");
 
         assert_eq!(status1.as_u16(), 220);
-        assert!(data1.ends_with(b"\r\n.\r\n"));
+        assert!(result_buf.ends_with(b"\r\n.\r\n"));
         assert!(
             conn.has_leftover(),
             "should have leftover from second response"
         );
 
         // Second read should consume leftover and return the 430
-        let (data2, status2) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+        let status2 = read_full_response(&mut buffer, &mut conn, &mut result_buf)
             .await
             .expect("should parse second response from leftover");
 
         assert_eq!(status2.as_u16(), 430);
-        assert_eq!(&data2[..], b"430 No such article\r\n");
+        assert_eq!(&result_buf[..], b"430 No such article\r\n");
     }
 
     #[tokio::test]
@@ -524,12 +525,12 @@ mod tests {
         // Leftover is only 2 bytes — too short to validate, triggers H5 additional read
         conn.stash_leftover(b"43").unwrap();
 
-        let (data, status) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+        let status = read_full_response(&mut buffer, &mut conn, &mut result_buf)
             .await
             .expect("short leftover + read should produce valid response");
 
         assert_eq!(status.as_u16(), 430);
-        assert!(data.starts_with(b"430"));
+        assert!(result_buf.starts_with(b"430"));
     }
 
     #[tokio::test]
@@ -891,11 +892,11 @@ mod tests {
                 let mut conn = mock_backend_conn(&wire).await;
 
                 for (idx, expected) in responses.iter().enumerate() {
-                    let (data, status) = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+                    let status = read_full_response(&mut buffer, &mut conn, &mut result_buf)
                         .await
                         .expect("packed single-line response should parse");
 
-                    prop_assert_eq!(&data[..], expected.as_slice());
+                    prop_assert_eq!(&result_buf[..], expected.as_slice());
                     prop_assert_eq!(status.as_u16(), codes[idx]);
                 }
 

--- a/src/session/handlers/pipeline_worker.rs
+++ b/src/session/handlers/pipeline_worker.rs
@@ -54,7 +54,7 @@ pub async fn backend_pipeline_worker(
     );
 
     // Hoist buffers to worker lifetime (reused across batches)
-    let mut result_buf = buffer_pool.acquire_capture().await;
+    let mut result_buf = crate::pool::ChunkedResponse::default();
     let mut batch = Vec::with_capacity(config.batch_size);
 
     loop {
@@ -123,7 +123,7 @@ async fn execute_pipeline_batch(
     mut batch: Vec<QueuedRequest>,
     metrics: &MetricsCollector,
     buffer_pool: &BufferPool,
-    result_buf: &mut crate::pool::PooledBuffer,
+    result_buf: &mut crate::pool::ChunkedResponse,
 ) -> (bool, Vec<QueuedRequest>) {
     let batch_len = batch.len();
 
@@ -167,13 +167,14 @@ async fn execute_pipeline_batch(
             &mut buffer,
             conn,
             result_buf,
+            buffer_pool,
             backend_id,
         )
         .await
         .map_err(crate::session::streaming::StreamingError::into_anyhow)
         {
             Ok(status_code) => {
-                let data = std::mem::replace(result_buf, buffer_pool.acquire_capture().await);
+                let data = std::mem::take(result_buf);
                 metrics.record_command(backend_id);
                 let data_len = data.len();
                 metrics.record_backend_to_client_bytes_for(backend_id, data_len as u64);
@@ -248,12 +249,14 @@ async fn execute_pipeline_batch(
 async fn read_full_response(
     buffer: &mut crate::pool::PooledBuffer,
     conn: &mut crate::stream::ConnectionStream,
-    result_buf: &mut crate::pool::PooledBuffer,
+    result_buf: &mut crate::pool::ChunkedResponse,
+    pool: &BufferPool,
 ) -> Result<crate::protocol::StatusCode> {
     crate::session::streaming::read_full_response(
         buffer,
         conn,
         result_buf,
+        pool,
         BackendId::from_index(0),
     )
     .await
@@ -373,7 +376,7 @@ mod tests {
         let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
         let mut conn = ConnectionStream::plain(stream);
 
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
         let (success, _batch) = execute_pipeline_batch(
             backend_id,
             &mut conn,
@@ -398,16 +401,16 @@ mod tests {
     async fn test_read_full_response_single_line() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         let mut conn = mock_backend_conn(b"430 No such article\r\n").await;
 
-        let status = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+        let status = read_full_response(&mut buffer, &mut conn, &mut result_buf, &pool)
             .await
             .expect("should parse single-line response");
 
         assert_eq!(status.as_u16(), 430);
-        assert_eq!(&result_buf[..], b"430 No such article\r\n");
+        assert_eq!(result_buf.to_vec(), b"430 No such article\r\n");
         assert!(!conn.has_leftover());
     }
 
@@ -415,17 +418,17 @@ mod tests {
     async fn test_read_full_response_multiline() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         let response = b"220 0 <msg@id> article\r\nSubject: test\r\n\r\nBody line\r\n.\r\n";
         let mut conn = mock_backend_conn(response).await;
 
-        let status = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+        let status = read_full_response(&mut buffer, &mut conn, &mut result_buf, &pool)
             .await
             .expect("should parse multiline response");
 
         assert_eq!(status.as_u16(), 220);
-        assert_eq!(&result_buf[..], &response[..]);
+        assert_eq!(result_buf.to_vec(), response);
         assert!(!conn.has_leftover());
     }
 
@@ -433,7 +436,7 @@ mod tests {
     async fn test_read_full_response_multiline_across_chunks() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Split the terminator \r\n.\r\n across two chunks
         let chunk1 = b"220 0 <msg@id> article\r\nBody\r\n.".to_vec();
@@ -441,7 +444,7 @@ mod tests {
 
         let mut conn = mock_backend_conn_chunked(vec![chunk1, chunk2]).await;
 
-        let status = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+        let status = read_full_response(&mut buffer, &mut conn, &mut result_buf, &pool)
             .await
             .expect("should detect terminator across chunks");
 
@@ -457,14 +460,14 @@ mod tests {
     async fn test_read_full_response_with_leftover() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Two responses packed together
         let packed = b"220 0 <a@b> article\r\nBody\r\n.\r\n430 No such article\r\n";
         let mut conn = mock_backend_conn(packed).await;
 
         // First read should get the multiline response and save leftover
-        let status1 = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+        let status1 = read_full_response(&mut buffer, &mut conn, &mut result_buf, &pool)
             .await
             .expect("should parse first response");
 
@@ -476,24 +479,24 @@ mod tests {
         );
 
         // Second read should consume leftover and return the 430
-        let status2 = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+        let status2 = read_full_response(&mut buffer, &mut conn, &mut result_buf, &pool)
             .await
             .expect("should parse second response from leftover");
 
         assert_eq!(status2.as_u16(), 430);
-        assert_eq!(&result_buf[..], b"430 No such article\r\n");
+        assert_eq!(result_buf.to_vec(), b"430 No such article\r\n");
     }
 
     #[tokio::test]
     async fn test_read_full_response_eof_mid_stream() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Multiline response without terminator — server disconnects
         let mut conn = mock_backend_conn(b"220 0 <a@b> article\r\nBody line\r\n").await;
 
-        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf).await;
+        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf, &pool).await;
         assert!(result.is_err(), "EOF before terminator should be an error");
         let err = result.unwrap_err().to_string();
         assert!(
@@ -506,11 +509,11 @@ mod tests {
     async fn test_read_full_response_invalid_status() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         let mut conn = mock_backend_conn(b"garbage data here\r\n").await;
 
-        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf).await;
+        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf, &pool).await;
         assert!(result.is_err(), "Invalid status code should be an error");
     }
 
@@ -518,14 +521,14 @@ mod tests {
     async fn test_read_full_response_short_leftover_triggers_h5() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Backend will provide the rest of the response
         let mut conn = mock_backend_conn(b"0 No such article\r\n").await;
         // Leftover is only 2 bytes — too short to validate, triggers H5 additional read
         conn.stash_leftover(b"43").unwrap();
 
-        let status = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+        let status = read_full_response(&mut buffer, &mut conn, &mut result_buf, &pool)
             .await
             .expect("short leftover + read should produce valid response");
 
@@ -537,12 +540,12 @@ mod tests {
     async fn test_read_full_response_empty_connection() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Server immediately closes
         let mut conn = mock_backend_conn(b"").await;
 
-        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf).await;
+        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf, &pool).await;
         assert!(result.is_err(), "Empty connection should be an error");
     }
 
@@ -627,7 +630,7 @@ mod tests {
             response_tx: tx,
         }];
 
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         let (success, _batch) = execute_pipeline_batch(
             backend_id,
@@ -688,7 +691,7 @@ mod tests {
             },
         ];
 
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         let (success, _batch) = execute_pipeline_batch(
             backend_id,
@@ -751,7 +754,7 @@ mod tests {
             },
         ];
 
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         let (success, _batch) = execute_pipeline_batch(
             backend_id,
@@ -820,7 +823,7 @@ mod tests {
             },
         ];
 
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         let (success, _batch) = execute_pipeline_batch(
             backend_id,
@@ -875,7 +878,7 @@ mod tests {
             rt.block_on(async {
                 let pool = BufferPool::for_tests();
                 let mut buffer = pool.acquire().await;
-                let mut result_buf = pool.acquire_capture().await;
+                let mut result_buf = crate::pool::ChunkedResponse::default();
 
                 let responses: Vec<Vec<u8>> = codes
                     .iter()
@@ -892,11 +895,11 @@ mod tests {
                 let mut conn = mock_backend_conn(&wire).await;
 
                 for (idx, expected) in responses.iter().enumerate() {
-                    let status = read_full_response(&mut buffer, &mut conn, &mut result_buf)
+                    let status = read_full_response(&mut buffer, &mut conn, &mut result_buf, &pool)
                         .await
                         .expect("packed single-line response should parse");
 
-                    prop_assert_eq!(&result_buf[..], expected.as_slice());
+                    prop_assert_eq!(result_buf.to_vec(), expected.as_slice());
                     prop_assert_eq!(status.as_u16(), codes[idx]);
                 }
 
@@ -932,7 +935,7 @@ mod tests {
                     match result {
                         PipelineResponse::Success { status_code, data, .. } => {
                             prop_assert_eq!(status_code.as_u16(), codes[idx]);
-                            prop_assert_eq!(&data[..], responses[idx].as_slice());
+                            prop_assert_eq!(data.to_vec(), responses[idx].clone());
                         }
                         other => prop_assert!(false, "expected success response, got {other:?}"),
                     }
@@ -963,7 +966,7 @@ mod tests {
 
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Create a multiline response that accumulates in result_buf across chunks,
         // followed by oversized leftover. When the terminator is found, the remainder
@@ -994,7 +997,7 @@ mod tests {
 
         let mut conn = mock_backend_conn_chunked(chunks).await;
 
-        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf).await;
+        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf, &pool).await;
 
         // Should fail with bounds check error (if TCP delivers enough data in one read)
         assert!(
@@ -1014,7 +1017,7 @@ mod tests {
 
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = pool.acquire_capture().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Create a response where leftover is within bounds (< MAX_LEFTOVER_BYTES)
         let mut normal_data = Vec::new();
@@ -1024,7 +1027,7 @@ mod tests {
 
         let mut conn = mock_backend_conn(&normal_data).await;
 
-        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf).await;
+        let result = read_full_response(&mut buffer, &mut conn, &mut result_buf, &pool).await;
 
         // Should succeed
         assert!(

--- a/src/session/handlers/pipeline_worker.rs
+++ b/src/session/handlers/pipeline_worker.rs
@@ -15,7 +15,7 @@ use tracing::{debug, info, warn};
 
 use crate::metrics::MetricsCollector;
 use crate::pool::{BufferPool, DeadpoolConnectionProvider};
-use crate::router::backend_queue::{BackendQueue, PipelineResponse, QueuedRequest};
+use crate::router::backend_queue::{BackendQueue, PipelineError, PipelineResponse, QueuedRequest};
 #[cfg(test)]
 use crate::session::backend::validate_backend_response;
 use crate::types::BackendId;
@@ -79,7 +79,7 @@ pub async fn backend_pipeline_worker(
                     backend_id, e
                 );
                 metrics.record_connection_failure(backend_id);
-                batch = fail_batch(batch, &format!("connection error: {e}"));
+                batch = fail_batch(batch, PipelineError::ConnectionAcquire);
                 continue;
             }
         };
@@ -139,8 +139,13 @@ async fn execute_pipeline_batch(
             );
             // We wrote commands 0..i successfully but can't read responses
             // because the connection is broken. Fail everything and return early.
-            let err_msg = format!("write failed at command {}/{}", i + 1, batch_len);
-            let batch = fail_batch(batch, &err_msg);
+            let batch = fail_batch(
+                batch,
+                PipelineError::WriteFailed {
+                    index: i + 1,
+                    batch_len,
+                },
+            );
             return (false, batch);
         }
     }
@@ -152,7 +157,7 @@ async fn execute_pipeline_batch(
             "Pipeline worker backend {:?}: flush failed: {}",
             backend_id, e
         );
-        let batch = fail_batch(batch, &format!("flush failed: {e}"));
+        let batch = fail_batch(batch, PipelineError::FlushFailed);
         return (false, batch);
     }
 
@@ -192,7 +197,7 @@ async fn execute_pipeline_batch(
                     backend = ?backend_id,
                     response_index = i + 1,
                     batch_size = batch_len,
-                    command = %req.command.trim(),
+                    command = %req.command.as_str().trim(),
                     error = %e,
                     leftover_bytes = conn.leftover_len(),
                     "Pipeline worker read failed"
@@ -201,14 +206,17 @@ async fn execute_pipeline_batch(
                 // Fail this request
                 let _ = req
                     .response_tx
-                    .send(PipelineResponse::Error(format!("read error: {e}")));
+                    .send(PipelineResponse::Error(PipelineError::ReadFailed));
 
                 // Fail remaining requests (no Vec allocation - iterate directly)
-                let error_msg = format!("connection lost after response {}/{}", i + 1, batch_len);
+                let error_msg = PipelineError::ConnectionLost {
+                    completed: i + 1,
+                    batch_len,
+                };
                 for (_, remaining_req) in batch_iter {
                     let _ = remaining_req
                         .response_tx
-                        .send(PipelineResponse::Error(error_msg.clone()));
+                        .send(PipelineResponse::Error(error_msg));
                 }
 
                 // Connection broken — return false immediately
@@ -268,11 +276,9 @@ async fn read_full_response(
 /// Takes ownership of the Vec, drains it, and returns the empty Vec
 /// so the caller can reuse the allocation.
 #[allow(clippy::iter_with_drain)] // drain used intentionally; empty Vec returned for allocation reuse
-fn fail_batch(mut batch: Vec<QueuedRequest>, error_msg: &str) -> Vec<QueuedRequest> {
+fn fail_batch(mut batch: Vec<QueuedRequest>, error: PipelineError) -> Vec<QueuedRequest> {
     for req in batch.drain(..) {
-        let _ = req
-            .response_tx
-            .send(PipelineResponse::Error(error_msg.to_string()));
+        let _ = req.response_tx.send(PipelineResponse::Error(error));
     }
     batch
 }
@@ -281,10 +287,34 @@ fn fail_batch(mut batch: Vec<QueuedRequest>, error_msg: &str) -> Vec<QueuedReque
 mod tests {
     use super::*;
     use crate::pool::BufferPool;
+    use crate::router::backend_queue::QueuedCommand;
     use crate::stream::ConnectionStream;
     use proptest::prelude::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
+
+    fn queued_request(
+        command: &str,
+    ) -> (
+        QueuedRequest,
+        tokio::sync::oneshot::Receiver<PipelineResponse>,
+    ) {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        (
+            QueuedRequest {
+                command: QueuedCommand::from_command(command),
+                response_tx: tx,
+            },
+            rx,
+        )
+    }
+
+    fn expect_success_status(response: PipelineResponse) -> u16 {
+        match response {
+            PipelineResponse::Success { status_code, .. } => status_code.as_u16(),
+            other @ PipelineResponse::Error(_) => panic!("Expected Success, got {other:?}"),
+        }
+    }
 
     /// Helper: create a TCP pair where the server writes `data` then optionally closes.
     /// Returns a `ConnectionStream` connected to the mock server.
@@ -348,13 +378,10 @@ mod tests {
         let mut rxs = Vec::with_capacity(responses.len());
         let mut expected_command_bytes = 0usize;
         for idx in 0..responses.len() {
-            let (tx, rx) = tokio::sync::oneshot::channel();
             let command = format!("STAT <msg{idx}@example.com>\r\n");
             expected_command_bytes += command.len();
-            batch.push(QueuedRequest {
-                command: Arc::from(command),
-                response_tx: tx,
-            });
+            let (request, rx) = queued_request(&command);
+            batch.push(request);
             rxs.push(rx);
         }
 
@@ -624,11 +651,8 @@ mod tests {
         let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
         let mut conn: crate::stream::ConnectionStream = ConnectionStream::plain(stream);
 
-        let (tx, rx) = tokio::sync::oneshot::channel();
-        let batch = vec![QueuedRequest {
-            command: Arc::from("STAT <test@msg.id>\r\n"),
-            response_tx: tx,
-        }];
+        let (request, rx) = queued_request("STAT <test@msg.id>\r\n");
+        let batch = vec![request];
 
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
@@ -643,12 +667,7 @@ mod tests {
         .await;
 
         assert!(success, "single 430 should not mark connection as broken");
-        match rx.await.unwrap() {
-            PipelineResponse::Success { status_code, .. } => {
-                assert_eq!(status_code.as_u16(), 430);
-            }
-            other @ PipelineResponse::Error(_) => panic!("Expected Success, got {other:?}"),
-        }
+        assert_eq!(expect_success_status(rx.await.unwrap()), 430);
     }
 
     #[tokio::test]
@@ -678,18 +697,9 @@ mod tests {
         let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
         let mut conn = ConnectionStream::plain(stream);
 
-        let (tx1, rx1) = tokio::sync::oneshot::channel();
-        let (tx2, rx2) = tokio::sync::oneshot::channel();
-        let batch = vec![
-            QueuedRequest {
-                command: Arc::from("STAT <a@b>\r\n"),
-                response_tx: tx1,
-            },
-            QueuedRequest {
-                command: Arc::from("STAT <c@d>\r\n"),
-                response_tx: tx2,
-            },
-        ];
+        let (req1, rx1) = queued_request("STAT <a@b>\r\n");
+        let (req2, rx2) = queued_request("STAT <c@d>\r\n");
+        let batch = vec![req1, req2];
 
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
@@ -704,18 +714,8 @@ mod tests {
         .await;
         assert!(success);
 
-        match rx1.await.unwrap() {
-            PipelineResponse::Success { status_code, .. } => {
-                assert_eq!(status_code.as_u16(), 223);
-            }
-            other @ PipelineResponse::Error(_) => panic!("Expected 223 Success, got {other:?}"),
-        }
-        match rx2.await.unwrap() {
-            PipelineResponse::Success { status_code, .. } => {
-                assert_eq!(status_code.as_u16(), 430);
-            }
-            other @ PipelineResponse::Error(_) => panic!("Expected 430 Success, got {other:?}"),
-        }
+        assert_eq!(expect_success_status(rx1.await.unwrap()), 223);
+        assert_eq!(expect_success_status(rx2.await.unwrap()), 430);
     }
 
     #[tokio::test]
@@ -741,18 +741,9 @@ mod tests {
         let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
         let mut conn = ConnectionStream::plain(stream);
 
-        let (tx1, rx1) = tokio::sync::oneshot::channel();
-        let (tx2, rx2) = tokio::sync::oneshot::channel();
-        let batch = vec![
-            QueuedRequest {
-                command: Arc::from("STAT <a@b>\r\n"),
-                response_tx: tx1,
-            },
-            QueuedRequest {
-                command: Arc::from("STAT <c@d>\r\n"),
-                response_tx: tx2,
-            },
-        ];
+        let (req1, rx1) = queued_request("STAT <a@b>\r\n");
+        let (req2, rx2) = queued_request("STAT <c@d>\r\n");
+        let batch = vec![req1, req2];
 
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
@@ -768,14 +759,7 @@ mod tests {
         assert!(!success, "server disconnect should mark connection broken");
 
         // First response should succeed
-        match rx1.await.unwrap() {
-            PipelineResponse::Success { status_code, .. } => {
-                assert_eq!(status_code.as_u16(), 223);
-            }
-            other @ PipelineResponse::Error(_) => {
-                panic!("Expected first to succeed, got {other:?}")
-            }
-        }
+        assert_eq!(expect_success_status(rx1.await.unwrap()), 223);
         // Second response should be error
         match rx2.await.unwrap() {
             PipelineResponse::Error(_) => {} // Expected
@@ -810,18 +794,9 @@ mod tests {
         let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
         let mut conn = ConnectionStream::plain(stream);
 
-        let (tx1, rx1) = tokio::sync::oneshot::channel();
-        let (tx2, rx2) = tokio::sync::oneshot::channel();
-        let batch = vec![
-            QueuedRequest {
-                command: Arc::from("STAT <a@b>\r\n"),
-                response_tx: tx1,
-            },
-            QueuedRequest {
-                command: Arc::from("STAT <c@d>\r\n"),
-                response_tx: tx2,
-            },
-        ];
+        let (req1, rx1) = queued_request("STAT <a@b>\r\n");
+        let (req2, rx2) = queued_request("STAT <c@d>\r\n");
+        let batch = vec![req1, req2];
 
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
@@ -844,18 +819,30 @@ mod tests {
             "unexpected extra response bytes should remain buffered until the connection is retired"
         );
 
-        match rx1.await.unwrap() {
-            PipelineResponse::Success { status_code, .. } => {
-                assert_eq!(status_code.as_u16(), 223);
-            }
-            other => panic!("Expected 223 Success, got {other:?}"),
-        }
-        match rx2.await.unwrap() {
-            PipelineResponse::Success { status_code, .. } => {
-                assert_eq!(status_code.as_u16(), 430);
-            }
-            other => panic!("Expected 430 Success, got {other:?}"),
-        }
+        assert_eq!(expect_success_status(rx1.await.unwrap()), 223);
+        assert_eq!(expect_success_status(rx2.await.unwrap()), 430);
+    }
+
+    #[test]
+    fn test_fail_batch_sends_same_error_to_all_requests() {
+        let (req1, rx1) = queued_request("STAT <a@b>\r\n");
+        let (req2, rx2) = queued_request("STAT <c@d>\r\n");
+        let error = PipelineError::ConnectionLost {
+            completed: 1,
+            batch_len: 2,
+        };
+
+        let reused = fail_batch(vec![req1, req2], error);
+
+        assert!(
+            reused.is_empty(),
+            "drained batch should be returned empty for reuse"
+        );
+        [rx1.blocking_recv().unwrap(), rx2.blocking_recv().unwrap()]
+            .into_iter()
+            .for_each(|response| {
+                assert!(matches!(response, PipelineResponse::Error(e) if e == error))
+            });
     }
 
     proptest! {

--- a/src/session/handlers/pipeline_worker.rs
+++ b/src/session/handlers/pipeline_worker.rs
@@ -7,6 +7,7 @@
 //!
 //! This enables N client sessions to share M backend connections (N >> M).
 
+#[cfg(test)]
 use anyhow::Result;
 use std::sync::Arc;
 use tokio::io::AsyncWriteExt;
@@ -15,6 +16,7 @@ use tracing::{debug, info, warn};
 use crate::metrics::MetricsCollector;
 use crate::pool::{BufferPool, DeadpoolConnectionProvider};
 use crate::router::backend_queue::{BackendQueue, PipelineResponse, QueuedRequest};
+#[cfg(test)]
 use crate::session::backend::validate_backend_response;
 use crate::types::BackendId;
 
@@ -52,7 +54,7 @@ pub async fn backend_pipeline_worker(
     );
 
     // Hoist buffers to worker lifetime (reused across batches)
-    let mut result_buf = bytes::BytesMut::with_capacity(4096);
+    let mut result_buf = buffer_pool.acquire_capture().await;
     let mut batch = Vec::with_capacity(config.batch_size);
 
     loop {
@@ -121,7 +123,7 @@ async fn execute_pipeline_batch(
     mut batch: Vec<QueuedRequest>,
     metrics: &MetricsCollector,
     buffer_pool: &BufferPool,
-    result_buf: &mut bytes::BytesMut,
+    result_buf: &mut crate::pool::PooledBuffer,
 ) -> (bool, Vec<QueuedRequest>) {
     let batch_len = batch.len();
 
@@ -161,7 +163,15 @@ async fn execute_pipeline_batch(
     let mut batch_iter = batch.drain(..).enumerate();
     while let Some((i, req)) = batch_iter.next() {
         // Read the response for this command
-        match read_full_response(&mut buffer, conn, result_buf).await {
+        match crate::session::streaming::read_full_response(
+            &mut buffer,
+            conn,
+            result_buf,
+            backend_id,
+        )
+        .await
+        .map_err(crate::session::streaming::StreamingError::into_anyhow)
+        {
             Ok((data, status_code)) => {
                 metrics.record_command(backend_id);
                 let data_len = data.len();
@@ -233,127 +243,20 @@ async fn execute_pipeline_batch(
 /// Returns the full response as `Bytes` and the parsed status code.
 ///
 /// `result_buf` is cleared and reused for each response to avoid per-response allocations.
+#[cfg(test)]
 async fn read_full_response(
     buffer: &mut crate::pool::PooledBuffer,
     conn: &mut crate::stream::ConnectionStream,
-    result_buf: &mut bytes::BytesMut,
+    result_buf: &mut crate::pool::PooledBuffer,
 ) -> Result<(bytes::Bytes, crate::protocol::StatusCode)> {
-    use crate::session::streaming::tail_buffer::TailBuffer;
-
-    let mut tail = TailBuffer::default();
-    result_buf.clear(); // Reuse buffer from previous response
-
-    // Get first data directly into result_buf (no intermediate Vec). ConnectionStream
-    // serves any stashed leftover bytes before polling the socket.
-    let from_leftover = conn.has_leftover();
-    let n = buffer.read_from(conn).await?;
-    if n == 0 {
-        anyhow::bail!("Backend connection closed unexpectedly");
-    }
-    result_buf.extend_from_slice(&buffer[..n]);
-
-    // H5: If leftover was too short to validate, read more data
-    if result_buf.len() < crate::protocol::MIN_RESPONSE_LENGTH {
-        let n = buffer.read_from(conn).await?;
-        if n == 0 {
-            anyhow::bail!(
-                "Backend EOF with partial status line ({} bytes)",
-                result_buf.len()
-            );
-        }
-        result_buf.extend_from_slice(&buffer[..n]);
-    }
-
-    // Validate the response to determine if it's multiline and get status code
-    let validated = validate_backend_response(
+    crate::session::streaming::read_full_response(
+        buffer,
+        conn,
         result_buf,
-        result_buf.len(),
-        crate::protocol::MIN_RESPONSE_LENGTH,
-    );
-    let status_code = validated.response.status_code().ok_or_else(|| {
-        // Log Invalid response with detailed context
-        tracing::warn!(
-            bytes_read = result_buf.len(),
-            first_bytes_hex = %crate::session::backend::format_hex_preview(result_buf, 256),
-            first_bytes_utf8 = %String::from_utf8_lossy(&result_buf[..result_buf.len().min(256)]),
-            source = if from_leftover { "leftover" } else { "fresh_read" },
-            "Invalid status code in pipeline response"
-        );
-        anyhow::anyhow!("Invalid status code in pipeline response")
-    })?;
-
-    if !validated.is_multiline {
-        // Single-line response: split at \r\n boundary to save leftover
-        if let Some(pos) = memchr::memchr(b'\n', &result_buf[..]) {
-            let end = pos + 1;
-            if end < result_buf.len() {
-                let remainder = &result_buf[end..];
-                anyhow::ensure!(
-                    remainder.len() <= crate::constants::buffer::MAX_LEFTOVER_BYTES,
-                    "Leftover exceeds {} bytes ({} bytes) — probable protocol desync",
-                    crate::constants::buffer::MAX_LEFTOVER_BYTES,
-                    remainder.len()
-                );
-                conn.stash_leftover(remainder)?;
-                result_buf.truncate(end);
-            }
-        }
-        return Ok((result_buf.split().freeze(), status_code));
-    }
-
-    // Multiline response: use TailBuffer to detect terminator
-    let status = tail.detect_terminator(result_buf);
-    let write_len = status.write_len(result_buf.len());
-
-    // Save any leftover bytes for next response
-    if write_len < result_buf.len() {
-        let remainder = &result_buf[write_len..];
-        anyhow::ensure!(
-            remainder.len() <= crate::constants::buffer::MAX_LEFTOVER_BYTES,
-            "Leftover exceeds {} bytes ({} bytes) — probable protocol desync",
-            crate::constants::buffer::MAX_LEFTOVER_BYTES,
-            remainder.len()
-        );
-        conn.stash_leftover(remainder)?;
-        result_buf.truncate(write_len);
-    }
-
-    if !status.is_found() {
-        tail.update(result_buf);
-
-        loop {
-            let n = buffer.read_from(conn).await?;
-            if n == 0 {
-                // C4: EOF before terminator is an error, not success
-                anyhow::bail!(
-                    "Backend EOF before multiline terminator (received {} bytes)",
-                    result_buf.len()
-                );
-            }
-            let chunk = &buffer[..n];
-            let status = tail.detect_terminator(chunk);
-            let write_len = status.write_len(n);
-            result_buf.extend_from_slice(&chunk[..write_len]);
-
-            if status.is_found() {
-                // Save leftover bytes for next response
-                if write_len < n {
-                    let remainder = &chunk[write_len..];
-                    anyhow::ensure!(
-                        remainder.len() <= crate::constants::buffer::MAX_LEFTOVER_BYTES,
-                        "Leftover exceeds {} bytes ({} bytes) — probable protocol desync",
-                        crate::constants::buffer::MAX_LEFTOVER_BYTES,
-                        remainder.len()
-                    );
-                    conn.stash_leftover(remainder)?;
-                }
-                break;
-            }
-            tail.update(&chunk[..write_len]);
-        }
-    }
-
-    Ok((result_buf.split().freeze(), status_code))
+        BackendId::from_index(0),
+    )
+    .await
+    .map_err(crate::session::streaming::StreamingError::into_anyhow)
 }
 
 /// Send error responses to all requests in a batch.
@@ -375,7 +278,6 @@ mod tests {
     use super::*;
     use crate::pool::BufferPool;
     use crate::stream::ConnectionStream;
-    use bytes::BytesMut;
     use proptest::prelude::*;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpListener;
@@ -470,7 +372,7 @@ mod tests {
         let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
         let mut conn = ConnectionStream::plain(stream);
 
-        let mut result_buf = bytes::BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
         let (success, _batch) = execute_pipeline_batch(
             backend_id,
             &mut conn,
@@ -495,7 +397,7 @@ mod tests {
     async fn test_read_full_response_single_line() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         let mut conn = mock_backend_conn(b"430 No such article\r\n").await;
 
@@ -512,7 +414,7 @@ mod tests {
     async fn test_read_full_response_multiline() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         let response = b"220 0 <msg@id> article\r\nSubject: test\r\n\r\nBody line\r\n.\r\n";
         let mut conn = mock_backend_conn(response).await;
@@ -530,7 +432,7 @@ mod tests {
     async fn test_read_full_response_multiline_across_chunks() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         // Split the terminator \r\n.\r\n across two chunks
         let chunk1 = b"220 0 <msg@id> article\r\nBody\r\n.".to_vec();
@@ -554,7 +456,7 @@ mod tests {
     async fn test_read_full_response_with_leftover() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         // Two responses packed together
         let packed = b"220 0 <a@b> article\r\nBody\r\n.\r\n430 No such article\r\n";
@@ -585,7 +487,7 @@ mod tests {
     async fn test_read_full_response_eof_mid_stream() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         // Multiline response without terminator — server disconnects
         let mut conn = mock_backend_conn(b"220 0 <a@b> article\r\nBody line\r\n").await;
@@ -594,8 +496,8 @@ mod tests {
         assert!(result.is_err(), "EOF before terminator should be an error");
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("EOF") || err.contains("eof"),
-            "Error should mention EOF: {err}"
+            err.contains("closed connection before multiline terminator"),
+            "Error should describe the premature backend close: {err}"
         );
     }
 
@@ -603,7 +505,7 @@ mod tests {
     async fn test_read_full_response_invalid_status() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         let mut conn = mock_backend_conn(b"garbage data here\r\n").await;
 
@@ -615,7 +517,7 @@ mod tests {
     async fn test_read_full_response_short_leftover_triggers_h5() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         // Backend will provide the rest of the response
         let mut conn = mock_backend_conn(b"0 No such article\r\n").await;
@@ -634,7 +536,7 @@ mod tests {
     async fn test_read_full_response_empty_connection() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         // Server immediately closes
         let mut conn = mock_backend_conn(b"").await;
@@ -724,7 +626,7 @@ mod tests {
             response_tx: tx,
         }];
 
-        let mut result_buf = bytes::BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         let (success, _batch) = execute_pipeline_batch(
             backend_id,
@@ -785,7 +687,7 @@ mod tests {
             },
         ];
 
-        let mut result_buf = bytes::BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         let (success, _batch) = execute_pipeline_batch(
             backend_id,
@@ -848,7 +750,7 @@ mod tests {
             },
         ];
 
-        let mut result_buf = bytes::BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         let (success, _batch) = execute_pipeline_batch(
             backend_id,
@@ -917,7 +819,7 @@ mod tests {
             },
         ];
 
-        let mut result_buf = bytes::BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         let (success, _batch) = execute_pipeline_batch(
             backend_id,
@@ -972,7 +874,7 @@ mod tests {
             rt.block_on(async {
                 let pool = BufferPool::for_tests();
                 let mut buffer = pool.acquire().await;
-                let mut result_buf = BytesMut::with_capacity(4096);
+                let mut result_buf = pool.acquire_capture().await;
 
                 let responses: Vec<Vec<u8>> = codes
                     .iter()
@@ -1060,7 +962,7 @@ mod tests {
 
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         // Create a multiline response that accumulates in result_buf across chunks,
         // followed by oversized leftover. When the terminator is found, the remainder
@@ -1111,7 +1013,7 @@ mod tests {
 
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
-        let mut result_buf = BytesMut::with_capacity(4096);
+        let mut result_buf = pool.acquire_capture().await;
 
         // Create a response where leftover is within bounds (< MAX_LEFTOVER_BYTES)
         let mut normal_data = Vec::new();

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -13,9 +13,9 @@ use crate::session::backend;
 use crate::types::{BackendId, MessageId};
 
 /// Result of querying a backend for an article.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum QueryResult {
-    Found(BackendId, Vec<u8>),
+    Found(BackendId, crate::cache::CacheBuffer),
     Missing(BackendId),
     Error(BackendId),
 }
@@ -102,21 +102,25 @@ async fn execute_backend_query(
                 return Err(());
             };
 
-            // For multiline responses, read remaining data until we have the full terminator
-            let mut response = buffer[..cmd_response.bytes_read].to_vec();
-            if multiline && cmd_response.is_multiline {
+            let response = if multiline && cmd_response.is_multiline {
                 use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
+                let mut response = crate::pool::ChunkedResponse::default();
+                response.extend_from_slice(&deps.buffer_pool, &buffer[..cmd_response.bytes_read]);
                 let mut tail = TailBuffer::default();
-                match tail.detect_terminator(&response) {
+                match tail.detect_terminator(buffer.as_ref()) {
                     TerminatorStatus::FoundAt(pos) => {
                         // pos is after the terminator (terminator included in [..pos])
-                        if pos < response.len() && conn.stash_leftover(&response[pos..]).is_err() {
+                        if pos < cmd_response.bytes_read
+                            && conn
+                                .stash_leftover(&buffer[pos..cmd_response.bytes_read])
+                                .is_err()
+                        {
                             return Err(());
                         }
                         response.truncate(pos);
                     }
                     TerminatorStatus::NotFound => {
-                        tail.update(&response);
+                        tail.update(buffer.as_ref());
                         loop {
                             match buffer.read_from(conn.as_mut()).await {
                                 Ok(0) | Err(_) => return Err(()),
@@ -126,19 +130,31 @@ async fn execute_backend_query(
                                         {
                                             return Err(());
                                         }
-                                        response.extend_from_slice(&buffer[..pos]);
+                                        response
+                                            .extend_from_slice(&deps.buffer_pool, &buffer[..pos]);
                                         break;
                                     }
                                     TerminatorStatus::NotFound => {
                                         tail.update(&buffer[..n]);
-                                        response.extend_from_slice(&buffer[..n]);
+                                        response.extend_from_slice(&deps.buffer_pool, &buffer[..n]);
                                     }
                                 },
                             }
                         }
                     }
                 }
-            }
+                if deps.cache_articles {
+                    crate::cache::CacheBuffer::Chunked(response)
+                } else {
+                    crate::cache::CacheBuffer::Small(crate::cache::extract_chunked_status_line(
+                        &response,
+                    ))
+                }
+            } else {
+                let mut response = Vec::with_capacity(cmd_response.bytes_read);
+                response.extend_from_slice(&buffer[..cmd_response.bytes_read]);
+                crate::cache::CacheBuffer::Vec(response)
+            };
 
             let result = match status_code.as_u16() {
                 220..=223 => {
@@ -151,12 +167,7 @@ async fn execute_backend_query(
                     deps.metrics.record_command(backend_id);
                     deps.metrics.record_ttfb_micros(backend_id, ttfb);
                     deps.metrics.record_send_recv_micros(backend_id, send, recv);
-                    let data = if deps.cache_articles || !multiline {
-                        response
-                    } else {
-                        format!("{status_code}\r\n").into_bytes()
-                    };
-                    QueryResult::Found(backend_id, data)
+                    QueryResult::Found(backend_id, response)
                 }
                 430 => {
                     deps.metrics.record_command(backend_id);
@@ -207,7 +218,7 @@ async fn query_all_backends_racing(
     command: &str,
     msg_id: &MessageId<'_>,
     multiline: bool,
-) -> Option<(BackendId, Vec<u8>)> {
+) -> Option<(BackendId, crate::cache::CacheBuffer)> {
     use futures::StreamExt;
 
     let tasks: Vec<_> = (0..deps.router.backend_count().get())
@@ -231,11 +242,10 @@ async fn query_all_backends_racing(
     let mut first_found = None;
 
     // Collect results until we find a success
-    while let Some(mut result) = pending.next().await {
-        match &mut result {
+    while let Some(result) = pending.next().await {
+        match result {
             QueryResult::Found(id, response) if first_found.is_none() => {
-                first_found = Some((*id, std::mem::take(response)));
-                results.push(result);
+                first_found = Some((id, response));
 
                 // Spawn background task to complete remaining backends and update cache
                 let cache = deps.cache.clone();
@@ -247,7 +257,8 @@ async fn query_all_backends_racing(
                         results.push(result);
                     }
                     // Build availability from all results and sync to cache
-                    let (_, availability) = summarize(results);
+                    let (_, mut availability) = summarize(results);
+                    availability.record_has(id);
                     cache.sync_availability(msg_id_owned, &availability).await;
                 });
 
@@ -278,7 +289,12 @@ async fn query_all_backends_racing(
 /// # NNTP Semantics
 /// 430 responses are authoritative (never false negatives), 2xx are not.
 /// See `crate::cache::article` module docs for full explanation.
-fn summarize(results: Vec<QueryResult>) -> (Option<(BackendId, Vec<u8>)>, ArticleAvailability) {
+fn summarize(
+    results: Vec<QueryResult>,
+) -> (
+    Option<(BackendId, crate::cache::CacheBuffer)>,
+    ArticleAvailability,
+) {
     let mut availability = ArticleAvailability::new();
     let mut found = None;
 
@@ -393,11 +409,17 @@ mod tests {
     fn summarize_finds_first() {
         let results = vec![
             QueryResult::Missing(BackendId::from_index(0)),
-            QueryResult::Found(BackendId::from_index(1), b"first".to_vec()),
-            QueryResult::Found(BackendId::from_index(2), b"second".to_vec()),
+            QueryResult::Found(BackendId::from_index(1), b"first".to_vec().into()),
+            QueryResult::Found(BackendId::from_index(2), b"second".to_vec().into()),
         ];
         let (found, avail) = summarize(results);
-        assert_eq!(found, Some((BackendId::from_index(1), b"first".to_vec())));
+        assert_eq!(
+            found,
+            Some((
+                BackendId::from_index(1),
+                crate::cache::CacheBuffer::Vec(b"first".to_vec())
+            ))
+        );
         assert!(avail.is_missing(BackendId::from_index(0)));
         assert!(!avail.is_missing(BackendId::from_index(1)));
         assert!(!avail.is_missing(BackendId::from_index(2)));

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -96,20 +96,6 @@ impl StreamingError {
     }
 }
 
-/// Classify a client-side write failure into the appropriate `StreamingError` variant.
-///
-/// Disconnect errors (`BrokenPipe`, `ConnectionReset`) become `ClientDisconnect`
-/// (backend is still clean — connection can be returned to pool). All other
-/// errors become `Io` (treat the connection as suspect).
-pub(crate) fn classify_client_write_err(e: std::io::Error) -> StreamingError {
-    use crate::connection_error::is_disconnect_kind;
-    if is_disconnect_kind(e.kind()) {
-        StreamingError::ClientDisconnect(e)
-    } else {
-        StreamingError::Io(e.into())
-    }
-}
-
 /// Identifies where a streaming operation is happening
 ///
 /// Groups the session-level context that is invariant across all chunks

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -244,7 +244,7 @@ pub(crate) async fn stream_and_capture_multiline_response<R, W>(
     client_write: &mut W,
     first_chunk: &[u8],
     ctx: &StreamContext<'_>,
-    capture: &mut crate::pool::PooledBuffer,
+    capture: &mut crate::pool::ChunkedResponse,
 ) -> Result<u64, StreamingError>
 where
     R: AsyncReadExt + Unpin,
@@ -259,31 +259,6 @@ where
         None,
     )
     .await
-}
-
-trait ResponseAccumulator {
-    fn len(&self) -> usize;
-    fn extend_from_slice(&mut self, data: &[u8]);
-    fn truncate(&mut self, len: usize);
-    fn as_slice(&self) -> &[u8];
-}
-
-impl ResponseAccumulator for crate::pool::PooledBuffer {
-    fn len(&self) -> usize {
-        self.initialized()
-    }
-
-    fn extend_from_slice(&mut self, data: &[u8]) {
-        crate::pool::PooledBuffer::extend_from_slice(self, data);
-    }
-
-    fn truncate(&mut self, len: usize) {
-        crate::pool::PooledBuffer::truncate(self, len);
-    }
-
-    fn as_slice(&self) -> &[u8] {
-        self.as_ref()
-    }
 }
 
 fn stash_leftover(
@@ -301,105 +276,82 @@ fn stash_leftover(
     Ok(())
 }
 
-async fn finish_read_full_response<A>(
-    io_buffer: &mut crate::pool::PooledBuffer,
-    conn: &mut crate::stream::ConnectionStream,
-    response: &mut A,
-    backend_id: crate::types::BackendId,
+fn validate_response_prefix(
+    response: &[u8],
     source: &'static str,
-) -> Result<crate::protocol::StatusCode, StreamingError>
-where
-    A: ResponseAccumulator,
-{
-    if response.len() < crate::protocol::MIN_RESPONSE_LENGTH {
-        loop {
-            let n = io_buffer.read_from(conn).await.map_err(|e| {
-                StreamingError::Io(
-                    anyhow::Error::from(e).context("Failed to read partial status line"),
-                )
-            })?;
-            if n == 0 {
-                return Err(StreamingError::Io(anyhow::anyhow!(
-                    "Backend EOF with partial status line ({} bytes)",
-                    response.len()
-                )));
-            }
-            response.extend_from_slice(&io_buffer[..n]);
-            if response.len() >= crate::protocol::MIN_RESPONSE_LENGTH {
-                break;
-            }
-        }
-    }
-
+) -> Result<(crate::protocol::StatusCode, bool), StreamingError> {
     let validated = crate::session::backend::validate_backend_response(
-        response.as_slice(),
+        response,
         response.len(),
         crate::protocol::MIN_RESPONSE_LENGTH,
     );
     let status_code = validated.response.status_code().ok_or_else(|| {
         warn!(
             bytes_read = response.len(),
-            first_bytes_hex = %crate::session::backend::format_hex_preview(response.as_slice(), 256),
-            first_bytes_utf8 = %String::from_utf8_lossy(
-                &response.as_slice()[..response.len().min(256)]
-            ),
+            first_bytes_hex = %crate::session::backend::format_hex_preview(response, 256),
+            first_bytes_utf8 = %String::from_utf8_lossy(&response[..response.len().min(256)]),
             source = source,
             "Invalid status code in response"
         );
         StreamingError::Io(anyhow::anyhow!("Invalid status code in response"))
     })?;
+    Ok((status_code, validated.is_multiline))
+}
 
-    if !validated.is_multiline {
-        if let Some(pos) = memchr::memchr(b'\n', response.as_slice()) {
-            let end = pos + 1;
-            if end < response.len() {
-                stash_leftover(conn, &response.as_slice()[end..])?;
-                response.truncate(end);
-            }
-        }
-        return Ok(status_code);
-    }
+async fn fill_multiline_response(
+    io_buffer: &mut crate::pool::PooledBuffer,
+    conn: &mut crate::stream::ConnectionStream,
+    response: &mut crate::pool::ChunkedResponse,
+    pool: &crate::pool::BufferPool,
+    initial_chunk_len: usize,
+    backend_id: crate::types::BackendId,
+) -> Result<(), StreamingError> {
+    use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
 
+    let initial_chunk = &io_buffer[..initial_chunk_len];
     let mut tail = TailBuffer::default();
-    let status = tail.detect_terminator(response.as_slice());
-    let write_len = status.write_len(response.len());
 
-    if write_len < response.len() {
-        stash_leftover(conn, &response.as_slice()[write_len..])?;
-        response.truncate(write_len);
-    }
-
-    if !status.is_found() {
-        tail.update(response.as_slice());
-
-        loop {
-            let n = io_buffer.read_from(conn).await.map_err(|e| {
-                StreamingError::Io(
-                    anyhow::Error::from(e).context("Failed to read remaining response body"),
-                )
-            })?;
-            if n == 0 {
-                return Err(StreamingError::BackendEof {
-                    backend_id,
-                    bytes_received: response.len() as u64,
-                });
+    match tail.detect_terminator(initial_chunk) {
+        TerminatorStatus::FoundAt(pos) => {
+            response.extend_from_slice(pool, &initial_chunk[..pos]);
+            if pos < initial_chunk.len() {
+                stash_leftover(conn, &initial_chunk[pos..])?;
             }
-            let chunk = &io_buffer[..n];
-            let status = tail.detect_terminator(chunk);
-            let write_len = status.write_len(n);
-            response.extend_from_slice(&chunk[..write_len]);
-
-            if status.is_found() {
-                if write_len < n {
-                    stash_leftover(conn, &chunk[write_len..n])?;
-                }
-                break;
-            }
-            tail.update(&chunk[..write_len]);
+            return Ok(());
+        }
+        TerminatorStatus::NotFound => {
+            response.extend_from_slice(pool, initial_chunk);
+            tail.update(initial_chunk);
         }
     }
 
-    Ok(status_code)
+    loop {
+        let n = io_buffer.read_from(conn).await.map_err(|e| {
+            StreamingError::Io(
+                anyhow::Error::from(e).context("Failed to read remaining response body"),
+            )
+        })?;
+        if n == 0 {
+            return Err(StreamingError::BackendEof {
+                backend_id,
+                bytes_received: response.len() as u64,
+            });
+        }
+
+        let chunk = &io_buffer[..n];
+        let status = tail.detect_terminator(chunk);
+        let write_len = status.write_len(n);
+        response.extend_from_slice(pool, &chunk[..write_len]);
+
+        if status.is_found() {
+            if write_len < n {
+                stash_leftover(conn, &chunk[write_len..n])?;
+            }
+            return Ok(());
+        }
+
+        tail.update(&chunk[..write_len]);
+    }
 }
 
 /// Read a complete NNTP response from a connection into a reusable accumulator.
@@ -408,7 +360,8 @@ where
 pub(crate) async fn read_full_response(
     io_buffer: &mut crate::pool::PooledBuffer,
     conn: &mut crate::stream::ConnectionStream,
-    result_buf: &mut crate::pool::PooledBuffer,
+    result_buf: &mut crate::pool::ChunkedResponse,
+    pool: &crate::pool::BufferPool,
     backend_id: crate::types::BackendId,
 ) -> Result<crate::protocol::StatusCode, StreamingError> {
     result_buf.clear();
@@ -426,9 +379,43 @@ pub(crate) async fn read_full_response(
             "Backend connection closed unexpectedly"
         )));
     }
-    result_buf.extend_from_slice(&io_buffer[..n]);
+    if n < crate::protocol::MIN_RESPONSE_LENGTH {
+        loop {
+            let more = io_buffer.read_more(conn).await.map_err(|e| {
+                StreamingError::Io(
+                    anyhow::Error::from(e).context("Failed to read partial status line"),
+                )
+            })?;
+            if more == 0 {
+                return Err(StreamingError::Io(anyhow::anyhow!(
+                    "Backend EOF with partial status line ({} bytes)",
+                    io_buffer.initialized()
+                )));
+            }
+            if io_buffer.initialized() >= crate::protocol::MIN_RESPONSE_LENGTH {
+                break;
+            }
+        }
+    }
 
-    finish_read_full_response(io_buffer, conn, result_buf, backend_id, source).await
+    let initial_len = io_buffer.initialized();
+    let response = &io_buffer[..initial_len];
+    let (status_code, is_multiline) = validate_response_prefix(response, source)?;
+
+    if !is_multiline {
+        result_buf.extend_from_slice(pool, response);
+        if let Some(pos) = memchr::memchr(b'\n', response) {
+            let end = pos + 1;
+            if end < response.len() {
+                stash_leftover(conn, &response[end..])?;
+                result_buf.truncate(end);
+            }
+        }
+        return Ok(status_code);
+    }
+
+    fill_multiline_response(io_buffer, conn, result_buf, pool, initial_len, backend_id).await?;
+    Ok(status_code)
 }
 
 /// Read and validate a full response after the first chunk has already been prefetched.
@@ -439,19 +426,54 @@ pub(crate) async fn buffer_multiline_response(
     conn: &mut crate::stream::ConnectionStream,
     first_chunk: &[u8],
     ctx: &StreamContext<'_>,
-) -> Result<crate::pool::PooledBuffer, StreamingError> {
+) -> Result<crate::pool::ChunkedResponse, StreamingError> {
+    use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
+
     let mut io_buffer = ctx.buffer_pool.acquire().await;
-    let mut captured = ctx.buffer_pool.acquire_capture().await;
-    captured.clear();
-    captured.extend_from_slice(first_chunk);
-    let _status_code = finish_read_full_response(
-        &mut io_buffer,
-        conn,
-        &mut captured,
-        ctx.backend_id,
-        "prefetched",
-    )
-    .await?;
+    let mut captured = crate::pool::ChunkedResponse::default();
+    let _status_code = validate_response_prefix(first_chunk, "prefetched")?;
+
+    let mut tail = TailBuffer::default();
+    match tail.detect_terminator(first_chunk) {
+        TerminatorStatus::FoundAt(pos) => {
+            captured.extend_from_slice(ctx.buffer_pool, &first_chunk[..pos]);
+            if pos < first_chunk.len() {
+                stash_leftover(conn, &first_chunk[pos..])?;
+            }
+        }
+        TerminatorStatus::NotFound => {
+            captured.extend_from_slice(ctx.buffer_pool, first_chunk);
+            tail.update(first_chunk);
+
+            loop {
+                let n = io_buffer.read_from(conn).await.map_err(|e| {
+                    StreamingError::Io(
+                        anyhow::Error::from(e).context("Failed to read remaining response body"),
+                    )
+                })?;
+                if n == 0 {
+                    return Err(StreamingError::BackendEof {
+                        backend_id: ctx.backend_id,
+                        bytes_received: captured.len() as u64,
+                    });
+                }
+
+                let chunk = &io_buffer[..n];
+                let status = tail.detect_terminator(chunk);
+                let write_len = status.write_len(n);
+                captured.extend_from_slice(ctx.buffer_pool, &chunk[..write_len]);
+
+                if status.is_found() {
+                    if write_len < n {
+                        stash_leftover(conn, &chunk[write_len..n])?;
+                    }
+                    break;
+                }
+
+                tail.update(&chunk[..write_len]);
+            }
+        }
+    }
     Ok(captured)
 }
 
@@ -501,7 +523,7 @@ enum ChunkResult {
 async fn process_chunk<R, W>(
     data: &[u8],
     tail: &mut TailBuffer,
-    capture: &mut Option<&mut crate::pool::PooledBuffer>,
+    capture: &mut Option<&mut crate::pool::ChunkedResponse>,
     client_write: &mut W,
     backend_read: &mut R,
     total_bytes: &mut u64,
@@ -517,7 +539,7 @@ where
 
     // Capture data if requested (for caching)
     if let Some(cap) = capture {
-        cap.extend_from_slice(&data[..write_len]);
+        cap.extend_from_slice(ctx.buffer_pool, &data[..write_len]);
     }
 
     // Write current chunk (or portion up to terminator) to client
@@ -559,7 +581,7 @@ async fn stream_multiline_response_impl<R, W>(
     client_write: &mut W,
     first_chunk: &[u8],
     ctx: &StreamContext<'_>,
-    mut capture: Option<&mut crate::pool::PooledBuffer>,
+    mut capture: Option<&mut crate::pool::ChunkedResponse>,
     mut leftover_out: Option<&mut crate::pool::PooledBuffer>,
 ) -> Result<u64, StreamingError>
 where
@@ -897,7 +919,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(&captured[..], response);
+        assert_eq!(captured.to_vec(), response);
     }
 
     #[tokio::test]

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -4,7 +4,6 @@
 //! Uses a single pooled buffer for sequential read-write I/O on large transfers.
 
 use anyhow::{Context, Result};
-use bytes::Bytes;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, warn};
 
@@ -368,8 +367,7 @@ where
         if let Some(pos) = memchr::memchr(b'\n', response.as_slice()) {
             let end = pos + 1;
             if end < response.len() {
-                let remainder = response.as_slice()[end..].to_vec();
-                stash_leftover(conn, &remainder)?;
+                stash_leftover(conn, &response.as_slice()[end..])?;
                 response.truncate(end);
             }
         }
@@ -381,8 +379,7 @@ where
     let write_len = status.write_len(response.len());
 
     if write_len < response.len() {
-        let remainder = response.as_slice()[write_len..].to_vec();
-        stash_leftover(conn, &remainder)?;
+        stash_leftover(conn, &response.as_slice()[write_len..])?;
         response.truncate(write_len);
     }
 
@@ -427,7 +424,7 @@ pub(crate) async fn read_full_response(
     conn: &mut crate::stream::ConnectionStream,
     result_buf: &mut crate::pool::PooledBuffer,
     backend_id: crate::types::BackendId,
-) -> Result<(Bytes, crate::protocol::StatusCode), StreamingError> {
+) -> Result<crate::protocol::StatusCode, StreamingError> {
     result_buf.clear();
 
     let source = if conn.has_leftover() {
@@ -445,9 +442,7 @@ pub(crate) async fn read_full_response(
     }
     result_buf.extend_from_slice(&io_buffer[..n]);
 
-    let status_code =
-        finish_read_full_response(io_buffer, conn, result_buf, backend_id, source).await?;
-    Ok((Bytes::copy_from_slice(result_buf.as_ref()), status_code))
+    finish_read_full_response(io_buffer, conn, result_buf, backend_id, source).await
 }
 
 /// Read and validate a full response after the first chunk has already been prefetched.

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -237,6 +237,7 @@ where
 /// Essential for large article downloads (50MB+) where buffering would kill performance.
 ///
 /// If `capture` is Some, the response will be captured into the Vec for caching.
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) async fn stream_multiline_response<R, W>(
     backend_read: &mut R,
     client_write: &mut W,
@@ -271,6 +272,25 @@ where
         None,
     )
     .await
+}
+
+/// Read and validate a full multiline response into memory before returning it.
+///
+/// This is used by per-command paths that want to verify the full backend
+/// response before writing anything to the client.
+pub(crate) async fn buffer_multiline_response<R>(
+    backend_read: &mut R,
+    first_chunk: &[u8],
+    ctx: &StreamContext<'_>,
+) -> Result<crate::pool::PooledBuffer, StreamingError>
+where
+    R: AsyncReadExt + Unpin,
+{
+    let mut captured = ctx.buffer_pool.acquire_capture().await;
+    let mut sink = tokio::io::sink();
+    stream_and_capture_multiline_response(backend_read, &mut sink, first_chunk, ctx, &mut captured)
+        .await?;
+    Ok(captured)
 }
 
 /// Stream multiline response from backend to client during pipelined batch execution.
@@ -682,6 +702,34 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), full_response.len() as u64);
         assert_eq!(&writer[..], &full_response[..]);
+    }
+
+    #[tokio::test]
+    async fn test_buffer_multiline_response_returns_complete_response() {
+        let response = b"220 Article follows\r\nLine 1\r\nLine 2\r\n.\r\n";
+        let mut reader = Cursor::new(b"");
+        let pool = test_helpers::make_pool();
+        let ctx = test_helpers::make_ctx(&pool);
+
+        let captured = buffer_multiline_response(&mut reader, response, &ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(&captured[..], response);
+    }
+
+    #[tokio::test]
+    async fn test_buffer_multiline_response_errors_on_truncated_backend() {
+        let partial = b"220 Article follows\r\nIncomplete body\r\n";
+        let mut reader = Cursor::new(&[] as &[u8]);
+        let pool = test_helpers::make_pool();
+        let ctx = test_helpers::make_ctx(&pool);
+
+        let result = buffer_multiline_response(&mut reader, partial, &ctx).await;
+        assert!(
+            matches!(result, Err(StreamingError::BackendEof { .. })),
+            "EOF before terminator must be BackendEof"
+        );
     }
 
     #[tokio::test]

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -478,7 +478,7 @@ pub(crate) async fn stream_multiline_response_pipelined<R, W>(
     client_write: &mut W,
     first_chunk: &[u8],
     ctx: &StreamContext<'_>,
-    leftover: &mut bytes::BytesMut,
+    leftover: &mut crate::pool::PooledBuffer,
 ) -> Result<u64, StreamingError>
 where
     R: AsyncReadExt + Unpin,
@@ -574,7 +574,7 @@ async fn stream_multiline_response_impl<R, W>(
     first_chunk: &[u8],
     ctx: &StreamContext<'_>,
     mut capture: Option<&mut crate::pool::PooledBuffer>,
-    mut leftover_out: Option<&mut bytes::BytesMut>,
+    mut leftover_out: Option<&mut crate::pool::PooledBuffer>,
 ) -> Result<u64, StreamingError>
 where
     R: AsyncReadExt + Unpin,
@@ -1024,8 +1024,8 @@ mod tests {
         // No backend reads needed — everything is in first chunk
         let mut reader = Cursor::new(b"" as &[u8]);
         let mut writer = Vec::new();
-        let mut leftover = bytes::BytesMut::new();
         let pool = test_helpers::make_pool();
+        let mut leftover = pool.acquire().await;
         let ctx = test_helpers::make_ctx(&pool);
 
         let result = stream_multiline_response_pipelined(
@@ -1054,8 +1054,8 @@ mod tests {
 
         let mut reader = Cursor::new(second_read.as_slice());
         let mut writer = Vec::new();
-        let mut leftover = bytes::BytesMut::new();
         let pool = test_helpers::make_pool();
+        let mut leftover = pool.acquire().await;
         let ctx = test_helpers::make_ctx(&pool);
 
         let result = stream_multiline_response_pipelined(
@@ -1087,8 +1087,8 @@ mod tests {
         let response = b"220 Article follows\r\nBody\r\n.\r\n";
         let mut reader = Cursor::new(b"" as &[u8]);
         let mut writer = Vec::new();
-        let mut leftover = bytes::BytesMut::new();
         let pool = test_helpers::make_pool();
+        let mut leftover = pool.acquire().await;
         let ctx = test_helpers::make_ctx(&pool);
 
         let result = stream_multiline_response_pipelined(
@@ -1120,8 +1120,8 @@ mod tests {
 
         let mut reader = Cursor::new(b"" as &[u8]);
         let mut writer = Vec::new();
-        let mut leftover = bytes::BytesMut::new();
         let pool = test_helpers::make_pool();
+        let mut leftover = pool.acquire().await;
         let ctx = test_helpers::make_ctx(&pool);
 
         let result = stream_multiline_response_pipelined(

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -4,6 +4,7 @@
 //! Uses a single pooled buffer for sequential read-write I/O on large transfers.
 
 use anyhow::{Context, Result};
+use bytes::Bytes;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, warn};
 
@@ -252,6 +253,7 @@ where
 }
 
 /// Stream multiline response and optionally capture for caching
+#[allow(dead_code)]
 pub(crate) async fn stream_and_capture_multiline_response<R, W>(
     backend_read: &mut R,
     client_write: &mut W,
@@ -274,22 +276,201 @@ where
     .await
 }
 
-/// Read and validate a full multiline response into memory before returning it.
+trait ResponseAccumulator {
+    fn len(&self) -> usize;
+    fn extend_from_slice(&mut self, data: &[u8]);
+    fn truncate(&mut self, len: usize);
+    fn as_slice(&self) -> &[u8];
+}
+
+impl ResponseAccumulator for crate::pool::PooledBuffer {
+    fn len(&self) -> usize {
+        self.initialized()
+    }
+
+    fn extend_from_slice(&mut self, data: &[u8]) {
+        crate::pool::PooledBuffer::extend_from_slice(self, data);
+    }
+
+    fn truncate(&mut self, len: usize) {
+        crate::pool::PooledBuffer::truncate(self, len);
+    }
+
+    fn as_slice(&self) -> &[u8] {
+        self.as_ref()
+    }
+}
+
+fn stash_leftover(
+    conn: &mut crate::stream::ConnectionStream,
+    remainder: &[u8],
+) -> Result<(), StreamingError> {
+    if remainder.len() > crate::constants::buffer::MAX_LEFTOVER_BYTES {
+        return Err(StreamingError::Io(anyhow::anyhow!(
+            "Leftover exceeds {} bytes ({} bytes) — probable protocol desync",
+            crate::constants::buffer::MAX_LEFTOVER_BYTES,
+            remainder.len()
+        )));
+    }
+    conn.stash_leftover(remainder).map_err(StreamingError::Io)?;
+    Ok(())
+}
+
+async fn finish_read_full_response<A>(
+    io_buffer: &mut crate::pool::PooledBuffer,
+    conn: &mut crate::stream::ConnectionStream,
+    response: &mut A,
+    backend_id: crate::types::BackendId,
+    source: &'static str,
+) -> Result<crate::protocol::StatusCode, StreamingError>
+where
+    A: ResponseAccumulator,
+{
+    if response.len() < crate::protocol::MIN_RESPONSE_LENGTH {
+        loop {
+            let n = io_buffer.read_from(conn).await.map_err(|e| {
+                StreamingError::Io(
+                    anyhow::Error::from(e).context("Failed to read partial status line"),
+                )
+            })?;
+            if n == 0 {
+                return Err(StreamingError::Io(anyhow::anyhow!(
+                    "Backend EOF with partial status line ({} bytes)",
+                    response.len()
+                )));
+            }
+            response.extend_from_slice(&io_buffer[..n]);
+            if response.len() >= crate::protocol::MIN_RESPONSE_LENGTH {
+                break;
+            }
+        }
+    }
+
+    let validated = crate::session::backend::validate_backend_response(
+        response.as_slice(),
+        response.len(),
+        crate::protocol::MIN_RESPONSE_LENGTH,
+    );
+    let status_code = validated.response.status_code().ok_or_else(|| {
+        warn!(
+            bytes_read = response.len(),
+            first_bytes_hex = %crate::session::backend::format_hex_preview(response.as_slice(), 256),
+            first_bytes_utf8 = %String::from_utf8_lossy(
+                &response.as_slice()[..response.len().min(256)]
+            ),
+            source = source,
+            "Invalid status code in response"
+        );
+        StreamingError::Io(anyhow::anyhow!("Invalid status code in response"))
+    })?;
+
+    if !validated.is_multiline {
+        if let Some(pos) = memchr::memchr(b'\n', response.as_slice()) {
+            let end = pos + 1;
+            if end < response.len() {
+                let remainder = response.as_slice()[end..].to_vec();
+                stash_leftover(conn, &remainder)?;
+                response.truncate(end);
+            }
+        }
+        return Ok(status_code);
+    }
+
+    let mut tail = TailBuffer::default();
+    let status = tail.detect_terminator(response.as_slice());
+    let write_len = status.write_len(response.len());
+
+    if write_len < response.len() {
+        let remainder = response.as_slice()[write_len..].to_vec();
+        stash_leftover(conn, &remainder)?;
+        response.truncate(write_len);
+    }
+
+    if !status.is_found() {
+        tail.update(response.as_slice());
+
+        loop {
+            let n = io_buffer.read_from(conn).await.map_err(|e| {
+                StreamingError::Io(
+                    anyhow::Error::from(e).context("Failed to read remaining response body"),
+                )
+            })?;
+            if n == 0 {
+                return Err(StreamingError::BackendEof {
+                    backend_id,
+                    bytes_received: response.len() as u64,
+                });
+            }
+            let chunk = &io_buffer[..n];
+            let status = tail.detect_terminator(chunk);
+            let write_len = status.write_len(n);
+            response.extend_from_slice(&chunk[..write_len]);
+
+            if status.is_found() {
+                if write_len < n {
+                    stash_leftover(conn, &chunk[write_len..n])?;
+                }
+                break;
+            }
+            tail.update(&chunk[..write_len]);
+        }
+    }
+
+    Ok(status_code)
+}
+
+/// Read a complete NNTP response from a connection into a reusable accumulator.
 ///
-/// This is used by per-command paths that want to verify the full backend
-/// response before writing anything to the client.
-pub(crate) async fn buffer_multiline_response<R>(
-    backend_read: &mut R,
+/// This is the shared non-streaming response reader used by the pipeline worker.
+pub(crate) async fn read_full_response(
+    io_buffer: &mut crate::pool::PooledBuffer,
+    conn: &mut crate::stream::ConnectionStream,
+    result_buf: &mut crate::pool::PooledBuffer,
+    backend_id: crate::types::BackendId,
+) -> Result<(Bytes, crate::protocol::StatusCode), StreamingError> {
+    result_buf.clear();
+
+    let source = if conn.has_leftover() {
+        "leftover"
+    } else {
+        "fresh_read"
+    };
+    let n = io_buffer.read_from(conn).await.map_err(|e| {
+        StreamingError::Io(anyhow::Error::from(e).context("Failed to read response from backend"))
+    })?;
+    if n == 0 {
+        return Err(StreamingError::Io(anyhow::anyhow!(
+            "Backend connection closed unexpectedly"
+        )));
+    }
+    result_buf.extend_from_slice(&io_buffer[..n]);
+
+    let status_code =
+        finish_read_full_response(io_buffer, conn, result_buf, backend_id, source).await?;
+    Ok((Bytes::copy_from_slice(result_buf.as_ref()), status_code))
+}
+
+/// Read and validate a full response after the first chunk has already been prefetched.
+///
+/// Used by the direct per-command path, which performs the initial command send/read
+/// before deciding how to route the response.
+pub(crate) async fn buffer_multiline_response(
+    conn: &mut crate::stream::ConnectionStream,
     first_chunk: &[u8],
     ctx: &StreamContext<'_>,
-) -> Result<crate::pool::PooledBuffer, StreamingError>
-where
-    R: AsyncReadExt + Unpin,
-{
+) -> Result<crate::pool::PooledBuffer, StreamingError> {
+    let mut io_buffer = ctx.buffer_pool.acquire().await;
     let mut captured = ctx.buffer_pool.acquire_capture().await;
-    let mut sink = tokio::io::sink();
-    stream_and_capture_multiline_response(backend_read, &mut sink, first_chunk, ctx, &mut captured)
-        .await?;
+    captured.clear();
+    captured.extend_from_slice(first_chunk);
+    let _status_code = finish_read_full_response(
+        &mut io_buffer,
+        conn,
+        &mut captured,
+        ctx.backend_id,
+        "prefetched",
+    )
+    .await?;
     Ok(captured)
 }
 
@@ -526,6 +707,8 @@ mod tests {
     mod test_helpers {
         use super::super::*;
         use crate::types::BufferSize;
+        use tokio::io::AsyncWriteExt;
+        use tokio::net::TcpListener;
 
         pub(super) fn make_pool() -> crate::pool::BufferPool {
             crate::pool::BufferPool::new(BufferSize::try_new(65536).unwrap(), 2)
@@ -538,6 +721,24 @@ mod tests {
                 backend_id: crate::types::BackendId::from_index(1),
                 buffer_pool: pool,
             }
+        }
+
+        pub(super) async fn mock_backend_conn(
+            chunks: Vec<Vec<u8>>,
+        ) -> crate::stream::ConnectionStream {
+            let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+
+            tokio::spawn(async move {
+                let (mut stream, _) = listener.accept().await.unwrap();
+                for chunk in chunks {
+                    stream.write_all(&chunk).await.unwrap();
+                }
+                stream.shutdown().await.unwrap();
+            });
+
+            let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+            crate::stream::ConnectionStream::plain(stream)
         }
     }
 
@@ -707,11 +908,11 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_multiline_response_returns_complete_response() {
         let response = b"220 Article follows\r\nLine 1\r\nLine 2\r\n.\r\n";
-        let mut reader = Cursor::new(b"");
         let pool = test_helpers::make_pool();
         let ctx = test_helpers::make_ctx(&pool);
+        let mut conn = test_helpers::mock_backend_conn(vec![]).await;
 
-        let captured = buffer_multiline_response(&mut reader, response, &ctx)
+        let captured = buffer_multiline_response(&mut conn, response, &ctx)
             .await
             .unwrap();
 
@@ -721,11 +922,11 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_multiline_response_errors_on_truncated_backend() {
         let partial = b"220 Article follows\r\nIncomplete body\r\n";
-        let mut reader = Cursor::new(&[] as &[u8]);
         let pool = test_helpers::make_pool();
         let ctx = test_helpers::make_ctx(&pool);
+        let mut conn = test_helpers::mock_backend_conn(vec![]).await;
 
-        let result = buffer_multiline_response(&mut reader, partial, &ctx).await;
+        let result = buffer_multiline_response(&mut conn, partial, &ctx).await;
         assert!(
             matches!(result, Err(StreamingError::BackendEof { .. })),
             "EOF before terminator must be BackendEof"

--- a/tests/rfc4643/backend.rs
+++ b/tests/rfc4643/backend.rs
@@ -322,7 +322,8 @@ async fn test_buffer_pool_different_sizes() {
     for size in &sizes {
         let buffer_pool = BufferPool::new(BufferSize::try_new(*size).unwrap(), 1);
         let buffer = buffer_pool.acquire().await;
-        assert_eq!(buffer.capacity(), *size);
+        assert!(buffer.capacity() >= *size);
+        assert_eq!(buffer.capacity() % 4096, 0);
     }
 }
 


### PR DESCRIPTION
## Summary
- fully buffer direct per-command multiline backend responses before writing anything to the client
- reuse the existing capture-buffer machinery to drain and terminator-validate the whole response in memory first
- remove the earlier partial-stream-specific fallback logic from the direct per-command path

## Behavior change
This PR changes the direct per-command/hybrid non-stateful multiline path so it no longer forwards the first chunk immediately. Instead it:
1. reads the full backend response into a capture buffer
2. validates completion by reading through the NNTP multiline terminator
3. only then writes the buffered response to the client

That makes the implementation match the intended invariant for per-command responses: no partial multiline response reaches the client from this path.

## Scope
This affects the direct per-command multiline response path used when commands bypass the pipeline worker, including large-transfer `ARTICLE`/`BODY` retrievals. It does not change batch pipelining or fully stateful proxying.

## RFC audit
RFC 3977 defines ARTICLE/HEAD/BODY success responses as multiline blocks terminated by `CRLF . CRLF`. Buffering until the full block is present before forwarding is compliant and avoids exposing clients to partial response framing from upstream failures.

## Verification
- `cargo test buffer_multiline_response --lib`
- `cargo fmt --check`
- `cargo llvm-cov nextest --workspace --lcov --output-path lcov.info`
- `cargo clippy --all-targets --all-features -- -D warnings`