### PR TITLE
perf/owned chunk handoff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,3 +168,4 @@ strip = false
 [profile.bench]
 inherits = "release"
 debug = 2              # Full debuginfo so benchmark flamegraphs resolve symbols
+strip = false          # Keep symbols for addr2line/callgrind hotspot attribution

--- a/benches/cache_lookup.rs
+++ b/benches/cache_lookup.rs
@@ -194,10 +194,7 @@ mod availability_cache {
     use std::sync::atomic::{AtomicU64, Ordering};
 
     fn make_cache() -> Arc<UnifiedCache> {
-        Arc::new(UnifiedCache::availability(
-            1024 * 1024,
-            std::time::Duration::MAX,
-        ))
+        Arc::new(UnifiedCache::availability(std::time::Duration::MAX))
     }
 
     #[divan::bench(sample_count = 1000, sample_size = 1000)]

--- a/src/cache/availability_index.rs
+++ b/src/cache/availability_index.rs
@@ -3,7 +3,8 @@
 //! Stores negative-only backend availability using a rotating blocked fingerprint
 //! filter. The filter is bounded by `capacity_bytes`, favors throughput, and
 //! accepts occasional false negatives from rotation/overwrites. False positives
-//! are pushed down by storing a 64-bit keyed fingerprint per slot.
+//! are pushed down by storing a keyed 64-bit fingerprint plus a keyed 16-bit
+//! confirmation tag per slot.
 
 use super::{ArticleAvailability, CachedArticle, availability::MAX_BACKENDS, ttl};
 use crate::io_util::atomic_replace_file;
@@ -22,11 +23,12 @@ use twox_hash::XxHash64;
 const DEFAULT_GENERATIONS: usize = 2;
 const BLOCK_SLOTS: usize = 2;
 const FIXED_ARTICLE_CAPACITY: usize = 256 * 1024;
-const SLOT_BYTES: usize = size_of::<u64>() + size_of::<u8>();
+const SLOT_BYTES: usize = size_of::<u64>() + size_of::<u16>() + size_of::<u8>();
 const ALL_BACKEND_BITS: u8 = ((1u16 << MAX_BACKENDS) - 1) as u8;
-const PERSISTENCE_MAGIC: &[u8; 8] = b"ANEGSIM1";
+const PERSISTENCE_MAGIC: &[u8; 8] = b"ANEGSIM2";
 const LEGACY_PERSISTENCE_MAGIC_V1: &[u8; 8] = b"ANEGIDX1";
 const LEGACY_PERSISTENCE_MAGIC_V2: &[u8; 8] = b"ANEGIDX2";
+const LEGACY_PERSISTENCE_MAGIC_V3: &[u8; 8] = b"ANEGSIM1";
 
 static SAVE_LOCK: Mutex<()> = Mutex::new(());
 static SAVE_SEQ: AtomicU64 = AtomicU64::new(0);
@@ -34,6 +36,7 @@ static SAVE_SEQ: AtomicU64 = AtomicU64::new(0);
 #[derive(Clone, Copy, Debug, Default)]
 struct Block {
     hashes: [u64; BLOCK_SLOTS],
+    tags: [u16; BLOCK_SLOTS],
     missing: [u8; BLOCK_SLOTS],
 }
 
@@ -42,8 +45,8 @@ const FIXED_TOTAL_BLOCKS: usize = FIXED_ARTICLE_CAPACITY / BLOCK_SLOTS;
 const FIXED_CAPACITY_BYTES: u64 = (FIXED_TOTAL_BLOCKS * size_of::<Block>()) as u64;
 
 impl Block {
-    fn missing_bits(&self, hash: u64) -> u8 {
-        let mut matched = matching_slots(&self.hashes, hash);
+    fn missing_bits(&self, hash: u64, tag: u16) -> u8 {
+        let mut matched = matching_slots(&self.hashes, &self.tags, hash, tag);
         let mut missing_bits = 0u8;
 
         while matched != 0 {
@@ -55,10 +58,10 @@ impl Block {
         missing_bits
     }
 
-    fn insert(&mut self, hash: u64, missing_bits: u8, victim: usize) -> InsertOutcome {
+    fn insert(&mut self, hash: u64, tag: u16, missing_bits: u8, victim: usize) -> InsertOutcome {
         debug_assert_ne!(hash, 0, "fingerprint slots use 0 as the empty sentinel");
 
-        let existing = matching_slots(&self.hashes, hash);
+        let existing = matching_slots(&self.hashes, &self.tags, hash, tag);
         if existing != 0 {
             let slot = existing.trailing_zeros() as usize;
             self.missing[slot] |= missing_bits;
@@ -67,11 +70,13 @@ impl Block {
 
         if let Some(empty_slot) = self.hashes.iter().position(|&value| value == 0) {
             self.hashes[empty_slot] = hash;
+            self.tags[empty_slot] = tag;
             self.missing[empty_slot] = missing_bits;
             return InsertOutcome::Inserted;
         }
 
         self.hashes[victim] = hash;
+        self.tags[victim] = tag;
         self.missing[victim] = missing_bits;
         InsertOutcome::Replaced
     }
@@ -79,6 +84,7 @@ impl Block {
     fn clear(&mut self) -> usize {
         let occupied = self.hashes.iter().filter(|&&hash| hash != 0).count();
         self.hashes = [0; BLOCK_SLOTS];
+        self.tags = [0; BLOCK_SLOTS];
         self.missing = [0; BLOCK_SLOTS];
         occupied
     }
@@ -121,6 +127,7 @@ impl Generation {
 #[derive(Clone, Copy, Debug)]
 struct PersistedEntry {
     hash: u64,
+    tag: u16,
     missing: u8,
     inserted_at: u64,
 }
@@ -264,7 +271,13 @@ impl FilterState {
         evicted
     }
 
-    fn lookup_missing_bits(&mut self, hash: u64, block_index: usize, now: u64) -> LookupResult {
+    fn lookup_missing_bits(
+        &mut self,
+        hash: u64,
+        tag: u16,
+        block_index: usize,
+        now: u64,
+    ) -> LookupResult {
         let evicted = self.rotate_if_needed(now);
         if self.blocks_per_generation == 0 || self.generations.is_empty() {
             return LookupResult {
@@ -277,7 +290,7 @@ impl FilterState {
         let mut missing_bits = 0u8;
         for generation_index in self.active_generation_indices() {
             missing_bits |=
-                self.generations[generation_index].blocks[block_index].missing_bits(hash);
+                self.generations[generation_index].blocks[block_index].missing_bits(hash, tag);
             if missing_bits == ALL_BACKEND_BITS {
                 break;
             }
@@ -293,6 +306,7 @@ impl FilterState {
     fn insert_missing_bits(
         &mut self,
         hash: u64,
+        tag: u16,
         missing_bits: u8,
         block_index: usize,
         victim: usize,
@@ -312,7 +326,7 @@ impl FilterState {
         self.ensure_current_generation_started(now);
         let generation = &mut self.generations[self.current_generation];
         let block = &mut generation.blocks[block_index];
-        let outcome = block.insert(hash, missing_bits, victim);
+        let outcome = block.insert(hash, tag, missing_bits, victim);
         if matches!(outcome, InsertOutcome::Inserted) {
             generation.occupied += 1;
         }
@@ -368,7 +382,12 @@ impl FilterState {
         self.live_generations = self.live_generations.max(offset + 1);
 
         let block = &mut generation.blocks[block_index(entry.hash, self.blocks_per_generation)];
-        match block.insert(entry.hash, entry.missing, victim_slot(entry.hash)) {
+        match block.insert(
+            entry.hash,
+            entry.tag,
+            entry.missing,
+            victim_slot(entry.hash),
+        ) {
             InsertOutcome::Inserted => {
                 generation.occupied += 1;
                 0
@@ -394,6 +413,7 @@ impl FilterState {
                     }
                     entries.push(PersistedEntry {
                         hash,
+                        tag: block.tags[slot],
                         missing,
                         inserted_at: generation.started_at,
                     });
@@ -585,12 +605,15 @@ impl AvailabilityIndex {
                 .fetch_add(snapshot.evicted as u64, Ordering::Relaxed);
         }
 
-        let mut bytes =
-            Vec::with_capacity(16 + snapshot.entries.len() * (size_of::<u64>() * 2 + 1));
+        let mut bytes = Vec::with_capacity(
+            16 + snapshot.entries.len()
+                * (size_of::<u64>() + size_of::<u16>() + 1 + size_of::<u64>()),
+        );
         bytes.extend_from_slice(PERSISTENCE_MAGIC);
         bytes.extend_from_slice(&(snapshot.entries.len() as u64).to_le_bytes());
         for entry in snapshot.entries {
             bytes.extend_from_slice(&entry.hash.to_le_bytes());
+            bytes.extend_from_slice(&entry.tag.to_le_bytes());
             bytes.push(entry.missing);
             bytes.extend_from_slice(&entry.inserted_at.to_le_bytes());
         }
@@ -667,7 +690,7 @@ impl AvailabilityIndex {
             return None;
         }
 
-        let hash = hash_key(key.as_bytes());
+        let (hash, tag) = hash_key(key.as_bytes());
         let now = ttl::now_millis();
         let lookup = {
             let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
@@ -679,7 +702,7 @@ impl AvailabilityIndex {
                 }
             } else {
                 let block_index = block_index(hash, state.blocks_per_generation);
-                let mut lookup = state.lookup_missing_bits(hash, block_index, now);
+                let mut lookup = state.lookup_missing_bits(hash, tag, block_index, now);
                 lookup.empty_after = state.occupied_slots() == 0;
                 lookup
             }
@@ -706,7 +729,7 @@ impl AvailabilityIndex {
             return;
         }
 
-        let hash = hash_key(key.as_bytes());
+        let (hash, tag) = hash_key(key.as_bytes());
         let outcome = {
             let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
             if state.blocks_per_generation == 0 {
@@ -715,7 +738,7 @@ impl AvailabilityIndex {
                 let block_index = block_index(hash, state.blocks_per_generation);
                 let victim = victim_slot(hash);
                 let now = ttl::now_millis();
-                state.insert_missing_bits(hash, missing_bits, block_index, victim, now)
+                state.insert_missing_bits(hash, tag, missing_bits, block_index, victim, now)
             }
         };
 
@@ -738,7 +761,10 @@ fn parse_entries(data: &[u8]) -> Result<Vec<PersistedEntry>> {
     }
 
     let magic = &data[..PERSISTENCE_MAGIC.len()];
-    if magic == LEGACY_PERSISTENCE_MAGIC_V1 || magic == LEGACY_PERSISTENCE_MAGIC_V2 {
+    if magic == LEGACY_PERSISTENCE_MAGIC_V1
+        || magic == LEGACY_PERSISTENCE_MAGIC_V2
+        || magic == LEGACY_PERSISTENCE_MAGIC_V3
+    {
         return Ok(Vec::new());
     }
     if magic != PERSISTENCE_MAGIC {
@@ -751,6 +777,7 @@ fn parse_entries(data: &[u8]) -> Result<Vec<PersistedEntry>> {
 
     for _ in 0..entry_count {
         let hash = read_u64(data, &mut cursor)?;
+        let tag = read_u16(data, &mut cursor)?;
         let missing = *data
             .get(cursor)
             .ok_or_else(|| anyhow::anyhow!("truncated availability missing bits"))?;
@@ -758,6 +785,7 @@ fn parse_entries(data: &[u8]) -> Result<Vec<PersistedEntry>> {
         let inserted_at = read_u64(data, &mut cursor)?;
         entries.push(PersistedEntry {
             hash,
+            tag,
             missing,
             inserted_at,
         });
@@ -774,10 +802,25 @@ fn read_u64(data: &[u8], cursor: &mut usize) -> Result<u64> {
     Ok(u64::from_le_bytes(bytes.try_into().unwrap()))
 }
 
-fn hash_key(bytes: &[u8]) -> u64 {
-    let mut hasher = XxHash64::default();
-    hasher.write(bytes);
-    normalize_hash(hasher.finish())
+fn read_u16(data: &[u8], cursor: &mut usize) -> Result<u16> {
+    let bytes = data
+        .get(*cursor..*cursor + size_of::<u16>())
+        .ok_or_else(|| anyhow::anyhow!("truncated u16 field"))?;
+    *cursor += size_of::<u16>();
+    Ok(u16::from_le_bytes(bytes.try_into().unwrap()))
+}
+
+fn hash_key(bytes: &[u8]) -> (u64, u16) {
+    let mut primary = XxHash64::default();
+    primary.write(bytes);
+
+    let mut tag = XxHash64::with_seed(0x9E37_79B9_7F4A_7C15);
+    tag.write(bytes);
+
+    (
+        normalize_hash(primary.finish()),
+        (tag.finish() & u16::MAX as u64) as u16,
+    )
 }
 
 fn normalize_hash(hash: u64) -> u64 {
@@ -793,10 +836,15 @@ fn victim_slot(hash: u64) -> usize {
     ((hash >> 48) as usize) & (BLOCK_SLOTS - 1)
 }
 
-fn matching_slots(hashes: &[u64; BLOCK_SLOTS], needle: u64) -> SlotMatchMask {
+fn matching_slots(
+    hashes: &[u64; BLOCK_SLOTS],
+    tags: &[u16; BLOCK_SLOTS],
+    needle_hash: u64,
+    needle_tag: u16,
+) -> SlotMatchMask {
     let mut mask = 0;
     for (index, &value) in hashes.iter().enumerate() {
-        if value == needle {
+        if value == needle_hash && tags[index] == needle_tag {
             mask |= 1u8 << index;
         }
     }
@@ -817,6 +865,17 @@ mod tests {
         let index = AvailabilityIndex::with_test_capacity(test_capacity_for(16, 2));
         let msg_id = MessageId::from_borrowed("<miss@example.com>").unwrap();
         assert!(index.get(&msg_id).is_none());
+    }
+
+    #[test]
+    fn slot_match_requires_confirmation_tag() {
+        let mut block = Block::default();
+        block.hashes[0] = 42;
+        block.tags[0] = 7;
+        block.missing[0] = 0b0000_0001;
+
+        assert_eq!(block.missing_bits(42, 7), 0b0000_0001);
+        assert_eq!(block.missing_bits(42, 8), 0);
     }
 
     #[test]

--- a/src/cache/availability_index.rs
+++ b/src/cache/availability_index.rs
@@ -209,6 +209,21 @@ impl FilterState {
         };
     }
 
+    fn reanchor_current_generation(&mut self) {
+        let Some((index, _)) = self
+            .generations
+            .iter()
+            .enumerate()
+            .filter(|(_, generation)| generation.started_at != 0)
+            .max_by_key(|(_, generation)| generation.started_at)
+        else {
+            return;
+        };
+
+        self.current_generation = index;
+        self.refresh_next_rotation_at();
+    }
+
     fn rotate_if_needed(&mut self, now: u64) -> usize {
         if self.blocks_per_generation == 0 || self.generations.is_empty() {
             return 0;
@@ -530,7 +545,7 @@ impl AvailabilityIndex {
             evicted += state.restore_entry(entry, now, self.ttl);
         }
         if state.live_generations != 0 {
-            state.refresh_next_rotation_at();
+            state.reanchor_current_generation();
         }
         let has_entries = state.occupied_slots() != 0;
         drop(state);
@@ -1011,6 +1026,33 @@ mod tests {
         );
         assert!(restored.load_from_path(&path).unwrap());
         assert!(restored.get(&msg_id).is_none());
+    }
+
+    #[test]
+    fn load_from_path_keeps_older_generation_as_rotation_anchor() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("availability-older-generation.idx");
+        let index = AvailabilityIndex::with_capacity_and_generation_count(
+            test_capacity_for(8, 2),
+            std::time::Duration::from_millis(40),
+            DEFAULT_GENERATIONS,
+        );
+        let msg_id = MessageId::from_borrowed("<persisted-older@example.com>").unwrap();
+
+        index.record_backend_missing(&msg_id, BackendId::from_index(0));
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        index.save_to_path(&path).unwrap();
+
+        let restored = AvailabilityIndex::with_capacity_and_generation_count(
+            test_capacity_for(8, 2),
+            std::time::Duration::from_millis(40),
+            DEFAULT_GENERATIONS,
+        );
+        assert!(restored.load_from_path(&path).unwrap());
+        assert!(
+            restored.get(&msg_id).is_some(),
+            "restored older-generation entry should survive the first lookup"
+        );
     }
 
     #[test]

--- a/src/cache/availability_index.rs
+++ b/src/cache/availability_index.rs
@@ -9,6 +9,7 @@ use super::{ArticleAvailability, CachedArticle, ttl};
 use crate::io_util::atomic_replace_file;
 use crate::types::{BackendId, MessageId};
 use anyhow::{Context, Result};
+use smallvec::SmallVec;
 use std::fs;
 use std::mem::{size_of, take};
 use std::path::Path;
@@ -21,6 +22,8 @@ const DEFAULT_SHARDS: usize = 16;
 const SLOT_BUDGET_DIVISOR: usize = 3;
 const LOAD_FACTOR_NUM: usize = 85;
 const LOAD_FACTOR_DEN: usize = 100;
+const INLINE_SHARD_ENTRIES: usize = 4;
+const INLINE_KEY_BYTES: usize = 64;
 const PERSISTENCE_MAGIC: &[u8; 8] = b"ANEGIDX2";
 const LEGACY_PERSISTENCE_MAGIC: &[u8; 8] = b"ANEGIDX1";
 
@@ -52,21 +55,40 @@ struct PersistedEntry {
     inserted_at: u64,
 }
 
-#[derive(Debug)]
-struct Shard {
-    slots: Box<[Slot]>,
-    len: usize,
-    arena: Box<[u8]>,
-    arena_len: usize,
+#[derive(Clone, Debug)]
+struct TinyEntry {
+    hash: u64,
+    key: SmallVec<[u8; INLINE_KEY_BYTES]>,
+    missing: u8,
+    last_touch: u64,
+    inserted_at: u64,
 }
 
-impl Shard {
+impl TinyEntry {
+    fn new(hash: u64, key: &[u8], missing: u8, last_touch: u64, inserted_at: u64) -> Self {
+        Self {
+            hash,
+            key: SmallVec::from_slice(key),
+            missing,
+            last_touch,
+            inserted_at,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FullShard {
+    slots: Box<[Slot]>,
+    len: usize,
+    arena: Vec<u8>,
+}
+
+impl FullShard {
     fn new(slot_count: usize, arena_bytes: usize) -> Self {
         Self {
             slots: vec![Slot::default(); slot_count].into_boxed_slice(),
             len: 0,
-            arena: vec![0; arena_bytes].into_boxed_slice(),
-            arena_len: 0,
+            arena: Vec::with_capacity(arena_bytes),
         }
     }
 
@@ -116,43 +138,6 @@ impl Shard {
         Some(slot.missing)
     }
 
-    fn insert_missing(
-        &mut self,
-        hash: u64,
-        key: &[u8],
-        missing_bits: u8,
-        touch: u64,
-        inserted_at: u64,
-    ) -> usize {
-        if missing_bits == 0 || key.is_empty() {
-            return 0;
-        }
-
-        if let Some(existing) = self.lookup_slot_index(hash, key) {
-            let slot = &mut self.slots[existing];
-            slot.missing |= missing_bits;
-            slot.last_touch = touch;
-            slot.inserted_at = inserted_at;
-            return 0;
-        }
-
-        let Some(evicted) = self.ensure_space_for(key.len()) else {
-            return usize::MAX;
-        };
-
-        let new_slot = Slot {
-            hash,
-            offset: self.allocate_key_bytes(key),
-            len: key.len() as u16,
-            missing: missing_bits,
-            occupied: true,
-            last_touch: touch,
-            inserted_at,
-        };
-        debug_assert!(self.place_slot(new_slot));
-        evicted
-    }
-
     fn restore_entry(
         &mut self,
         hash: u64,
@@ -190,10 +175,8 @@ impl Shard {
     }
 
     fn allocate_key_bytes(&mut self, key: &[u8]) -> u32 {
-        let offset = self.arena_len;
-        let end = offset + key.len();
-        self.arena[offset..end].copy_from_slice(key);
-        self.arena_len = end;
+        let offset = self.arena.len();
+        self.arena.extend_from_slice(key);
         offset as u32
     }
 
@@ -228,21 +211,21 @@ impl Shard {
     fn ensure_space_for(&mut self, required_key_len: usize) -> Option<usize> {
         if self.slots.is_empty()
             || required_key_len == 0
-            || required_key_len > self.arena.len()
+            || required_key_len > self.arena.capacity()
             || required_key_len > u16::MAX as usize
         {
             return None;
         }
 
         let mut evicted = 0usize;
-        while (!self.can_insert() || self.arena_len + required_key_len > self.arena.len())
+        while (!self.can_insert() || self.arena.len() + required_key_len > self.arena.capacity())
             && self.len > 0
         {
             self.evict_lru()?;
             evicted += 1;
         }
 
-        if self.can_insert() && self.arena_len + required_key_len <= self.arena.len() {
+        if self.can_insert() && self.arena.len() + required_key_len <= self.arena.capacity() {
             Some(evicted)
         } else {
             None
@@ -262,12 +245,10 @@ impl Shard {
     }
 
     fn rebuild_excluding(&mut self, victim_idx: usize) {
-        let slot_count = self.slots.len();
-        let arena_bytes = self.arena.len();
         let old_slots = take(&mut self.slots);
         let old_arena = take(&mut self.arena);
 
-        let mut rebuilt = Shard::new(slot_count, arena_bytes);
+        let mut rebuilt = FullShard::new(old_slots.len(), old_arena.capacity());
         for (idx, slot) in old_slots.iter().copied().enumerate() {
             if idx == victim_idx || slot.is_empty() {
                 continue;
@@ -318,9 +299,267 @@ impl Shard {
             }
         }
     }
+}
+
+// Keep Tiny inline so untouched and low-cardinality shards avoid any heap allocation.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug)]
+enum ShardStorage {
+    Tiny(SmallVec<[TinyEntry; INLINE_SHARD_ENTRIES]>),
+    Full(Box<FullShard>),
+}
+
+#[derive(Debug)]
+struct Shard {
+    slot_capacity: usize,
+    arena_capacity: usize,
+    storage: ShardStorage,
+}
+
+impl Shard {
+    fn new(slot_count: usize, arena_bytes: usize) -> Self {
+        Self {
+            slot_capacity: slot_count,
+            arena_capacity: arena_bytes,
+            storage: ShardStorage::Tiny(SmallVec::new()),
+        }
+    }
+
+    fn len(&self) -> usize {
+        match &self.storage {
+            ShardStorage::Tiny(entries) => entries.len(),
+            ShardStorage::Full(full) => full.len,
+        }
+    }
+
+    fn used_bytes(&self) -> usize {
+        match &self.storage {
+            ShardStorage::Tiny(entries) => entries.len() * size_of::<TinyEntry>(),
+            ShardStorage::Full(full) => full.slots.len() * size_of::<Slot>() + full.arena.len(),
+        }
+    }
+
+    fn tiny_key_bytes(entries: &[TinyEntry]) -> usize {
+        entries.iter().map(|entry| entry.key.len()).sum()
+    }
+
+    fn tiny_lookup_index(entries: &[TinyEntry], hash: u64, key: &[u8]) -> Option<usize> {
+        entries
+            .iter()
+            .position(|entry| entry.hash == hash && entry.key.as_slice() == key)
+    }
+
+    fn tiny_can_insert(
+        slot_capacity: usize,
+        arena_capacity: usize,
+        entries: &[TinyEntry],
+        key: &[u8],
+    ) -> bool {
+        key.len() <= INLINE_KEY_BYTES
+            && key.len() <= u16::MAX as usize
+            && entries.len()
+                < if slot_capacity == 0 || arena_capacity == 0 {
+                    0
+                } else {
+                    INLINE_SHARD_ENTRIES
+                        .min((slot_capacity * LOAD_FACTOR_NUM / LOAD_FACTOR_DEN).max(1))
+                }
+            && Self::tiny_key_bytes(entries) + key.len() <= arena_capacity
+    }
+
+    fn promote_to_full(&mut self) {
+        let old_storage = std::mem::replace(&mut self.storage, ShardStorage::Tiny(SmallVec::new()));
+        let ShardStorage::Tiny(entries) = old_storage else {
+            return;
+        };
+
+        let mut full = FullShard::new(self.slot_capacity, self.arena_capacity);
+        for entry in entries {
+            let inserted = full.restore_entry(
+                entry.hash,
+                entry.key.as_slice(),
+                entry.missing,
+                entry.last_touch,
+                entry.inserted_at,
+            );
+            debug_assert!(
+                inserted,
+                "promoting tiny shard entries should preserve exact negatives"
+            );
+        }
+        self.storage = ShardStorage::Full(Box::new(full));
+    }
+
+    fn lookup_missing(
+        &mut self,
+        hash: u64,
+        key: &[u8],
+        touch: u64,
+        base_ttl: ttl::CacheTtlMillis,
+    ) -> Option<u8> {
+        match &mut self.storage {
+            ShardStorage::Tiny(entries) => {
+                let index = Self::tiny_lookup_index(entries, hash, key)?;
+                if ttl::is_expired(
+                    ttl::CacheTimestampMillis::new(entries[index].inserted_at),
+                    base_ttl,
+                    ttl::CacheTier::new(0),
+                ) {
+                    entries.swap_remove(index);
+                    return None;
+                }
+                entries[index].last_touch = touch;
+                Some(entries[index].missing)
+            }
+            ShardStorage::Full(full) => full.lookup_missing(hash, key, touch, base_ttl),
+        }
+    }
+
+    fn insert_missing(
+        &mut self,
+        hash: u64,
+        key: &[u8],
+        missing_bits: u8,
+        touch: u64,
+        inserted_at: u64,
+    ) -> usize {
+        if missing_bits == 0 || key.is_empty() || key.len() > u16::MAX as usize {
+            return 0;
+        }
+
+        loop {
+            match &mut self.storage {
+                ShardStorage::Tiny(entries) => {
+                    if let Some(existing) = Self::tiny_lookup_index(entries, hash, key) {
+                        let entry = &mut entries[existing];
+                        entry.missing |= missing_bits;
+                        entry.last_touch = touch;
+                        entry.inserted_at = inserted_at;
+                        return 0;
+                    }
+
+                    if Self::tiny_can_insert(self.slot_capacity, self.arena_capacity, entries, key)
+                    {
+                        entries.push(TinyEntry::new(hash, key, missing_bits, touch, inserted_at));
+                        return 0;
+                    }
+
+                    self.promote_to_full();
+                }
+                ShardStorage::Full(full) => {
+                    if let Some(existing) = full.lookup_slot_index(hash, key) {
+                        let slot = &mut full.slots[existing];
+                        slot.missing |= missing_bits;
+                        slot.last_touch = touch;
+                        slot.inserted_at = inserted_at;
+                        return 0;
+                    }
+
+                    let Some(evicted) = full.ensure_space_for(key.len()) else {
+                        return usize::MAX;
+                    };
+
+                    let new_slot = Slot {
+                        hash,
+                        offset: full.allocate_key_bytes(key),
+                        len: key.len() as u16,
+                        missing: missing_bits,
+                        occupied: true,
+                        last_touch: touch,
+                        inserted_at,
+                    };
+                    debug_assert!(full.place_slot(new_slot));
+                    return evicted;
+                }
+            }
+        }
+    }
+
+    fn restore_entry(
+        &mut self,
+        hash: u64,
+        key: &[u8],
+        missing_bits: u8,
+        last_touch: u64,
+        inserted_at: u64,
+    ) -> bool {
+        if missing_bits == 0 || key.is_empty() || key.len() > u16::MAX as usize {
+            return true;
+        }
+
+        loop {
+            match &mut self.storage {
+                ShardStorage::Tiny(entries) => {
+                    if let Some(existing) = Self::tiny_lookup_index(entries, hash, key) {
+                        let entry = &mut entries[existing];
+                        entry.missing |= missing_bits;
+                        entry.last_touch = entry.last_touch.max(last_touch);
+                        entry.inserted_at = entry.inserted_at.max(inserted_at);
+                        return true;
+                    }
+
+                    if Self::tiny_can_insert(self.slot_capacity, self.arena_capacity, entries, key)
+                    {
+                        entries.push(TinyEntry::new(
+                            hash,
+                            key,
+                            missing_bits,
+                            last_touch,
+                            inserted_at,
+                        ));
+                        return true;
+                    }
+
+                    self.promote_to_full();
+                }
+                ShardStorage::Full(full) => {
+                    return full.restore_entry(hash, key, missing_bits, last_touch, inserted_at);
+                }
+            }
+        }
+    }
 
     fn clear(&mut self) {
-        *self = Shard::new(self.slots.len(), self.arena.len());
+        self.storage = ShardStorage::Tiny(SmallVec::new());
+    }
+
+    fn snapshot_entries(&self, out: &mut Vec<PersistedEntry>) {
+        match &self.storage {
+            ShardStorage::Tiny(entries) => {
+                out.extend(entries.iter().map(|entry| PersistedEntry {
+                    key: entry.key.to_vec(),
+                    missing: entry.missing,
+                    last_touch: entry.last_touch,
+                    inserted_at: entry.inserted_at,
+                }));
+            }
+            ShardStorage::Full(full) => {
+                out.extend(
+                    full.slots
+                        .iter()
+                        .copied()
+                        .filter(|slot| slot.occupied)
+                        .filter_map(|slot| {
+                            full.entry_bytes(slot).map(|key| PersistedEntry {
+                                key: key.to_vec(),
+                                missing: slot.missing,
+                                last_touch: slot.last_touch,
+                                inserted_at: slot.inserted_at,
+                            })
+                        }),
+                );
+            }
+        }
+    }
+
+    #[cfg(test)]
+    fn is_tiny(&self) -> bool {
+        matches!(self.storage, ShardStorage::Tiny(_))
+    }
+
+    #[cfg(test)]
+    fn is_full(&self) -> bool {
+        matches!(self.storage, ShardStorage::Full(_))
     }
 }
 
@@ -513,7 +752,7 @@ impl AvailabilityIndex {
     pub fn entry_count(&self) -> u64 {
         self.shards
             .iter()
-            .map(|shard| shard.lock().unwrap_or_else(|e| e.into_inner()).len as u64)
+            .map(|shard| shard.lock().unwrap_or_else(|e| e.into_inner()).len() as u64)
             .sum()
     }
 
@@ -523,7 +762,7 @@ impl AvailabilityIndex {
             .iter()
             .map(|shard| {
                 let shard = shard.lock().unwrap_or_else(|e| e.into_inner());
-                (shard.slots.len() * size_of::<Slot>() + shard.arena_len) as u64
+                shard.used_bytes() as u64
             })
             .sum()
     }
@@ -620,20 +859,9 @@ impl AvailabilityIndex {
         let mut entries = Vec::with_capacity(self.entry_count() as usize);
         for shard in &self.shards {
             let shard = shard.lock().unwrap_or_else(|e| e.into_inner());
-            for slot in shard.slots.iter().copied().filter(|slot| slot.occupied) {
-                if self.is_expired(slot.inserted_at) {
-                    continue;
-                }
-                if let Some(key) = shard.entry_bytes(slot) {
-                    entries.push(PersistedEntry {
-                        key: key.to_vec(),
-                        missing: slot.missing,
-                        last_touch: slot.last_touch,
-                        inserted_at: slot.inserted_at,
-                    });
-                }
-            }
+            shard.snapshot_entries(&mut entries);
         }
+        entries.retain(|entry| !self.is_expired(entry.inserted_at));
         entries
     }
 
@@ -815,6 +1043,74 @@ mod tests {
     }
 
     #[test]
+    fn shards_start_in_tiny_mode() {
+        let index = AvailabilityIndex::with_shard_count(4096, 4);
+        for shard in &index.shards {
+            let shard = shard.lock().unwrap_or_else(|e| e.into_inner());
+            assert!(shard.is_tiny());
+            assert_eq!(shard.len(), 0);
+            assert_eq!(shard.used_bytes(), 0);
+        }
+    }
+
+    #[test]
+    fn single_negative_entry_stays_in_tiny_mode() {
+        let index = AvailabilityIndex::with_shard_count(4096, 1);
+        let msg_id = MessageId::from_borrowed("<tiny@example.com>").unwrap();
+
+        index.record_backend_missing(&msg_id, BackendId::from_index(0));
+
+        let shard = index.shards[0].lock().unwrap_or_else(|e| e.into_inner());
+        assert!(shard.is_tiny());
+        assert_eq!(shard.len(), 1);
+    }
+
+    #[test]
+    fn shard_promotes_to_full_after_inline_capacity() {
+        let index = AvailabilityIndex::with_shard_count(4096, 1);
+
+        for idx in 0..=INLINE_SHARD_ENTRIES {
+            let msg_id = MessageId::new(format!("<promote-{idx}@example.com>")).unwrap();
+            index.record_backend_missing(&msg_id, BackendId::from_index(idx % 4));
+        }
+
+        let shard = index.shards[0].lock().unwrap_or_else(|e| e.into_inner());
+        assert!(shard.is_full());
+        assert_eq!(shard.len(), INLINE_SHARD_ENTRIES + 1);
+    }
+
+    #[test]
+    fn promotion_preserves_existing_entries() {
+        let index = AvailabilityIndex::with_shard_count(4096, 1);
+        let first = MessageId::from_borrowed("<first-promote@example.com>").unwrap();
+        let second = MessageId::from_borrowed("<second-promote@example.com>").unwrap();
+
+        index.record_backend_missing(&first, BackendId::from_index(0));
+        index.record_backend_missing(&second, BackendId::from_index(1));
+        for idx in 2..=INLINE_SHARD_ENTRIES {
+            let msg_id = MessageId::new(format!("<fill-{idx}@example.com>")).unwrap();
+            index.record_backend_missing(&msg_id, BackendId::from_index(idx % 4));
+        }
+        let trigger = MessageId::from_borrowed("<promote-trigger@example.com>").unwrap();
+        index.record_backend_missing(&trigger, BackendId::from_index(3));
+
+        assert!(
+            !index
+                .get(&first)
+                .unwrap()
+                .should_try_backend(BackendId::from_index(0))
+        );
+        assert!(
+            !index
+                .get(&second)
+                .unwrap()
+                .should_try_backend(BackendId::from_index(1))
+        );
+        let shard = index.shards[0].lock().unwrap_or_else(|e| e.into_inner());
+        assert!(shard.is_full());
+    }
+
+    #[test]
     fn lru_eviction_keeps_newer_entry() {
         let index = AvailabilityIndex::with_shard_count(320, 1);
         let older = MessageId::from_borrowed("<older@example.com>").unwrap();
@@ -864,6 +1160,32 @@ mod tests {
                 .expect("restored second entry")
                 .should_try_backend(BackendId::from_index(2))
         );
+    }
+
+    #[test]
+    fn save_and_load_roundtrip_restores_promoted_shard_entries() {
+        let temp_dir = TempDir::new().unwrap();
+        let path = temp_dir.path().join("availability-promoted.idx");
+        let index = AvailabilityIndex::with_shard_count(4096, 1);
+
+        for idx in 0..=INLINE_SHARD_ENTRIES {
+            let msg_id = MessageId::new(format!("<persist-promote-{idx}@example.com>")).unwrap();
+            index.record_backend_missing(&msg_id, BackendId::from_index(idx % 4));
+        }
+        index.save_to_path(&path).unwrap();
+
+        let restored = AvailabilityIndex::with_shard_count(4096, 1);
+        assert!(restored.load_from_path(&path).unwrap());
+
+        for idx in 0..=INLINE_SHARD_ENTRIES {
+            let msg_id = MessageId::new(format!("<persist-promote-{idx}@example.com>")).unwrap();
+            assert!(
+                restored.get(&msg_id).is_some(),
+                "missing restored entry {idx}"
+            );
+        }
+        let shard = restored.shards[0].lock().unwrap_or_else(|e| e.into_inner());
+        assert!(shard.is_full());
     }
 
     #[test]

--- a/src/cache/availability_index.rs
+++ b/src/cache/availability_index.rs
@@ -23,7 +23,6 @@ use twox_hash::XxHash64;
 const DEFAULT_GENERATIONS: usize = 2;
 const BLOCK_SLOTS: usize = 2;
 const FIXED_ARTICLE_CAPACITY: usize = 256 * 1024;
-const SLOT_BYTES: usize = size_of::<u64>() + size_of::<u16>() + size_of::<u8>();
 const ALL_BACKEND_BITS: u8 = ((1u16 << MAX_BACKENDS) - 1) as u8;
 const PERSISTENCE_MAGIC: &[u8; 8] = b"ANEGSIM2";
 const LEGACY_PERSISTENCE_MAGIC_V1: &[u8; 8] = b"ANEGIDX1";
@@ -258,12 +257,10 @@ impl FilterState {
         let rotations = (1 + ((now.saturating_sub(self.next_rotation_at)) / interval) as usize)
             .min(self.generations.len());
         let mut evicted = 0usize;
-        for step in 0..rotations {
+        for _ in 0..rotations {
             self.current_generation = (self.current_generation + 1) % self.generations.len();
             let generation = &mut self.generations[self.current_generation];
             evicted += generation.clear();
-            generation.started_at =
-                scheduled_at.saturating_add((step as u64).saturating_mul(interval));
         }
         self.live_generations = (self.live_generations + rotations).min(self.generations.len());
         self.next_rotation_at =
@@ -465,6 +462,11 @@ impl Default for AvailabilityIndex {
 
 impl AvailabilityIndex {
     #[must_use]
+    pub const fn fixed_capacity_bytes() -> u64 {
+        FIXED_CAPACITY_BYTES
+    }
+
+    #[must_use]
     pub fn new() -> Self {
         Self::with_ttl(Duration::MAX)
     }
@@ -472,6 +474,11 @@ impl AvailabilityIndex {
     #[must_use]
     pub fn with_ttl(ttl: Duration) -> Self {
         Self::with_capacity_and_generation_count(FIXED_CAPACITY_BYTES, ttl, DEFAULT_GENERATIONS)
+    }
+
+    #[must_use]
+    pub(crate) fn disabled(ttl: Duration) -> Self {
+        Self::with_capacity_and_generation_count(0, ttl, DEFAULT_GENERATIONS)
     }
 
     #[must_use]
@@ -664,7 +671,7 @@ impl AvailabilityIndex {
 
     #[must_use]
     pub fn used_bytes(&self) -> u64 {
-        self.entry_count().saturating_mul(SLOT_BYTES as u64)
+        self.capacity_bytes
     }
 
     #[must_use]
@@ -989,7 +996,21 @@ mod tests {
         }
 
         assert!(index.used_bytes() <= capacity);
-        assert!(index.entry_count() <= (capacity as usize / SLOT_BYTES) as u64);
+        let slot_bytes = size_of::<u64>() + size_of::<u16>() + size_of::<u8>();
+        assert!(index.entry_count() <= (capacity as usize / slot_bytes) as u64);
+    }
+
+    #[test]
+    fn used_bytes_reports_preallocated_capacity() {
+        let capacity = test_capacity_for(4, 2);
+        let index = AvailabilityIndex::with_test_capacity(capacity);
+        let msg_id = MessageId::from_borrowed("<allocated@example.com>").unwrap();
+
+        assert_eq!(index.used_bytes(), capacity);
+
+        index.record_backend_missing(&msg_id, BackendId::from_index(0));
+
+        assert_eq!(index.used_bytes(), capacity);
     }
 
     #[test]
@@ -1111,6 +1132,38 @@ mod tests {
         assert!(
             restored.get(&msg_id).is_some(),
             "restored older-generation entry should survive the first lookup"
+        );
+    }
+
+    #[test]
+    fn rotated_generation_starts_when_it_receives_a_new_insert() {
+        let index = AvailabilityIndex::with_capacity_and_generation_count(
+            test_capacity_for(8, 2),
+            std::time::Duration::from_millis(40),
+            DEFAULT_GENERATIONS,
+        );
+        let first = MessageId::from_borrowed("<before-rotate@example.com>").unwrap();
+        let second = MessageId::from_borrowed("<after-rotate@example.com>").unwrap();
+
+        index.record_backend_missing(&first, BackendId::from_index(0));
+        let initial_started_at = {
+            let state = index.state.lock().unwrap_or_else(|e| e.into_inner());
+            state.generations[state.current_generation].started_at
+        };
+
+        std::thread::sleep(std::time::Duration::from_millis(25));
+        let before_second_insert = ttl::now_millis();
+        index.record_backend_missing(&second, BackendId::from_index(1));
+
+        let state = index.state.lock().unwrap_or_else(|e| e.into_inner());
+        let current_generation = &state.generations[state.current_generation];
+        assert!(
+            current_generation.started_at >= before_second_insert,
+            "rotated generation should start when the new insert arrives"
+        );
+        assert!(
+            current_generation.started_at > initial_started_at,
+            "rotated generation should not keep the historical rotation timestamp"
         );
     }
 

--- a/src/cache/availability_index.rs
+++ b/src/cache/availability_index.rs
@@ -9,7 +9,6 @@ use super::{ArticleAvailability, CachedArticle, ttl};
 use crate::io_util::atomic_replace_file;
 use crate::types::{BackendId, MessageId};
 use anyhow::{Context, Result};
-use smallvec::SmallVec;
 use std::fs;
 use std::mem::{size_of, take};
 use std::path::Path;
@@ -22,8 +21,6 @@ const DEFAULT_SHARDS: usize = 16;
 const SLOT_BUDGET_DIVISOR: usize = 3;
 const LOAD_FACTOR_NUM: usize = 85;
 const LOAD_FACTOR_DEN: usize = 100;
-const INLINE_SHARD_ENTRIES: usize = 4;
-const INLINE_KEY_BYTES: usize = 64;
 const PERSISTENCE_MAGIC: &[u8; 8] = b"ANEGIDX2";
 const LEGACY_PERSISTENCE_MAGIC: &[u8; 8] = b"ANEGIDX1";
 
@@ -55,40 +52,21 @@ struct PersistedEntry {
     inserted_at: u64,
 }
 
-#[derive(Clone, Debug)]
-struct TinyEntry {
-    hash: u64,
-    key: SmallVec<[u8; INLINE_KEY_BYTES]>,
-    missing: u8,
-    last_touch: u64,
-    inserted_at: u64,
-}
-
-impl TinyEntry {
-    fn new(hash: u64, key: &[u8], missing: u8, last_touch: u64, inserted_at: u64) -> Self {
-        Self {
-            hash,
-            key: SmallVec::from_slice(key),
-            missing,
-            last_touch,
-            inserted_at,
-        }
-    }
-}
-
 #[derive(Debug)]
-struct FullShard {
+struct Shard {
     slots: Box<[Slot]>,
     len: usize,
-    arena: Vec<u8>,
+    arena: Box<[u8]>,
+    arena_len: usize,
 }
 
-impl FullShard {
+impl Shard {
     fn new(slot_count: usize, arena_bytes: usize) -> Self {
         Self {
             slots: vec![Slot::default(); slot_count].into_boxed_slice(),
             len: 0,
-            arena: Vec::with_capacity(arena_bytes),
+            arena: vec![0; arena_bytes].into_boxed_slice(),
+            arena_len: 0,
         }
     }
 
@@ -138,6 +116,43 @@ impl FullShard {
         Some(slot.missing)
     }
 
+    fn insert_missing(
+        &mut self,
+        hash: u64,
+        key: &[u8],
+        missing_bits: u8,
+        touch: u64,
+        inserted_at: u64,
+    ) -> usize {
+        if missing_bits == 0 || key.is_empty() {
+            return 0;
+        }
+
+        if let Some(existing) = self.lookup_slot_index(hash, key) {
+            let slot = &mut self.slots[existing];
+            slot.missing |= missing_bits;
+            slot.last_touch = touch;
+            slot.inserted_at = inserted_at;
+            return 0;
+        }
+
+        let Some(evicted) = self.ensure_space_for(key.len()) else {
+            return usize::MAX;
+        };
+
+        let new_slot = Slot {
+            hash,
+            offset: self.allocate_key_bytes(key),
+            len: key.len() as u16,
+            missing: missing_bits,
+            occupied: true,
+            last_touch: touch,
+            inserted_at,
+        };
+        debug_assert!(self.place_slot(new_slot));
+        evicted
+    }
+
     fn restore_entry(
         &mut self,
         hash: u64,
@@ -175,8 +190,10 @@ impl FullShard {
     }
 
     fn allocate_key_bytes(&mut self, key: &[u8]) -> u32 {
-        let offset = self.arena.len();
-        self.arena.extend_from_slice(key);
+        let offset = self.arena_len;
+        let end = offset + key.len();
+        self.arena[offset..end].copy_from_slice(key);
+        self.arena_len = end;
         offset as u32
     }
 
@@ -211,21 +228,21 @@ impl FullShard {
     fn ensure_space_for(&mut self, required_key_len: usize) -> Option<usize> {
         if self.slots.is_empty()
             || required_key_len == 0
-            || required_key_len > self.arena.capacity()
+            || required_key_len > self.arena.len()
             || required_key_len > u16::MAX as usize
         {
             return None;
         }
 
         let mut evicted = 0usize;
-        while (!self.can_insert() || self.arena.len() + required_key_len > self.arena.capacity())
+        while (!self.can_insert() || self.arena_len + required_key_len > self.arena.len())
             && self.len > 0
         {
             self.evict_lru()?;
             evicted += 1;
         }
 
-        if self.can_insert() && self.arena.len() + required_key_len <= self.arena.capacity() {
+        if self.can_insert() && self.arena_len + required_key_len <= self.arena.len() {
             Some(evicted)
         } else {
             None
@@ -245,10 +262,12 @@ impl FullShard {
     }
 
     fn rebuild_excluding(&mut self, victim_idx: usize) {
+        let slot_count = self.slots.len();
+        let arena_bytes = self.arena.len();
         let old_slots = take(&mut self.slots);
         let old_arena = take(&mut self.arena);
 
-        let mut rebuilt = FullShard::new(old_slots.len(), old_arena.capacity());
+        let mut rebuilt = Shard::new(slot_count, arena_bytes);
         for (idx, slot) in old_slots.iter().copied().enumerate() {
             if idx == victim_idx || slot.is_empty() {
                 continue;
@@ -299,267 +318,9 @@ impl FullShard {
             }
         }
     }
-}
-
-// Keep Tiny inline so untouched and low-cardinality shards avoid any heap allocation.
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
-enum ShardStorage {
-    Tiny(SmallVec<[TinyEntry; INLINE_SHARD_ENTRIES]>),
-    Full(Box<FullShard>),
-}
-
-#[derive(Debug)]
-struct Shard {
-    slot_capacity: usize,
-    arena_capacity: usize,
-    storage: ShardStorage,
-}
-
-impl Shard {
-    fn new(slot_count: usize, arena_bytes: usize) -> Self {
-        Self {
-            slot_capacity: slot_count,
-            arena_capacity: arena_bytes,
-            storage: ShardStorage::Tiny(SmallVec::new()),
-        }
-    }
-
-    fn len(&self) -> usize {
-        match &self.storage {
-            ShardStorage::Tiny(entries) => entries.len(),
-            ShardStorage::Full(full) => full.len,
-        }
-    }
-
-    fn used_bytes(&self) -> usize {
-        match &self.storage {
-            ShardStorage::Tiny(entries) => entries.len() * size_of::<TinyEntry>(),
-            ShardStorage::Full(full) => full.slots.len() * size_of::<Slot>() + full.arena.len(),
-        }
-    }
-
-    fn tiny_key_bytes(entries: &[TinyEntry]) -> usize {
-        entries.iter().map(|entry| entry.key.len()).sum()
-    }
-
-    fn tiny_lookup_index(entries: &[TinyEntry], hash: u64, key: &[u8]) -> Option<usize> {
-        entries
-            .iter()
-            .position(|entry| entry.hash == hash && entry.key.as_slice() == key)
-    }
-
-    fn tiny_can_insert(
-        slot_capacity: usize,
-        arena_capacity: usize,
-        entries: &[TinyEntry],
-        key: &[u8],
-    ) -> bool {
-        key.len() <= INLINE_KEY_BYTES
-            && key.len() <= u16::MAX as usize
-            && entries.len()
-                < if slot_capacity == 0 || arena_capacity == 0 {
-                    0
-                } else {
-                    INLINE_SHARD_ENTRIES
-                        .min((slot_capacity * LOAD_FACTOR_NUM / LOAD_FACTOR_DEN).max(1))
-                }
-            && Self::tiny_key_bytes(entries) + key.len() <= arena_capacity
-    }
-
-    fn promote_to_full(&mut self) {
-        let old_storage = std::mem::replace(&mut self.storage, ShardStorage::Tiny(SmallVec::new()));
-        let ShardStorage::Tiny(entries) = old_storage else {
-            return;
-        };
-
-        let mut full = FullShard::new(self.slot_capacity, self.arena_capacity);
-        for entry in entries {
-            let inserted = full.restore_entry(
-                entry.hash,
-                entry.key.as_slice(),
-                entry.missing,
-                entry.last_touch,
-                entry.inserted_at,
-            );
-            debug_assert!(
-                inserted,
-                "promoting tiny shard entries should preserve exact negatives"
-            );
-        }
-        self.storage = ShardStorage::Full(Box::new(full));
-    }
-
-    fn lookup_missing(
-        &mut self,
-        hash: u64,
-        key: &[u8],
-        touch: u64,
-        base_ttl: ttl::CacheTtlMillis,
-    ) -> Option<u8> {
-        match &mut self.storage {
-            ShardStorage::Tiny(entries) => {
-                let index = Self::tiny_lookup_index(entries, hash, key)?;
-                if ttl::is_expired(
-                    ttl::CacheTimestampMillis::new(entries[index].inserted_at),
-                    base_ttl,
-                    ttl::CacheTier::new(0),
-                ) {
-                    entries.swap_remove(index);
-                    return None;
-                }
-                entries[index].last_touch = touch;
-                Some(entries[index].missing)
-            }
-            ShardStorage::Full(full) => full.lookup_missing(hash, key, touch, base_ttl),
-        }
-    }
-
-    fn insert_missing(
-        &mut self,
-        hash: u64,
-        key: &[u8],
-        missing_bits: u8,
-        touch: u64,
-        inserted_at: u64,
-    ) -> usize {
-        if missing_bits == 0 || key.is_empty() || key.len() > u16::MAX as usize {
-            return 0;
-        }
-
-        loop {
-            match &mut self.storage {
-                ShardStorage::Tiny(entries) => {
-                    if let Some(existing) = Self::tiny_lookup_index(entries, hash, key) {
-                        let entry = &mut entries[existing];
-                        entry.missing |= missing_bits;
-                        entry.last_touch = touch;
-                        entry.inserted_at = inserted_at;
-                        return 0;
-                    }
-
-                    if Self::tiny_can_insert(self.slot_capacity, self.arena_capacity, entries, key)
-                    {
-                        entries.push(TinyEntry::new(hash, key, missing_bits, touch, inserted_at));
-                        return 0;
-                    }
-
-                    self.promote_to_full();
-                }
-                ShardStorage::Full(full) => {
-                    if let Some(existing) = full.lookup_slot_index(hash, key) {
-                        let slot = &mut full.slots[existing];
-                        slot.missing |= missing_bits;
-                        slot.last_touch = touch;
-                        slot.inserted_at = inserted_at;
-                        return 0;
-                    }
-
-                    let Some(evicted) = full.ensure_space_for(key.len()) else {
-                        return usize::MAX;
-                    };
-
-                    let new_slot = Slot {
-                        hash,
-                        offset: full.allocate_key_bytes(key),
-                        len: key.len() as u16,
-                        missing: missing_bits,
-                        occupied: true,
-                        last_touch: touch,
-                        inserted_at,
-                    };
-                    debug_assert!(full.place_slot(new_slot));
-                    return evicted;
-                }
-            }
-        }
-    }
-
-    fn restore_entry(
-        &mut self,
-        hash: u64,
-        key: &[u8],
-        missing_bits: u8,
-        last_touch: u64,
-        inserted_at: u64,
-    ) -> bool {
-        if missing_bits == 0 || key.is_empty() || key.len() > u16::MAX as usize {
-            return true;
-        }
-
-        loop {
-            match &mut self.storage {
-                ShardStorage::Tiny(entries) => {
-                    if let Some(existing) = Self::tiny_lookup_index(entries, hash, key) {
-                        let entry = &mut entries[existing];
-                        entry.missing |= missing_bits;
-                        entry.last_touch = entry.last_touch.max(last_touch);
-                        entry.inserted_at = entry.inserted_at.max(inserted_at);
-                        return true;
-                    }
-
-                    if Self::tiny_can_insert(self.slot_capacity, self.arena_capacity, entries, key)
-                    {
-                        entries.push(TinyEntry::new(
-                            hash,
-                            key,
-                            missing_bits,
-                            last_touch,
-                            inserted_at,
-                        ));
-                        return true;
-                    }
-
-                    self.promote_to_full();
-                }
-                ShardStorage::Full(full) => {
-                    return full.restore_entry(hash, key, missing_bits, last_touch, inserted_at);
-                }
-            }
-        }
-    }
 
     fn clear(&mut self) {
-        self.storage = ShardStorage::Tiny(SmallVec::new());
-    }
-
-    fn snapshot_entries(&self, out: &mut Vec<PersistedEntry>) {
-        match &self.storage {
-            ShardStorage::Tiny(entries) => {
-                out.extend(entries.iter().map(|entry| PersistedEntry {
-                    key: entry.key.to_vec(),
-                    missing: entry.missing,
-                    last_touch: entry.last_touch,
-                    inserted_at: entry.inserted_at,
-                }));
-            }
-            ShardStorage::Full(full) => {
-                out.extend(
-                    full.slots
-                        .iter()
-                        .copied()
-                        .filter(|slot| slot.occupied)
-                        .filter_map(|slot| {
-                            full.entry_bytes(slot).map(|key| PersistedEntry {
-                                key: key.to_vec(),
-                                missing: slot.missing,
-                                last_touch: slot.last_touch,
-                                inserted_at: slot.inserted_at,
-                            })
-                        }),
-                );
-            }
-        }
-    }
-
-    #[cfg(test)]
-    fn is_tiny(&self) -> bool {
-        matches!(self.storage, ShardStorage::Tiny(_))
-    }
-
-    #[cfg(test)]
-    fn is_full(&self) -> bool {
-        matches!(self.storage, ShardStorage::Full(_))
+        *self = Shard::new(self.slots.len(), self.arena.len());
     }
 }
 
@@ -752,7 +513,7 @@ impl AvailabilityIndex {
     pub fn entry_count(&self) -> u64 {
         self.shards
             .iter()
-            .map(|shard| shard.lock().unwrap_or_else(|e| e.into_inner()).len() as u64)
+            .map(|shard| shard.lock().unwrap_or_else(|e| e.into_inner()).len as u64)
             .sum()
     }
 
@@ -762,7 +523,7 @@ impl AvailabilityIndex {
             .iter()
             .map(|shard| {
                 let shard = shard.lock().unwrap_or_else(|e| e.into_inner());
-                shard.used_bytes() as u64
+                (shard.slots.len() * size_of::<Slot>() + shard.arena_len) as u64
             })
             .sum()
     }
@@ -859,9 +620,20 @@ impl AvailabilityIndex {
         let mut entries = Vec::with_capacity(self.entry_count() as usize);
         for shard in &self.shards {
             let shard = shard.lock().unwrap_or_else(|e| e.into_inner());
-            shard.snapshot_entries(&mut entries);
+            for slot in shard.slots.iter().copied().filter(|slot| slot.occupied) {
+                if self.is_expired(slot.inserted_at) {
+                    continue;
+                }
+                if let Some(key) = shard.entry_bytes(slot) {
+                    entries.push(PersistedEntry {
+                        key: key.to_vec(),
+                        missing: slot.missing,
+                        last_touch: slot.last_touch,
+                        inserted_at: slot.inserted_at,
+                    });
+                }
+            }
         }
-        entries.retain(|entry| !self.is_expired(entry.inserted_at));
         entries
     }
 
@@ -1043,74 +815,6 @@ mod tests {
     }
 
     #[test]
-    fn shards_start_in_tiny_mode() {
-        let index = AvailabilityIndex::with_shard_count(4096, 4);
-        for shard in &index.shards {
-            let shard = shard.lock().unwrap_or_else(|e| e.into_inner());
-            assert!(shard.is_tiny());
-            assert_eq!(shard.len(), 0);
-            assert_eq!(shard.used_bytes(), 0);
-        }
-    }
-
-    #[test]
-    fn single_negative_entry_stays_in_tiny_mode() {
-        let index = AvailabilityIndex::with_shard_count(4096, 1);
-        let msg_id = MessageId::from_borrowed("<tiny@example.com>").unwrap();
-
-        index.record_backend_missing(&msg_id, BackendId::from_index(0));
-
-        let shard = index.shards[0].lock().unwrap_or_else(|e| e.into_inner());
-        assert!(shard.is_tiny());
-        assert_eq!(shard.len(), 1);
-    }
-
-    #[test]
-    fn shard_promotes_to_full_after_inline_capacity() {
-        let index = AvailabilityIndex::with_shard_count(4096, 1);
-
-        for idx in 0..=INLINE_SHARD_ENTRIES {
-            let msg_id = MessageId::new(format!("<promote-{idx}@example.com>")).unwrap();
-            index.record_backend_missing(&msg_id, BackendId::from_index(idx % 4));
-        }
-
-        let shard = index.shards[0].lock().unwrap_or_else(|e| e.into_inner());
-        assert!(shard.is_full());
-        assert_eq!(shard.len(), INLINE_SHARD_ENTRIES + 1);
-    }
-
-    #[test]
-    fn promotion_preserves_existing_entries() {
-        let index = AvailabilityIndex::with_shard_count(4096, 1);
-        let first = MessageId::from_borrowed("<first-promote@example.com>").unwrap();
-        let second = MessageId::from_borrowed("<second-promote@example.com>").unwrap();
-
-        index.record_backend_missing(&first, BackendId::from_index(0));
-        index.record_backend_missing(&second, BackendId::from_index(1));
-        for idx in 2..=INLINE_SHARD_ENTRIES {
-            let msg_id = MessageId::new(format!("<fill-{idx}@example.com>")).unwrap();
-            index.record_backend_missing(&msg_id, BackendId::from_index(idx % 4));
-        }
-        let trigger = MessageId::from_borrowed("<promote-trigger@example.com>").unwrap();
-        index.record_backend_missing(&trigger, BackendId::from_index(3));
-
-        assert!(
-            !index
-                .get(&first)
-                .unwrap()
-                .should_try_backend(BackendId::from_index(0))
-        );
-        assert!(
-            !index
-                .get(&second)
-                .unwrap()
-                .should_try_backend(BackendId::from_index(1))
-        );
-        let shard = index.shards[0].lock().unwrap_or_else(|e| e.into_inner());
-        assert!(shard.is_full());
-    }
-
-    #[test]
     fn lru_eviction_keeps_newer_entry() {
         let index = AvailabilityIndex::with_shard_count(320, 1);
         let older = MessageId::from_borrowed("<older@example.com>").unwrap();
@@ -1160,32 +864,6 @@ mod tests {
                 .expect("restored second entry")
                 .should_try_backend(BackendId::from_index(2))
         );
-    }
-
-    #[test]
-    fn save_and_load_roundtrip_restores_promoted_shard_entries() {
-        let temp_dir = TempDir::new().unwrap();
-        let path = temp_dir.path().join("availability-promoted.idx");
-        let index = AvailabilityIndex::with_shard_count(4096, 1);
-
-        for idx in 0..=INLINE_SHARD_ENTRIES {
-            let msg_id = MessageId::new(format!("<persist-promote-{idx}@example.com>")).unwrap();
-            index.record_backend_missing(&msg_id, BackendId::from_index(idx % 4));
-        }
-        index.save_to_path(&path).unwrap();
-
-        let restored = AvailabilityIndex::with_shard_count(4096, 1);
-        assert!(restored.load_from_path(&path).unwrap());
-
-        for idx in 0..=INLINE_SHARD_ENTRIES {
-            let msg_id = MessageId::new(format!("<persist-promote-{idx}@example.com>")).unwrap();
-            assert!(
-                restored.get(&msg_id).is_some(),
-                "missing restored entry {idx}"
-            );
-        }
-        let shard = restored.shards[0].lock().unwrap_or_else(|e| e.into_inner());
-        assert!(shard.is_full());
     }
 
     #[test]

--- a/src/cache/availability_index.rs
+++ b/src/cache/availability_index.rs
@@ -1,643 +1,489 @@
-//! Compact availability-only negative index.
+//! Bounded availability-only blocked fingerprint index.
 //!
-//! Stores exact per-message-id 430 knowledge without any payload bytes. Lookups are
-//! zero-allocation on the request path; inserts copy message-id bytes into a
-//! preallocated shard-local arena. When a shard fills, it evicts the least
-//! recently used entries and compacts the shard so bounded memory stays usable.
+//! Stores negative-only backend availability using a rotating blocked fingerprint
+//! filter. The filter is bounded by `capacity_bytes`, favors throughput, and
+//! accepts occasional false negatives from rotation/overwrites. False positives
+//! are pushed down by storing a 64-bit keyed fingerprint per slot.
 
-use super::{ArticleAvailability, CachedArticle, ttl};
+use super::{ArticleAvailability, CachedArticle, availability::MAX_BACKENDS, ttl};
 use crate::io_util::atomic_replace_file;
 use crate::types::{BackendId, MessageId};
 use anyhow::{Context, Result};
-use smallvec::SmallVec;
 use std::fs;
-use std::mem::{size_of, take};
+use std::hash::Hasher;
+use std::mem::size_of;
 use std::path::Path;
 use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use twox_hash::XxHash64;
 
-const DEFAULT_SHARDS: usize = 16;
-const SLOT_BUDGET_DIVISOR: usize = 3;
-const LOAD_FACTOR_NUM: usize = 85;
-const LOAD_FACTOR_DEN: usize = 100;
-const INLINE_SHARD_ENTRIES: usize = 4;
-const INLINE_KEY_BYTES: usize = 64;
-const PERSISTENCE_MAGIC: &[u8; 8] = b"ANEGIDX2";
-const LEGACY_PERSISTENCE_MAGIC: &[u8; 8] = b"ANEGIDX1";
+const DEFAULT_GENERATIONS: usize = 2;
+const BLOCK_SLOTS: usize = 2;
+const FIXED_ARTICLE_CAPACITY: usize = 256 * 1024;
+const SLOT_BYTES: usize = size_of::<u64>() + size_of::<u8>();
+const ALL_BACKEND_BITS: u8 = ((1u16 << MAX_BACKENDS) - 1) as u8;
+const PERSISTENCE_MAGIC: &[u8; 8] = b"ANEGSIM1";
+const LEGACY_PERSISTENCE_MAGIC_V1: &[u8; 8] = b"ANEGIDX1";
+const LEGACY_PERSISTENCE_MAGIC_V2: &[u8; 8] = b"ANEGIDX2";
 
 static SAVE_LOCK: Mutex<()> = Mutex::new(());
 static SAVE_SEQ: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Clone, Copy, Debug, Default)]
-struct Slot {
-    hash: u64,
-    offset: u32,
-    len: u16,
-    missing: u8,
-    occupied: bool,
-    last_touch: u64,
-    inserted_at: u64,
+struct Block {
+    hashes: [u64; BLOCK_SLOTS],
+    missing: [u8; BLOCK_SLOTS],
 }
 
-impl Slot {
-    const fn is_empty(self) -> bool {
-        !self.occupied
+type SlotMatchMask = u8;
+const FIXED_TOTAL_BLOCKS: usize = FIXED_ARTICLE_CAPACITY / BLOCK_SLOTS;
+const FIXED_CAPACITY_BYTES: u64 = (FIXED_TOTAL_BLOCKS * size_of::<Block>()) as u64;
+
+impl Block {
+    fn missing_bits(&self, hash: u64) -> u8 {
+        let mut matched = matching_slots(&self.hashes, hash);
+        let mut missing_bits = 0u8;
+
+        while matched != 0 {
+            let slot = matched.trailing_zeros() as usize;
+            missing_bits |= self.missing[slot];
+            matched &= matched - 1;
+        }
+
+        missing_bits
+    }
+
+    fn insert(&mut self, hash: u64, missing_bits: u8, victim: usize) -> InsertOutcome {
+        debug_assert_ne!(hash, 0, "fingerprint slots use 0 as the empty sentinel");
+
+        let existing = matching_slots(&self.hashes, hash);
+        if existing != 0 {
+            let slot = existing.trailing_zeros() as usize;
+            self.missing[slot] |= missing_bits;
+            return InsertOutcome::Updated;
+        }
+
+        if let Some(empty_slot) = self.hashes.iter().position(|&value| value == 0) {
+            self.hashes[empty_slot] = hash;
+            self.missing[empty_slot] = missing_bits;
+            return InsertOutcome::Inserted;
+        }
+
+        self.hashes[victim] = hash;
+        self.missing[victim] = missing_bits;
+        InsertOutcome::Replaced
+    }
+
+    fn clear(&mut self) -> usize {
+        let occupied = self.hashes.iter().filter(|&&hash| hash != 0).count();
+        self.hashes = [0; BLOCK_SLOTS];
+        self.missing = [0; BLOCK_SLOTS];
+        occupied
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InsertOutcome {
+    Inserted,
+    Updated,
+    Replaced,
+}
+
 #[derive(Clone, Debug)]
+struct Generation {
+    started_at: u64,
+    occupied: usize,
+    blocks: Box<[Block]>,
+}
+
+impl Generation {
+    fn new(blocks_per_generation: usize) -> Self {
+        Self {
+            started_at: 0,
+            occupied: 0,
+            blocks: vec![Block::default(); blocks_per_generation].into_boxed_slice(),
+        }
+    }
+
+    fn clear(&mut self) -> usize {
+        let evicted = self.occupied;
+        for block in &mut self.blocks {
+            block.clear();
+        }
+        self.started_at = 0;
+        self.occupied = 0;
+        evicted
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
 struct PersistedEntry {
-    key: Vec<u8>,
-    missing: u8,
-    last_touch: u64,
-    inserted_at: u64,
-}
-
-#[derive(Clone, Debug)]
-struct TinyEntry {
     hash: u64,
-    key: SmallVec<[u8; INLINE_KEY_BYTES]>,
     missing: u8,
-    last_touch: u64,
     inserted_at: u64,
 }
 
-impl TinyEntry {
-    fn new(hash: u64, key: &[u8], missing: u8, last_touch: u64, inserted_at: u64) -> Self {
-        Self {
-            hash,
-            key: SmallVec::from_slice(key),
-            missing,
-            last_touch,
-            inserted_at,
-        }
-    }
-}
-
 #[derive(Debug)]
-struct FullShard {
-    slots: Box<[Slot]>,
-    len: usize,
-    arena_limit: usize,
-    arena: Vec<u8>,
+struct FilterState {
+    generations: Box<[Generation]>,
+    current_generation: usize,
+    blocks_per_generation: usize,
+    live_generations: usize,
+    rotation_interval_millis: u64,
+    next_rotation_at: u64,
 }
 
-impl FullShard {
-    fn new(slot_count: usize, arena_bytes: usize) -> Self {
+impl FilterState {
+    fn new(
+        blocks_per_generation: usize,
+        generation_count: usize,
+        rotation_interval_millis: u64,
+    ) -> Self {
+        let generation_count = generation_count.max(1);
         Self {
-            slots: vec![Slot::default(); slot_count].into_boxed_slice(),
-            len: 0,
-            arena_limit: arena_bytes,
-            arena: Vec::with_capacity(arena_bytes),
+            generations: (0..generation_count)
+                .map(|_| Generation::new(blocks_per_generation))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+            current_generation: 0,
+            blocks_per_generation,
+            live_generations: 0,
+            rotation_interval_millis,
+            next_rotation_at: 0,
         }
     }
 
-    fn mask(&self) -> usize {
-        self.slots.len().saturating_sub(1)
+    #[cfg(test)]
+    fn blocks_per_generation(&self) -> usize {
+        self.blocks_per_generation
     }
 
-    fn can_insert(&self) -> bool {
-        !self.slots.is_empty()
-            && self.len.saturating_mul(LOAD_FACTOR_DEN) < self.slots.len() * LOAD_FACTOR_NUM
+    #[cfg(test)]
+    fn generation_count(&self) -> usize {
+        self.generations.len()
     }
 
-    fn key_eq(&self, slot: Slot, key: &[u8]) -> bool {
-        self.entry_bytes(slot) == Some(key)
+    fn active_generation_indices(&self) -> impl Iterator<Item = usize> + '_ {
+        (0..self.live_generations).map(|offset| {
+            (self.current_generation + self.generations.len() - offset) % self.generations.len()
+        })
     }
 
-    fn entry_bytes(&self, slot: Slot) -> Option<&[u8]> {
-        let start = slot.offset as usize;
-        let end = start.checked_add(slot.len as usize)?;
-        self.arena.get(start..end)
+    fn occupied_slots(&self) -> usize {
+        self.active_generation_indices()
+            .map(|index| self.generations[index].occupied)
+            .sum()
     }
 
-    fn probe_distance(&self, hash: u64, idx: usize) -> usize {
-        let home = (hash as usize) & self.mask();
-        idx.wrapping_sub(home) & self.mask()
-    }
-
-    fn lookup_missing(
-        &mut self,
-        hash: u64,
-        key: &[u8],
-        touch: u64,
-        base_ttl: ttl::CacheTtlMillis,
-    ) -> Option<u8> {
-        let index = self.lookup_slot_index(hash, key)?;
-        let slot = self.slots[index];
-        if ttl::is_expired(
-            ttl::CacheTimestampMillis::new(slot.inserted_at),
-            base_ttl,
-            ttl::CacheTier::new(0),
-        ) {
-            self.rebuild_excluding(index);
-            return None;
+    fn reset(&mut self) {
+        for generation in &mut self.generations {
+            generation.clear();
         }
-        let slot = &mut self.slots[index];
-        slot.last_touch = touch;
-        Some(slot.missing)
+        self.current_generation = 0;
+        self.live_generations = 0;
+        self.next_rotation_at = 0;
     }
 
-    fn restore_entry(
-        &mut self,
-        hash: u64,
-        key: &[u8],
-        missing_bits: u8,
-        last_touch: u64,
-        inserted_at: u64,
-    ) -> bool {
-        if missing_bits == 0 || key.is_empty() {
-            return true;
-        }
-
-        if let Some(existing) = self.lookup_slot_index(hash, key) {
-            let slot = &mut self.slots[existing];
-            slot.missing |= missing_bits;
-            slot.last_touch = slot.last_touch.max(last_touch);
-            slot.inserted_at = slot.inserted_at.max(inserted_at);
-            return true;
-        }
-
-        if self.ensure_space_for(key.len()).is_none() {
-            return false;
-        }
-
-        let new_slot = Slot {
-            hash,
-            offset: self.allocate_key_bytes(key),
-            len: key.len() as u16,
-            missing: missing_bits,
-            occupied: true,
-            last_touch,
-            inserted_at,
-        };
-        self.place_slot(new_slot)
-    }
-
-    fn allocate_key_bytes(&mut self, key: &[u8]) -> u32 {
-        let offset = self.arena.len();
-        self.arena.extend_from_slice(key);
-        offset as u32
-    }
-
-    fn place_slot(&mut self, mut new_slot: Slot) -> bool {
-        if self.slots.is_empty() {
-            return false;
-        }
-
-        let mut idx = (new_slot.hash as usize) & self.mask();
-        let mut distance = 0usize;
-        loop {
-            if self.slots[idx].is_empty() {
-                self.slots[idx] = new_slot;
-                self.len += 1;
-                return true;
-            }
-
-            let resident_distance = self.probe_distance(self.slots[idx].hash, idx);
-            if resident_distance < distance {
-                std::mem::swap(&mut self.slots[idx], &mut new_slot);
-                distance = resident_distance;
-            }
-
-            idx = (idx + 1) & self.mask();
-            distance += 1;
-            if distance > self.mask() {
-                return false;
-            }
-        }
-    }
-
-    fn ensure_space_for(&mut self, required_key_len: usize) -> Option<usize> {
-        if self.slots.is_empty()
-            || required_key_len == 0
-            || required_key_len > self.arena_limit
-            || required_key_len > u16::MAX as usize
-        {
-            return None;
-        }
-
-        let mut evicted = 0usize;
-        while (!self.can_insert() || self.arena.len() + required_key_len > self.arena_limit)
-            && self.len > 0
-        {
-            self.evict_lru()?;
-            evicted += 1;
-        }
-
-        if self.can_insert() && self.arena.len() + required_key_len <= self.arena_limit {
-            Some(evicted)
-        } else {
-            None
-        }
-    }
-
-    fn evict_lru(&mut self) -> Option<()> {
-        let victim = self
-            .slots
-            .iter()
-            .enumerate()
-            .filter(|(_, slot)| slot.occupied)
-            .min_by_key(|(_, slot)| slot.last_touch)
-            .map(|(idx, _)| idx)?;
-        self.rebuild_excluding(victim);
-        Some(())
-    }
-
-    fn rebuild_excluding(&mut self, victim_idx: usize) {
-        let old_slots = take(&mut self.slots);
-        let old_arena = take(&mut self.arena);
-
-        let mut rebuilt = FullShard::new(old_slots.len(), self.arena_limit);
-        for (idx, slot) in old_slots.iter().copied().enumerate() {
-            if idx == victim_idx || slot.is_empty() {
-                continue;
-            }
-
-            if let Some(key) =
-                old_arena.get(slot.offset as usize..slot.offset as usize + slot.len as usize)
-            {
-                let inserted = rebuilt.restore_entry(
-                    slot.hash,
-                    key,
-                    slot.missing,
-                    slot.last_touch,
-                    slot.inserted_at,
-                );
-                debug_assert!(
-                    inserted,
-                    "rebuilding shard should preserve existing entries"
-                );
-            }
-        }
-
-        *self = rebuilt;
-    }
-
-    fn lookup_slot_index(&self, hash: u64, key: &[u8]) -> Option<usize> {
-        if self.slots.is_empty() {
-            return None;
-        }
-
-        let mut idx = (hash as usize) & self.mask();
-        let mut distance = 0usize;
-        loop {
-            let slot = self.slots[idx];
-            if slot.is_empty() {
-                return None;
-            }
-            if self.probe_distance(slot.hash, idx) < distance {
-                return None;
-            }
-            if slot.hash == hash && self.key_eq(slot, key) {
-                return Some(idx);
-            }
-            idx = (idx + 1) & self.mask();
-            distance += 1;
-            if distance > self.mask() {
-                return None;
-            }
-        }
-    }
-}
-
-// Keep Tiny inline so untouched and low-cardinality shards avoid any heap allocation.
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug)]
-enum ShardStorage {
-    Tiny(SmallVec<[TinyEntry; INLINE_SHARD_ENTRIES]>),
-    Full(Box<FullShard>),
-}
-
-#[derive(Debug)]
-struct Shard {
-    slot_capacity: usize,
-    arena_capacity: usize,
-    storage: ShardStorage,
-}
-
-impl Shard {
-    fn new(slot_count: usize, arena_bytes: usize) -> Self {
-        Self {
-            slot_capacity: slot_count,
-            arena_capacity: arena_bytes,
-            storage: ShardStorage::Tiny(SmallVec::new()),
-        }
-    }
-
-    fn len(&self) -> usize {
-        match &self.storage {
-            ShardStorage::Tiny(entries) => entries.len(),
-            ShardStorage::Full(full) => full.len,
-        }
-    }
-
-    fn used_bytes(&self) -> usize {
-        match &self.storage {
-            ShardStorage::Tiny(entries) => entries.len() * size_of::<TinyEntry>(),
-            ShardStorage::Full(full) => full.slots.len() * size_of::<Slot>() + full.arena.len(),
-        }
-    }
-
-    fn tiny_key_bytes(entries: &[TinyEntry]) -> usize {
-        entries.iter().map(|entry| entry.key.len()).sum()
-    }
-
-    fn tiny_lookup_index(entries: &[TinyEntry], hash: u64, key: &[u8]) -> Option<usize> {
-        entries
-            .iter()
-            .position(|entry| entry.hash == hash && entry.key.as_slice() == key)
-    }
-
-    fn tiny_can_insert(
-        slot_capacity: usize,
-        arena_capacity: usize,
-        entries: &[TinyEntry],
-        key: &[u8],
-    ) -> bool {
-        key.len() <= INLINE_KEY_BYTES
-            && key.len() <= u16::MAX as usize
-            && entries.len()
-                < if slot_capacity == 0 || arena_capacity == 0 {
-                    0
-                } else {
-                    INLINE_SHARD_ENTRIES
-                        .min((slot_capacity * LOAD_FACTOR_NUM / LOAD_FACTOR_DEN).max(1))
-                }
-            && Self::tiny_key_bytes(entries) + key.len() <= arena_capacity
-    }
-
-    fn promote_to_full(&mut self) {
-        let old_storage = std::mem::replace(&mut self.storage, ShardStorage::Tiny(SmallVec::new()));
-        let ShardStorage::Tiny(entries) = old_storage else {
+    fn ensure_current_generation_started(&mut self, now: u64) {
+        let generation = &mut self.generations[self.current_generation];
+        if generation.started_at != 0 {
             return;
+        }
+
+        generation.started_at = now;
+        self.live_generations = self.live_generations.max(1);
+        self.next_rotation_at = match self.rotation_interval_millis {
+            0 | u64::MAX => 0,
+            interval => now.saturating_add(interval),
         };
-
-        let mut full = FullShard::new(self.slot_capacity, self.arena_capacity);
-        for entry in entries {
-            let inserted = full.restore_entry(
-                entry.hash,
-                entry.key.as_slice(),
-                entry.missing,
-                entry.last_touch,
-                entry.inserted_at,
-            );
-            debug_assert!(
-                inserted,
-                "promoting tiny shard entries should preserve exact negatives"
-            );
-        }
-        self.storage = ShardStorage::Full(Box::new(full));
     }
 
-    fn lookup_missing(
-        &mut self,
-        hash: u64,
-        key: &[u8],
-        touch: u64,
-        base_ttl: ttl::CacheTtlMillis,
-    ) -> Option<u8> {
-        match &mut self.storage {
-            ShardStorage::Tiny(entries) => {
-                let index = Self::tiny_lookup_index(entries, hash, key)?;
-                if ttl::is_expired(
-                    ttl::CacheTimestampMillis::new(entries[index].inserted_at),
-                    base_ttl,
-                    ttl::CacheTier::new(0),
-                ) {
-                    entries.swap_remove(index);
-                    return None;
-                }
-                entries[index].last_touch = touch;
-                Some(entries[index].missing)
-            }
-            ShardStorage::Full(full) => full.lookup_missing(hash, key, touch, base_ttl),
-        }
+    fn refresh_next_rotation_at(&mut self) {
+        self.next_rotation_at = match self.rotation_interval_millis {
+            0 | u64::MAX => 0,
+            interval => self.generations[self.current_generation]
+                .started_at
+                .saturating_add(interval),
+        };
     }
 
-    fn insert_missing(
-        &mut self,
-        hash: u64,
-        key: &[u8],
-        missing_bits: u8,
-        touch: u64,
-        inserted_at: u64,
-    ) -> usize {
-        if missing_bits == 0 || key.is_empty() || key.len() > u16::MAX as usize {
+    fn rotate_if_needed(&mut self, now: u64) -> usize {
+        if self.blocks_per_generation == 0 || self.generations.is_empty() {
             return 0;
         }
 
-        loop {
-            match &mut self.storage {
-                ShardStorage::Tiny(entries) => {
-                    if let Some(existing) = Self::tiny_lookup_index(entries, hash, key) {
-                        let entry = &mut entries[existing];
-                        entry.missing |= missing_bits;
-                        entry.last_touch = touch;
-                        entry.inserted_at = inserted_at;
-                        return 0;
-                    }
-
-                    if Self::tiny_can_insert(self.slot_capacity, self.arena_capacity, entries, key)
-                    {
-                        entries.push(TinyEntry::new(hash, key, missing_bits, touch, inserted_at));
-                        return 0;
-                    }
-
-                    self.promote_to_full();
-                }
-                ShardStorage::Full(full) => {
-                    if let Some(existing) = full.lookup_slot_index(hash, key) {
-                        let slot = &mut full.slots[existing];
-                        slot.missing |= missing_bits;
-                        slot.last_touch = touch;
-                        slot.inserted_at = inserted_at;
-                        return 0;
-                    }
-
-                    let Some(evicted) = full.ensure_space_for(key.len()) else {
-                        return usize::MAX;
-                    };
-
-                    let new_slot = Slot {
-                        hash,
-                        offset: full.allocate_key_bytes(key),
-                        len: key.len() as u16,
-                        missing: missing_bits,
-                        occupied: true,
-                        last_touch: touch,
-                        inserted_at,
-                    };
-                    debug_assert!(full.place_slot(new_slot));
-                    return evicted;
-                }
+        let interval = self.rotation_interval_millis;
+        if interval == 0 {
+            let mut evicted = 0usize;
+            for generation in &mut self.generations {
+                evicted += generation.clear();
             }
+            self.current_generation = 0;
+            self.live_generations = 0;
+            self.next_rotation_at = 0;
+            return evicted;
+        }
+        if interval == u64::MAX {
+            return 0;
+        }
+        if self.live_generations == 0 || self.next_rotation_at == 0 || now < self.next_rotation_at {
+            return 0;
+        }
+
+        let scheduled_at = self.next_rotation_at;
+        let rotations = (1 + ((now.saturating_sub(self.next_rotation_at)) / interval) as usize)
+            .min(self.generations.len());
+        let mut evicted = 0usize;
+        for step in 0..rotations {
+            self.current_generation = (self.current_generation + 1) % self.generations.len();
+            let generation = &mut self.generations[self.current_generation];
+            evicted += generation.clear();
+            generation.started_at =
+                scheduled_at.saturating_add((step as u64).saturating_mul(interval));
+        }
+        self.live_generations = (self.live_generations + rotations).min(self.generations.len());
+        self.next_rotation_at =
+            scheduled_at.saturating_add((rotations as u64).saturating_mul(interval));
+        evicted
+    }
+
+    fn lookup_missing_bits(&mut self, hash: u64, block_index: usize, now: u64) -> LookupResult {
+        let evicted = self.rotate_if_needed(now);
+        if self.blocks_per_generation == 0 || self.generations.is_empty() {
+            return LookupResult {
+                missing_bits: 0,
+                evicted,
+                empty_after: true,
+            };
+        }
+
+        let mut missing_bits = 0u8;
+        for generation_index in self.active_generation_indices() {
+            missing_bits |=
+                self.generations[generation_index].blocks[block_index].missing_bits(hash);
+            if missing_bits == ALL_BACKEND_BITS {
+                break;
+            }
+        }
+
+        LookupResult {
+            missing_bits,
+            evicted,
+            empty_after: self.occupied_slots() == 0,
+        }
+    }
+
+    fn insert_missing_bits(
+        &mut self,
+        hash: u64,
+        missing_bits: u8,
+        block_index: usize,
+        victim: usize,
+        now: u64,
+    ) -> StateInsertOutcome {
+        let evicted = self.rotate_if_needed(now);
+        if self.blocks_per_generation == 0
+            || missing_bits == 0
+            || self.rotation_interval_millis == 0
+        {
+            return StateInsertOutcome {
+                changed: false,
+                evicted,
+            };
+        }
+
+        self.ensure_current_generation_started(now);
+        let generation = &mut self.generations[self.current_generation];
+        let block = &mut generation.blocks[block_index];
+        let outcome = block.insert(hash, missing_bits, victim);
+        if matches!(outcome, InsertOutcome::Inserted) {
+            generation.occupied += 1;
+        }
+
+        StateInsertOutcome {
+            changed: !matches!(outcome, InsertOutcome::Updated),
+            evicted: match outcome {
+                InsertOutcome::Replaced => evicted.saturating_add(1),
+                _ => evicted,
+            },
         }
     }
 
     fn restore_entry(
         &mut self,
-        hash: u64,
-        key: &[u8],
-        missing_bits: u8,
-        last_touch: u64,
-        inserted_at: u64,
-    ) -> bool {
-        if missing_bits == 0 || key.is_empty() || key.len() > u16::MAX as usize {
-            return true;
+        entry: PersistedEntry,
+        now: u64,
+        ttl_millis: ttl::CacheTtlMillis,
+    ) -> usize {
+        if self.blocks_per_generation == 0
+            || entry.hash == 0
+            || entry.missing == 0
+            || ttl::is_expired(
+                ttl::CacheTimestampMillis::new(entry.inserted_at),
+                ttl_millis,
+                ttl::CacheTier::new(0),
+            )
+        {
+            return 0;
         }
 
-        loop {
-            match &mut self.storage {
-                ShardStorage::Tiny(entries) => {
-                    if let Some(existing) = Self::tiny_lookup_index(entries, hash, key) {
-                        let entry = &mut entries[existing];
-                        entry.missing |= missing_bits;
-                        entry.last_touch = entry.last_touch.max(last_touch);
-                        entry.inserted_at = entry.inserted_at.max(inserted_at);
-                        return true;
+        let interval = self.rotation_interval_millis;
+        let offset = if interval == 0 || interval == u64::MAX {
+            0
+        } else {
+            (now.saturating_sub(entry.inserted_at) / interval) as usize
+        }
+        .min(self.generations.len().saturating_sub(1));
+        let generation_index =
+            (self.current_generation + self.generations.len() - offset) % self.generations.len();
+        let generation = &mut self.generations[generation_index];
+        let started_at = if interval == 0 || interval == u64::MAX {
+            entry.inserted_at
+        } else {
+            now.saturating_sub((offset as u64).saturating_mul(interval))
+        };
+
+        if generation.started_at == 0 {
+            generation.started_at = started_at;
+        } else {
+            generation.started_at = generation.started_at.min(started_at);
+        }
+        self.live_generations = self.live_generations.max(offset + 1);
+
+        let block = &mut generation.blocks[block_index(entry.hash, self.blocks_per_generation)];
+        match block.insert(entry.hash, entry.missing, victim_slot(entry.hash)) {
+            InsertOutcome::Inserted => {
+                generation.occupied += 1;
+                0
+            }
+            InsertOutcome::Updated => 0,
+            InsertOutcome::Replaced => 1,
+        }
+    }
+
+    fn snapshot_entries(&mut self, now: u64) -> SnapshotResult {
+        let evicted = self.rotate_if_needed(now);
+        let mut entries = Vec::with_capacity(self.occupied_slots());
+
+        for generation_index in self.active_generation_indices() {
+            let generation = &self.generations[generation_index];
+
+            for block in &generation.blocks {
+                for slot in 0..BLOCK_SLOTS {
+                    let hash = block.hashes[slot];
+                    let missing = block.missing[slot];
+                    if hash == 0 || missing == 0 {
+                        continue;
                     }
-
-                    if Self::tiny_can_insert(self.slot_capacity, self.arena_capacity, entries, key)
-                    {
-                        entries.push(TinyEntry::new(
-                            hash,
-                            key,
-                            missing_bits,
-                            last_touch,
-                            inserted_at,
-                        ));
-                        return true;
-                    }
-
-                    self.promote_to_full();
-                }
-                ShardStorage::Full(full) => {
-                    return full.restore_entry(hash, key, missing_bits, last_touch, inserted_at);
+                    entries.push(PersistedEntry {
+                        hash,
+                        missing,
+                        inserted_at: generation.started_at,
+                    });
                 }
             }
         }
-    }
 
-    fn clear(&mut self) {
-        self.storage = ShardStorage::Tiny(SmallVec::new());
+        SnapshotResult { entries, evicted }
     }
+}
 
-    fn snapshot_entries(&self, out: &mut Vec<PersistedEntry>) {
-        match &self.storage {
-            ShardStorage::Tiny(entries) => {
-                out.extend(entries.iter().map(|entry| PersistedEntry {
-                    key: entry.key.to_vec(),
-                    missing: entry.missing,
-                    last_touch: entry.last_touch,
-                    inserted_at: entry.inserted_at,
-                }));
-            }
-            ShardStorage::Full(full) => {
-                out.extend(
-                    full.slots
-                        .iter()
-                        .copied()
-                        .filter(|slot| slot.occupied)
-                        .filter_map(|slot| {
-                            full.entry_bytes(slot).map(|key| PersistedEntry {
-                                key: key.to_vec(),
-                                missing: slot.missing,
-                                last_touch: slot.last_touch,
-                                inserted_at: slot.inserted_at,
-                            })
-                        }),
-                );
-            }
-        }
-    }
+#[derive(Clone, Copy, Debug, Default)]
+struct LookupResult {
+    missing_bits: u8,
+    evicted: usize,
+    empty_after: bool,
+}
 
-    #[cfg(test)]
-    fn is_tiny(&self) -> bool {
-        matches!(self.storage, ShardStorage::Tiny(_))
-    }
+#[derive(Clone, Copy, Debug, Default)]
+struct StateInsertOutcome {
+    changed: bool,
+    evicted: usize,
+}
 
-    #[cfg(test)]
-    fn is_full(&self) -> bool {
-        matches!(self.storage, ShardStorage::Full(_))
-    }
+#[derive(Debug, Default)]
+struct SnapshotResult {
+    entries: Vec<PersistedEntry>,
+    evicted: usize,
 }
 
 #[derive(Debug)]
 pub struct AvailabilityIndex {
-    shards: Box<[Mutex<Shard>]>,
+    state: Mutex<FilterState>,
     capacity_bytes: u64,
+    has_entries: AtomicBool,
     hits: AtomicU64,
     misses: AtomicU64,
     inserts: AtomicU64,
     dropped: AtomicU64,
     evictions: AtomicU64,
-    clock: AtomicU64,
     ttl: ttl::CacheTtlMillis,
+}
+
+impl Default for AvailabilityIndex {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl AvailabilityIndex {
     #[must_use]
-    pub fn new(capacity_bytes: u64) -> Self {
-        Self::with_ttl(capacity_bytes, Duration::MAX)
+    pub fn new() -> Self {
+        Self::with_ttl(Duration::MAX)
     }
 
     #[must_use]
-    pub fn with_ttl(capacity_bytes: u64, ttl: Duration) -> Self {
-        Self::with_ttl_and_shard_count(capacity_bytes, ttl, DEFAULT_SHARDS)
+    pub fn with_ttl(ttl: Duration) -> Self {
+        Self::with_capacity_and_generation_count(FIXED_CAPACITY_BYTES, ttl, DEFAULT_GENERATIONS)
     }
 
     #[must_use]
     #[cfg(test)]
-    fn with_shard_count(capacity_bytes: u64, shard_limit: usize) -> Self {
-        Self::with_ttl_and_shard_count(capacity_bytes, Duration::MAX, shard_limit)
+    fn with_test_capacity(capacity_bytes: u64) -> Self {
+        Self::with_capacity_and_generation_count(capacity_bytes, Duration::MAX, DEFAULT_GENERATIONS)
     }
 
     #[must_use]
-    fn with_ttl_and_shard_count(capacity_bytes: u64, ttl: Duration, shard_limit: usize) -> Self {
+    #[cfg(test)]
+    fn with_generation_count(capacity_bytes: u64, generation_count: usize) -> Self {
+        Self::with_capacity_and_generation_count(capacity_bytes, Duration::MAX, generation_count)
+    }
+
+    #[must_use]
+    fn with_capacity_and_generation_count(
+        capacity_bytes: u64,
+        ttl: Duration,
+        generation_count: usize,
+    ) -> Self {
         let ttl = ttl::CacheTtlMillis::from_duration(ttl);
-        let total_bytes = capacity_bytes as usize;
-        if total_bytes == 0 {
-            return Self {
-                shards: Box::new([Mutex::new(Shard::new(0, 0))]),
-                capacity_bytes,
-                hits: AtomicU64::new(0),
-                misses: AtomicU64::new(0),
-                inserts: AtomicU64::new(0),
-                dropped: AtomicU64::new(0),
-                evictions: AtomicU64::new(0),
-                clock: AtomicU64::new(0),
-                ttl,
-            };
-        }
-
-        let shard_count = shard_limit.min(total_bytes.max(1));
-        let slot_budget = total_bytes / SLOT_BUDGET_DIVISOR;
-        let arena_budget = total_bytes.saturating_sub(slot_budget);
-        let slot_bytes_per_shard = slot_budget / shard_count;
-        let arena_bytes_per_shard = arena_budget / shard_count;
-        let slot_count = next_power_of_two(
-            (slot_bytes_per_shard / size_of::<Slot>())
-                .max(2)
-                .saturating_sub(1),
-        );
-
-        let shards = (0..shard_count)
-            .map(|_| Mutex::new(Shard::new(slot_count, arena_bytes_per_shard)))
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
+        let total_blocks = (capacity_bytes as usize) / size_of::<Block>();
+        let generation_count = generation_count.max(1).min(total_blocks.max(1));
+        let blocks_per_generation = if total_blocks == 0 {
+            0
+        } else {
+            total_blocks / generation_count
+        };
+        let rotation_interval_millis = match ttl.get() {
+            0 => 0,
+            u64::MAX => u64::MAX,
+            ttl_millis => (ttl_millis / generation_count as u64).max(1),
+        };
 
         Self {
-            shards,
+            state: Mutex::new(FilterState::new(
+                blocks_per_generation,
+                generation_count,
+                rotation_interval_millis,
+            )),
             capacity_bytes,
+            has_entries: AtomicBool::new(false),
             hits: AtomicU64::new(0),
             misses: AtomicU64::new(0),
             inserts: AtomicU64::new(0),
             dropped: AtomicU64::new(0),
             evictions: AtomicU64::new(0),
-            clock: AtomicU64::new(0),
             ttl,
         }
     }
@@ -674,23 +520,27 @@ impl AvailabilityIndex {
             format!("Failed to read availability index from {}", path.display())
         })?;
         let mut entries = parse_entries(&data)?;
-        entries.sort_by_key(|entry| entry.last_touch);
+        entries.sort_by_key(|entry| entry.inserted_at);
 
-        self.reset();
-        let mut max_touch = 0u64;
+        let now = ttl::now_millis();
+        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        state.reset();
+        let mut evicted = 0usize;
         for entry in entries {
-            if self.is_expired(entry.inserted_at) {
-                continue;
-            }
-            max_touch = max_touch.max(entry.last_touch);
-            self.restore_entry(
-                &entry.key,
-                entry.missing,
-                entry.last_touch,
-                entry.inserted_at,
-            );
+            evicted += state.restore_entry(entry, now, self.ttl);
         }
-        self.clock.store(max_touch, Ordering::Relaxed);
+        if state.live_generations != 0 {
+            state.refresh_next_rotation_at();
+        }
+        let has_entries = state.occupied_slots() != 0;
+        drop(state);
+
+        self.has_entries.store(has_entries, Ordering::Relaxed);
+        self.hits.store(0, Ordering::Relaxed);
+        self.misses.store(0, Ordering::Relaxed);
+        self.inserts.store(0, Ordering::Relaxed);
+        self.dropped.store(0, Ordering::Relaxed);
+        self.evictions.store(evicted as u64, Ordering::Relaxed);
         Ok(true)
     }
 
@@ -710,17 +560,24 @@ impl AvailabilityIndex {
             })?;
         }
 
-        let entries = self.snapshot_entries();
-        let total_key_bytes: usize = entries.iter().map(|entry| entry.key.len()).sum();
-        let mut bytes = Vec::with_capacity(16 + entries.len() * 19 + total_key_bytes);
+        let now = ttl::now_millis();
+        let snapshot = {
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            state.snapshot_entries(now)
+        };
+        if snapshot.evicted != 0 {
+            self.evictions
+                .fetch_add(snapshot.evicted as u64, Ordering::Relaxed);
+        }
+
+        let mut bytes =
+            Vec::with_capacity(16 + snapshot.entries.len() * (size_of::<u64>() * 2 + 1));
         bytes.extend_from_slice(PERSISTENCE_MAGIC);
-        bytes.extend_from_slice(&(entries.len() as u64).to_le_bytes());
-        for entry in entries {
-            bytes.extend_from_slice(&(entry.key.len() as u16).to_le_bytes());
+        bytes.extend_from_slice(&(snapshot.entries.len() as u64).to_le_bytes());
+        for entry in snapshot.entries {
+            bytes.extend_from_slice(&entry.hash.to_le_bytes());
             bytes.push(entry.missing);
-            bytes.extend_from_slice(&entry.last_touch.to_le_bytes());
             bytes.extend_from_slice(&entry.inserted_at.to_le_bytes());
-            bytes.extend_from_slice(&entry.key);
         }
 
         let seq = SAVE_SEQ.fetch_add(1, Ordering::Relaxed);
@@ -752,21 +609,24 @@ impl AvailabilityIndex {
 
     #[must_use]
     pub fn entry_count(&self) -> u64 {
-        self.shards
-            .iter()
-            .map(|shard| shard.lock().unwrap_or_else(|e| e.into_inner()).len() as u64)
-            .sum()
+        if !self.has_entries.load(Ordering::Relaxed) {
+            return 0;
+        }
+        let result = {
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            let evicted = state.rotate_if_needed(ttl::now_millis());
+            (state.occupied_slots() as u64, evicted)
+        };
+        self.has_entries.store(result.0 != 0, Ordering::Relaxed);
+        if result.1 != 0 {
+            self.evictions.fetch_add(result.1 as u64, Ordering::Relaxed);
+        }
+        result.0
     }
 
     #[must_use]
     pub fn used_bytes(&self) -> u64 {
-        self.shards
-            .iter()
-            .map(|shard| {
-                let shard = shard.lock().unwrap_or_else(|e| e.into_inner());
-                shard.used_bytes() as u64
-            })
-            .sum()
+        self.entry_count().saturating_mul(SLOT_BYTES as u64)
     }
 
     #[must_use]
@@ -787,100 +647,73 @@ impl AvailabilityIndex {
     }
 
     fn lookup_by_key(&self, key: &str) -> Option<CachedArticle> {
-        let hash = hash_key(key.as_bytes());
-        let shard = self.shard_for(hash);
-        let mut shard = shard.lock().unwrap_or_else(|e| e.into_inner());
-        let result = shard.lookup_missing(hash, key.as_bytes(), self.next_touch(), self.ttl);
-        drop(shard);
+        if !self.has_entries.load(Ordering::Relaxed) {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+            return None;
+        }
 
-        match result {
-            Some(bits) if bits != 0 => {
-                self.hits.fetch_add(1, Ordering::Relaxed);
-                Some(CachedArticle::negative_only(bits))
+        let hash = hash_key(key.as_bytes());
+        let now = ttl::now_millis();
+        let lookup = {
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            if state.blocks_per_generation == 0 {
+                LookupResult {
+                    missing_bits: 0,
+                    evicted: 0,
+                    empty_after: true,
+                }
+            } else {
+                let block_index = block_index(hash, state.blocks_per_generation);
+                let mut lookup = state.lookup_missing_bits(hash, block_index, now);
+                lookup.empty_after = state.occupied_slots() == 0;
+                lookup
             }
-            _ => {
-                self.misses.fetch_add(1, Ordering::Relaxed);
-                None
-            }
+        };
+        if lookup.empty_after {
+            self.has_entries.store(false, Ordering::Relaxed);
+        }
+        if lookup.evicted != 0 {
+            self.evictions
+                .fetch_add(lookup.evicted as u64, Ordering::Relaxed);
+        }
+
+        if lookup.missing_bits != 0 {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            Some(CachedArticle::negative_only(lookup.missing_bits))
+        } else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+            None
         }
     }
 
     fn insert_missing_bits(&self, key: &str, missing_bits: u8) {
-        if missing_bits == 0 || key.is_empty() {
+        if key.is_empty() || missing_bits == 0 || self.ttl.get() == 0 {
             return;
         }
 
         let hash = hash_key(key.as_bytes());
-        let shard = self.shard_for(hash);
-        let mut shard = shard.lock().unwrap_or_else(|e| e.into_inner());
-        match shard.insert_missing(
-            hash,
-            key.as_bytes(),
-            missing_bits,
-            self.next_touch(),
-            ttl::now_millis(),
-        ) {
-            usize::MAX => {
-                self.dropped.fetch_add(1, Ordering::Relaxed);
+        let outcome = {
+            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            if state.blocks_per_generation == 0 {
+                StateInsertOutcome::default()
+            } else {
+                let block_index = block_index(hash, state.blocks_per_generation);
+                let victim = victim_slot(hash);
+                let now = ttl::now_millis();
+                state.insert_missing_bits(hash, missing_bits, block_index, victim, now)
             }
-            evicted => {
-                self.inserts.fetch_add(1, Ordering::Relaxed);
-                if evicted != 0 {
-                    self.evictions.fetch_add(evicted as u64, Ordering::Relaxed);
-                }
-            }
-        }
-    }
+        };
 
-    fn restore_entry(&self, key: &[u8], missing_bits: u8, last_touch: u64, inserted_at: u64) {
-        if missing_bits == 0 || key.is_empty() {
-            return;
+        if outcome.evicted != 0 {
+            self.evictions
+                .fetch_add(outcome.evicted as u64, Ordering::Relaxed);
         }
-
-        let hash = hash_key(key);
-        let shard = self.shard_for(hash);
-        let mut shard = shard.lock().unwrap_or_else(|e| e.into_inner());
-        if !shard.restore_entry(hash, key, missing_bits, last_touch, inserted_at) {
+        if outcome.changed {
+            self.has_entries.store(true, Ordering::Relaxed);
+            self.inserts.fetch_add(1, Ordering::Relaxed);
+        } else if self.capacity_bytes == 0 {
             self.dropped.fetch_add(1, Ordering::Relaxed);
         }
-    }
-
-    fn reset(&self) {
-        for shard in &self.shards {
-            shard.lock().unwrap_or_else(|e| e.into_inner()).clear();
-        }
-        self.hits.store(0, Ordering::Relaxed);
-        self.misses.store(0, Ordering::Relaxed);
-        self.inserts.store(0, Ordering::Relaxed);
-        self.dropped.store(0, Ordering::Relaxed);
-        self.evictions.store(0, Ordering::Relaxed);
-        self.clock.store(0, Ordering::Relaxed);
-    }
-
-    fn snapshot_entries(&self) -> Vec<PersistedEntry> {
-        let mut entries = Vec::with_capacity(self.entry_count() as usize);
-        for shard in &self.shards {
-            let shard = shard.lock().unwrap_or_else(|e| e.into_inner());
-            shard.snapshot_entries(&mut entries);
-        }
-        entries.retain(|entry| !self.is_expired(entry.inserted_at));
-        entries
-    }
-
-    fn next_touch(&self) -> u64 {
-        self.clock.fetch_add(1, Ordering::Relaxed) + 1
-    }
-
-    fn shard_for(&self, hash: u64) -> &Mutex<Shard> {
-        &self.shards[(hash as usize) % self.shards.len()]
-    }
-
-    fn is_expired(&self, inserted_at: u64) -> bool {
-        ttl::is_expired(
-            ttl::CacheTimestampMillis::new(inserted_at),
-            self.ttl,
-            ttl::CacheTier::new(0),
-        )
     }
 }
 
@@ -888,8 +721,9 @@ fn parse_entries(data: &[u8]) -> Result<Vec<PersistedEntry>> {
     if data.len() < PERSISTENCE_MAGIC.len() + size_of::<u64>() {
         anyhow::bail!("availability index file too short");
     }
+
     let magic = &data[..PERSISTENCE_MAGIC.len()];
-    if magic == LEGACY_PERSISTENCE_MAGIC {
+    if magic == LEGACY_PERSISTENCE_MAGIC_V1 || magic == LEGACY_PERSISTENCE_MAGIC_V2 {
         return Ok(Vec::new());
     }
     if magic != PERSISTENCE_MAGIC {
@@ -901,35 +735,20 @@ fn parse_entries(data: &[u8]) -> Result<Vec<PersistedEntry>> {
     let mut entries = Vec::with_capacity(entry_count);
 
     for _ in 0..entry_count {
-        let key_len = read_u16(data, &mut cursor)? as usize;
+        let hash = read_u64(data, &mut cursor)?;
         let missing = *data
             .get(cursor)
             .ok_or_else(|| anyhow::anyhow!("truncated availability missing bits"))?;
         cursor += 1;
-        let last_touch = read_u64(data, &mut cursor)?;
         let inserted_at = read_u64(data, &mut cursor)?;
-        let key = data
-            .get(cursor..cursor + key_len)
-            .ok_or_else(|| anyhow::anyhow!("truncated availability key bytes"))?
-            .to_vec();
-        cursor += key_len;
         entries.push(PersistedEntry {
-            key,
+            hash,
             missing,
-            last_touch,
             inserted_at,
         });
     }
 
     Ok(entries)
-}
-
-fn read_u16(data: &[u8], cursor: &mut usize) -> Result<u16> {
-    let bytes = data
-        .get(*cursor..*cursor + size_of::<u16>())
-        .ok_or_else(|| anyhow::anyhow!("truncated u16 field"))?;
-    *cursor += size_of::<u16>();
-    Ok(u16::from_le_bytes([bytes[0], bytes[1]]))
 }
 
 fn read_u64(data: &[u8], cursor: &mut usize) -> Result<u64> {
@@ -941,15 +760,32 @@ fn read_u64(data: &[u8], cursor: &mut usize) -> Result<u64> {
 }
 
 fn hash_key(bytes: &[u8]) -> u64 {
-    use std::hash::Hasher;
-
     let mut hasher = XxHash64::default();
     hasher.write(bytes);
-    hasher.finish()
+    normalize_hash(hasher.finish())
 }
 
-fn next_power_of_two(value: usize) -> usize {
-    value.next_power_of_two()
+fn normalize_hash(hash: u64) -> u64 {
+    if hash == 0 { 1 } else { hash }
+}
+
+fn block_index(hash: u64, block_count: usize) -> usize {
+    debug_assert!(block_count > 0);
+    (((hash >> 32) as usize) ^ (hash as usize)) % block_count
+}
+
+fn victim_slot(hash: u64) -> usize {
+    ((hash >> 48) as usize) & (BLOCK_SLOTS - 1)
+}
+
+fn matching_slots(hashes: &[u64; BLOCK_SLOTS], needle: u64) -> SlotMatchMask {
+    let mut mask = 0;
+    for (index, &value) in hashes.iter().enumerate() {
+        if value == needle {
+            mask |= 1u8 << index;
+        }
+    }
+    mask
 }
 
 #[cfg(test)]
@@ -957,16 +793,20 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn test_capacity_for(blocks: usize, generations: usize) -> u64 {
+        (blocks * generations * size_of::<Block>()) as u64
+    }
+
     #[test]
     fn lookup_miss_returns_none() {
-        let index = AvailabilityIndex::new(1024);
+        let index = AvailabilityIndex::with_test_capacity(test_capacity_for(16, 2));
         let msg_id = MessageId::from_borrowed("<miss@example.com>").unwrap();
         assert!(index.get(&msg_id).is_none());
     }
 
     #[test]
     fn record_missing_round_trips_as_negative_cached_article() {
-        let index = AvailabilityIndex::new(8192);
+        let index = AvailabilityIndex::with_test_capacity(test_capacity_for(32, 2));
         let msg_id = MessageId::from_borrowed("<gone@example.com>").unwrap();
         let backend_id = BackendId::from_index(2);
 
@@ -982,8 +822,31 @@ mod tests {
     }
 
     #[test]
+    fn request_message_id_lookup_requires_brackets() {
+        let index = AvailabilityIndex::with_test_capacity(test_capacity_for(8, 2));
+        let msg_id = MessageId::from_borrowed("<request@example.com>").unwrap();
+
+        index.record_backend_missing(&msg_id, BackendId::from_index(0));
+
+        assert!(
+            index
+                .get_request_message_id("request@example.com")
+                .is_none()
+        );
+        assert!(
+            index
+                .get_request_message_id("<request@example.com>")
+                .is_some()
+        );
+    }
+
+    #[test]
     fn record_missing_expires_after_configured_ttl() {
-        let index = AvailabilityIndex::with_ttl(8192, std::time::Duration::from_millis(5));
+        let index = AvailabilityIndex::with_capacity_and_generation_count(
+            test_capacity_for(8, 2),
+            std::time::Duration::from_millis(5),
+            DEFAULT_GENERATIONS,
+        );
         let msg_id = MessageId::from_borrowed("<expires@example.com>").unwrap();
 
         index.record_backend_missing(&msg_id, BackendId::from_index(0));
@@ -991,15 +854,12 @@ mod tests {
 
         std::thread::sleep(std::time::Duration::from_millis(15));
 
-        assert!(
-            index.get(&msg_id).is_none(),
-            "availability-only negatives must expire on the configured cache TTL"
-        );
+        assert!(index.get(&msg_id).is_none());
     }
 
     #[test]
     fn record_missing_supports_highest_backend_bit() {
-        let index = AvailabilityIndex::new(8192);
+        let index = AvailabilityIndex::with_test_capacity(test_capacity_for(16, 2));
         let msg_id = MessageId::from_borrowed("<highest@example.com>").unwrap();
         let backend_id = BackendId::from_index(7);
 
@@ -1014,7 +874,7 @@ mod tests {
     #[cfg(debug_assertions)]
     #[should_panic(expected = "Backend index 8 exceeds MAX_BACKENDS")]
     fn record_missing_panics_for_out_of_range_backend() {
-        let index = AvailabilityIndex::new(8192);
+        let index = AvailabilityIndex::with_test_capacity(test_capacity_for(8, 2));
         let msg_id = MessageId::from_borrowed("<panic@example.com>").unwrap();
 
         index.record_backend_missing(&msg_id, BackendId::from_index(8));
@@ -1022,7 +882,7 @@ mod tests {
 
     #[test]
     fn sync_availability_persists_only_missing_bits() {
-        let index = AvailabilityIndex::new(8192);
+        let index = AvailabilityIndex::with_test_capacity(test_capacity_for(16, 2));
         let msg_id = MessageId::from_borrowed("<mixed@example.com>").unwrap();
         let mut availability = ArticleAvailability::new();
         availability.record_missing(BackendId::from_index(0));
@@ -1038,108 +898,53 @@ mod tests {
 
     #[test]
     fn zero_capacity_index_never_records_entries() {
-        let index = AvailabilityIndex::new(0);
+        let index = AvailabilityIndex::with_test_capacity(0);
         let msg_id = MessageId::from_borrowed("<nocap@example.com>").unwrap();
         index.record_backend_missing(&msg_id, BackendId::from_index(0));
         assert!(index.get(&msg_id).is_none());
     }
 
     #[test]
-    fn shards_start_in_tiny_mode() {
-        let index = AvailabilityIndex::with_shard_count(4096, 4);
-        for shard in &index.shards {
-            let shard = shard.lock().unwrap_or_else(|e| e.into_inner());
-            assert!(shard.is_tiny());
-            assert_eq!(shard.len(), 0);
-            assert_eq!(shard.used_bytes(), 0);
-        }
-    }
+    fn bounded_filter_stays_within_capacity() {
+        let capacity = test_capacity_for(4, 2);
+        let index = AvailabilityIndex::with_test_capacity(capacity);
 
-    #[test]
-    fn single_negative_entry_stays_in_tiny_mode() {
-        let index = AvailabilityIndex::with_shard_count(4096, 1);
-        let msg_id = MessageId::from_borrowed("<tiny@example.com>").unwrap();
-
-        index.record_backend_missing(&msg_id, BackendId::from_index(0));
-
-        let shard = index.shards[0].lock().unwrap_or_else(|e| e.into_inner());
-        assert!(shard.is_tiny());
-        assert_eq!(shard.len(), 1);
-    }
-
-    #[test]
-    fn shard_promotes_to_full_after_inline_capacity() {
-        let index = AvailabilityIndex::with_shard_count(4096, 1);
-
-        for idx in 0..=INLINE_SHARD_ENTRIES {
-            let msg_id = MessageId::new(format!("<promote-{idx}@example.com>")).unwrap();
-            index.record_backend_missing(&msg_id, BackendId::from_index(idx % 4));
+        for idx in 0..128 {
+            let msg_id = MessageId::new(format!("<bounded-{idx}@example.com>")).unwrap();
+            index.record_backend_missing(&msg_id, BackendId::from_index(idx % MAX_BACKENDS));
         }
 
-        let shard = index.shards[0].lock().unwrap_or_else(|e| e.into_inner());
-        assert!(shard.is_full());
-        assert_eq!(shard.len(), INLINE_SHARD_ENTRIES + 1);
+        assert!(index.used_bytes() <= capacity);
+        assert!(index.entry_count() <= (capacity as usize / SLOT_BYTES) as u64);
     }
 
     #[test]
-    fn promotion_preserves_existing_entries() {
-        let index = AvailabilityIndex::with_shard_count(4096, 1);
-        let first = MessageId::from_borrowed("<first-promote@example.com>").unwrap();
-        let second = MessageId::from_borrowed("<second-promote@example.com>").unwrap();
+    fn saturated_block_evicts_old_fingerprints() {
+        let capacity = test_capacity_for(1, 1);
+        let index = AvailabilityIndex::with_generation_count(capacity, 1);
 
-        index.record_backend_missing(&first, BackendId::from_index(0));
-        index.record_backend_missing(&second, BackendId::from_index(1));
-        for idx in 2..=INLINE_SHARD_ENTRIES {
-            let msg_id = MessageId::new(format!("<fill-{idx}@example.com>")).unwrap();
-            index.record_backend_missing(&msg_id, BackendId::from_index(idx % 4));
+        for idx in 0..(BLOCK_SLOTS + 4) {
+            let msg_id = MessageId::new(format!("<evict-{idx}@example.com>")).unwrap();
+            index.record_backend_missing(&msg_id, BackendId::from_index(idx % MAX_BACKENDS));
         }
-        let trigger = MessageId::from_borrowed("<promote-trigger@example.com>").unwrap();
-        index.record_backend_missing(&trigger, BackendId::from_index(3));
 
+        let latest = MessageId::new(format!("<evict-{}@example.com>", BLOCK_SLOTS + 3)).unwrap();
         assert!(
-            !index
-                .get(&first)
-                .unwrap()
-                .should_try_backend(BackendId::from_index(0))
+            index.get(&latest).is_some(),
+            "latest insert should still be resident"
         );
-        assert!(
-            !index
-                .get(&second)
-                .unwrap()
-                .should_try_backend(BackendId::from_index(1))
-        );
-        let shard = index.shards[0].lock().unwrap_or_else(|e| e.into_inner());
-        assert!(shard.is_full());
-    }
-
-    #[test]
-    fn lru_eviction_keeps_newer_entry() {
-        let index = AvailabilityIndex::with_shard_count(320, 1);
-        let older = MessageId::from_borrowed("<older@example.com>").unwrap();
-        let newer = MessageId::from_borrowed("<newer@example.com>").unwrap();
-        let latest = MessageId::from_borrowed("<latest@example.com>").unwrap();
-
-        index.record_backend_missing(&older, BackendId::from_index(0));
-        index.record_backend_missing(&newer, BackendId::from_index(1));
-        assert!(
-            index.get(&older).is_some(),
-            "touch older so newer becomes LRU"
-        );
-        index.record_backend_missing(&latest, BackendId::from_index(2));
-
-        assert!(index.get(&latest).is_some());
-        assert!(index.get(&older).is_some());
         assert!(
             index.evictions() >= 1,
-            "bounded index should evict rather than saturate"
+            "full blocks should overwrite old fingerprints"
         );
+        assert!(index.entry_count() <= BLOCK_SLOTS as u64);
     }
 
     #[test]
     fn save_and_load_roundtrip_restores_entries() {
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("availability.idx");
-        let index = AvailabilityIndex::with_shard_count(1024, 1);
+        let index = AvailabilityIndex::with_test_capacity(test_capacity_for(16, 2));
         let first = MessageId::from_borrowed("<first@example.com>").unwrap();
         let second = MessageId::from_borrowed("<second@example.com>").unwrap();
 
@@ -1147,7 +952,7 @@ mod tests {
         index.record_backend_missing(&second, BackendId::from_index(2));
         index.save_to_path(&path).unwrap();
 
-        let restored = AvailabilityIndex::with_shard_count(1024, 1);
+        let restored = AvailabilityIndex::with_test_capacity(test_capacity_for(16, 2));
         assert!(restored.load_from_path(&path).unwrap());
 
         assert!(
@@ -1165,54 +970,33 @@ mod tests {
     }
 
     #[test]
-    fn save_and_load_roundtrip_restores_promoted_shard_entries() {
+    fn save_and_load_roundtrip_restores_multiple_backend_bits() {
         let temp_dir = TempDir::new().unwrap();
-        let path = temp_dir.path().join("availability-promoted.idx");
-        let index = AvailabilityIndex::with_shard_count(4096, 1);
+        let path = temp_dir.path().join("availability-multi.idx");
+        let index = AvailabilityIndex::with_test_capacity(test_capacity_for(16, 2));
+        let msg_id = MessageId::from_borrowed("<multi@example.com>").unwrap();
 
-        for idx in 0..=INLINE_SHARD_ENTRIES {
-            let msg_id = MessageId::new(format!("<persist-promote-{idx}@example.com>")).unwrap();
-            index.record_backend_missing(&msg_id, BackendId::from_index(idx % 4));
-        }
+        index.record_backend_missing(&msg_id, BackendId::from_index(1));
+        index.record_backend_missing(&msg_id, BackendId::from_index(3));
         index.save_to_path(&path).unwrap();
 
-        let restored = AvailabilityIndex::with_shard_count(4096, 1);
+        let restored = AvailabilityIndex::with_test_capacity(test_capacity_for(16, 2));
         assert!(restored.load_from_path(&path).unwrap());
 
-        for idx in 0..=INLINE_SHARD_ENTRIES {
-            let msg_id = MessageId::new(format!("<persist-promote-{idx}@example.com>")).unwrap();
-            assert!(
-                restored.get(&msg_id).is_some(),
-                "missing restored entry {idx}"
-            );
-        }
-        let shard = restored.shards[0].lock().unwrap_or_else(|e| e.into_inner());
-        assert!(shard.is_full());
-    }
-
-    #[test]
-    fn full_shard_uses_configured_arena_limit_not_vec_capacity() {
-        let mut shard = FullShard::new(8, 8);
-        shard.arena = Vec::with_capacity(64);
-        shard.arena.extend_from_slice(b"12345678");
-
-        assert_eq!(shard.arena_limit, 8);
-        assert_eq!(shard.arena.len(), 8);
-        assert!(shard.arena.capacity() > shard.arena_limit);
-        assert!(
-            shard.ensure_space_for(1).is_none(),
-            "configured arena budget must win over allocator-rounded capacity"
-        );
+        let cached = restored.get(&msg_id).expect("restored negative");
+        assert!(!cached.should_try_backend(BackendId::from_index(1)));
+        assert!(!cached.should_try_backend(BackendId::from_index(3)));
+        assert!(cached.should_try_backend(BackendId::from_index(0)));
     }
 
     #[test]
     fn load_from_path_skips_expired_entries() {
         let temp_dir = TempDir::new().unwrap();
-        let path = temp_dir.path().join("availability.idx");
-        let index = AvailabilityIndex::with_ttl_and_shard_count(
-            1024,
+        let path = temp_dir.path().join("availability-expired.idx");
+        let index = AvailabilityIndex::with_capacity_and_generation_count(
+            test_capacity_for(8, 2),
             std::time::Duration::from_millis(5),
-            1,
+            DEFAULT_GENERATIONS,
         );
         let msg_id = MessageId::from_borrowed("<persisted-expired@example.com>").unwrap();
 
@@ -1220,16 +1004,34 @@ mod tests {
         index.save_to_path(&path).unwrap();
         std::thread::sleep(std::time::Duration::from_millis(15));
 
-        let restored = AvailabilityIndex::with_ttl_and_shard_count(
-            1024,
+        let restored = AvailabilityIndex::with_capacity_and_generation_count(
+            test_capacity_for(8, 2),
             std::time::Duration::from_millis(5),
-            1,
+            DEFAULT_GENERATIONS,
         );
         assert!(restored.load_from_path(&path).unwrap());
+        assert!(restored.get(&msg_id).is_none());
+    }
 
-        assert!(
-            restored.get(&msg_id).is_none(),
-            "persisted availability-only negatives must not outlive cache TTL"
-        );
+    #[test]
+    fn hit_rate_tracks_hits_and_misses() {
+        let index = AvailabilityIndex::with_test_capacity(test_capacity_for(8, 2));
+        let hit = MessageId::from_borrowed("<hit-rate@example.com>").unwrap();
+        let miss = MessageId::from_borrowed("<miss-rate@example.com>").unwrap();
+
+        index.record_backend_missing(&hit, BackendId::from_index(0));
+        assert!(index.get(&hit).is_some());
+        assert!(index.get(&miss).is_none());
+
+        assert_eq!(index.hit_rate(), 50.0);
+    }
+
+    #[test]
+    fn state_uses_expected_geometry() {
+        let capacity = test_capacity_for(6, 3);
+        let index = AvailabilityIndex::with_generation_count(capacity, 3);
+        let state = index.state.lock().unwrap_or_else(|e| e.into_inner());
+        assert_eq!(state.generation_count(), 3);
+        assert_eq!(state.blocks_per_generation(), 6);
     }
 }

--- a/src/cache/availability_index.rs
+++ b/src/cache/availability_index.rs
@@ -80,6 +80,7 @@ impl TinyEntry {
 struct FullShard {
     slots: Box<[Slot]>,
     len: usize,
+    arena_limit: usize,
     arena: Vec<u8>,
 }
 
@@ -88,6 +89,7 @@ impl FullShard {
         Self {
             slots: vec![Slot::default(); slot_count].into_boxed_slice(),
             len: 0,
+            arena_limit: arena_bytes,
             arena: Vec::with_capacity(arena_bytes),
         }
     }
@@ -211,21 +213,21 @@ impl FullShard {
     fn ensure_space_for(&mut self, required_key_len: usize) -> Option<usize> {
         if self.slots.is_empty()
             || required_key_len == 0
-            || required_key_len > self.arena.capacity()
+            || required_key_len > self.arena_limit
             || required_key_len > u16::MAX as usize
         {
             return None;
         }
 
         let mut evicted = 0usize;
-        while (!self.can_insert() || self.arena.len() + required_key_len > self.arena.capacity())
+        while (!self.can_insert() || self.arena.len() + required_key_len > self.arena_limit)
             && self.len > 0
         {
             self.evict_lru()?;
             evicted += 1;
         }
 
-        if self.can_insert() && self.arena.len() + required_key_len <= self.arena.capacity() {
+        if self.can_insert() && self.arena.len() + required_key_len <= self.arena_limit {
             Some(evicted)
         } else {
             None
@@ -248,7 +250,7 @@ impl FullShard {
         let old_slots = take(&mut self.slots);
         let old_arena = take(&mut self.arena);
 
-        let mut rebuilt = FullShard::new(old_slots.len(), old_arena.capacity());
+        let mut rebuilt = FullShard::new(old_slots.len(), self.arena_limit);
         for (idx, slot) in old_slots.iter().copied().enumerate() {
             if idx == victim_idx || slot.is_empty() {
                 continue;
@@ -1186,6 +1188,21 @@ mod tests {
         }
         let shard = restored.shards[0].lock().unwrap_or_else(|e| e.into_inner());
         assert!(shard.is_full());
+    }
+
+    #[test]
+    fn full_shard_uses_configured_arena_limit_not_vec_capacity() {
+        let mut shard = FullShard::new(8, 8);
+        shard.arena = Vec::with_capacity(64);
+        shard.arena.extend_from_slice(b"12345678");
+
+        assert_eq!(shard.arena_limit, 8);
+        assert_eq!(shard.arena.len(), 8);
+        assert!(shard.arena.capacity() > shard.arena_limit);
+        assert!(
+            shard.ensure_space_for(1).is_none(),
+            "configured arena budget must win over allocator-rounded capacity"
+        );
     }
 
     #[test]

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -353,6 +353,12 @@ impl UnifiedCache {
         Self::Availability(AvailabilityIndex::with_ttl(ttl))
     }
 
+    /// Create a disabled availability index that retains no entries.
+    #[must_use]
+    pub(crate) fn availability_disabled(ttl: std::time::Duration) -> Self {
+        Self::Availability(AvailabilityIndex::disabled(ttl))
+    }
+
     /// Create a memory-only cache
     #[must_use]
     pub fn memory(capacity: u64, ttl: std::time::Duration) -> Self {

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -349,7 +349,7 @@ pub enum UnifiedCache {
 impl UnifiedCache {
     /// Create an availability-only negative index.
     #[must_use]
-    pub fn availability(_capacity: u64, ttl: std::time::Duration) -> Self {
+    pub fn availability(ttl: std::time::Duration) -> Self {
         Self::Availability(AvailabilityIndex::with_ttl(ttl))
     }
 

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -349,8 +349,8 @@ pub enum UnifiedCache {
 impl UnifiedCache {
     /// Create an availability-only negative index.
     #[must_use]
-    pub fn availability(capacity: u64, ttl: std::time::Duration) -> Self {
-        Self::Availability(AvailabilityIndex::with_ttl(capacity, ttl))
+    pub fn availability(_capacity: u64, ttl: std::time::Duration) -> Self {
+        Self::Availability(AvailabilityIndex::with_ttl(ttl))
     }
 
     /// Create a memory-only cache

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -507,4 +507,39 @@ mod tests {
             "unexpected error: {err:#}"
         );
     }
+
+    #[tokio::test]
+    async fn test_drain_multiline_into_stashes_packed_leftover_response() {
+        use crate::pool::BufferPool;
+        use crate::types::BufferSize;
+
+        let article = b"220 body follows\r\nHello world\r\n.\r\n";
+        let packed = [article.as_slice(), b"430 No such article\r\n"].concat();
+        let packed: &'static [u8] = Box::leak(packed.into_boxed_slice());
+        let (addr, notify) = spawn_test_server(packed).await;
+        let pool = make_test_pool(addr);
+        let buffer_pool = BufferPool::new(BufferSize::try_new(4096).unwrap(), 2);
+
+        let mut conn = pool.get().await.unwrap();
+        notify.notify_one();
+
+        let mut io_buffer = buffer_pool.acquire().await;
+        let mut capture = buffer_pool.acquire_capture().await;
+        let first_chunk_size = io_buffer.read_from(&mut *conn).await.unwrap();
+
+        NntpClient::drain_multiline_into(&mut conn, &mut io_buffer, &mut capture, first_chunk_size)
+            .await
+            .unwrap();
+
+        assert_eq!(&capture[..], article as &[u8]);
+        assert!(conn.has_leftover(), "next response should be stashed");
+        assert_eq!(conn.leftover_len(), b"430 No such article\r\n".len());
+
+        let next = io_buffer.read_from(&mut *conn).await.unwrap();
+        assert_eq!(&io_buffer[..next], b"430 No such article\r\n");
+        assert!(
+            !conn.has_leftover(),
+            "stashed bytes should be consumed first"
+        );
+    }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -217,7 +217,7 @@ impl NntpClient {
     ) -> Result<()> {
         use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
 
-        let first_chunk = &io_buffer.as_mut_slice()[..first_chunk_size];
+        let first_chunk = &io_buffer[..first_chunk_size];
         let mut tail = TailBuffer::default();
 
         match tail.detect_terminator(first_chunk) {
@@ -245,20 +245,20 @@ impl NntpClient {
             }
             // NLL: chunk borrow ends before next read_from call
             let found_at = {
-                let chunk = &io_buffer.as_mut_slice()[..n];
+                let chunk = &io_buffer[..n];
                 tail.detect_terminator(chunk)
             };
             match found_at {
                 TerminatorStatus::FoundAt(pos) => {
                     // pos is after the terminator (terminator included in [..pos])
-                    capture.extend_from_slice(&io_buffer.as_mut_slice()[..pos]);
+                    capture.extend_from_slice(&io_buffer[..pos]);
                     if pos < n {
-                        conn.stash_leftover(&io_buffer.as_mut_slice()[pos..n])?;
+                        conn.stash_leftover(&io_buffer[pos..n])?;
                     }
                     return Ok(());
                 }
                 TerminatorStatus::NotFound => {
-                    let chunk = &io_buffer.as_mut_slice()[..n];
+                    let chunk = &io_buffer[..n];
                     tail.update(chunk);
                     capture.extend_from_slice(chunk);
                 }

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -283,6 +283,18 @@ impl ChunkedResponse {
         self.len = 0;
     }
 
+    /// Append an initialized owned chunk without copying its bytes.
+    #[inline]
+    pub fn push_chunk(&mut self, chunk: PooledBuffer) {
+        let chunk_len = chunk.initialized();
+        if chunk_len == 0 {
+            return;
+        }
+
+        self.len += chunk_len;
+        self.chunks.push(chunk);
+    }
+
     /// Append bytes using one or more pooled capture buffers.
     ///
     /// # Panics
@@ -982,6 +994,47 @@ mod tests {
         let mut prefix = SmallVec::<[u8; 128]>::new();
         response.copy_prefix_into(64, &mut prefix);
         assert_eq!(&prefix[..], b"430\r\n");
+    }
+
+    #[tokio::test]
+    async fn test_chunked_response_push_chunk_preserves_owned_boundaries() {
+        let pool = BufferPool::new(BufferSize::try_new(16).unwrap(), 4).with_capture_pool(1024, 1);
+        let mut first = pool.acquire().await;
+        let mut second = pool.acquire().await;
+        first.copy_from_slice(b"220 0 <id>\r\n");
+        second.copy_from_slice(b"Body\r\n.\r\n");
+
+        let mut response = ChunkedResponse::default();
+        response.push_chunk(first);
+        response.push_chunk(second);
+
+        let chunks: Vec<&[u8]> = response.iter_chunks().collect();
+        assert_eq!(
+            chunks,
+            vec![b"220 0 <id>\r\n".as_slice(), b"Body\r\n.\r\n".as_slice()]
+        );
+        assert_eq!(response.to_vec(), b"220 0 <id>\r\nBody\r\n.\r\n");
+    }
+
+    #[tokio::test]
+    async fn test_chunked_response_truncate_mid_owned_chunk() {
+        let pool = BufferPool::new(BufferSize::try_new(16).unwrap(), 4).with_capture_pool(1024, 1);
+        let mut first = pool.acquire().await;
+        let mut second = pool.acquire().await;
+        first.copy_from_slice(b"220 0 <id>\r\n");
+        second.copy_from_slice(b"Body\r\n.\r\n");
+
+        let mut response = ChunkedResponse::default();
+        response.push_chunk(first);
+        response.push_chunk(second);
+        response.truncate(b"220 0 <id>\r\nBody\r\n".len());
+
+        let chunks: Vec<&[u8]> = response.iter_chunks().collect();
+        assert_eq!(
+            chunks,
+            vec![b"220 0 <id>\r\n".as_slice(), b"Body\r\n".as_slice()]
+        );
+        assert_eq!(response.to_vec(), b"220 0 <id>\r\nBody\r\n");
     }
 
     #[tokio::test]

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -137,32 +137,6 @@ impl PooledBuffer {
         self.buffer.truncate(len);
     }
 
-    /// Get mutable access to the fixed I/O writable region.
-    ///
-    /// This is for scratch-buffer paths that need to inspect bytes returned by
-    /// a read that already reported its byte count. It does not update the
-    /// logical initialized length; callers must use the read byte count directly.
-    ///
-    /// # Safety Note
-    /// Only bytes written by the caller's I/O operation should be read. Prefer
-    /// `read_from()` or `read_more()` when possible because those update the
-    /// initialized length automatically.
-    ///
-    /// # Examples
-    /// ```ignore
-    /// let mut buffer = pool.acquire().await;
-    /// let n = stream.read(buffer.as_mut_slice()).await?;
-    /// let initialized_data = &buffer.as_mut_slice()[..n];
-    /// ```
-    #[must_use]
-    #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [u8] {
-        // `create_aligned_buffer` initializes the full writable region before
-        // clearing the logical length, so this preserves the old fixed-I/O API
-        // without making those bytes part of the initialized slice.
-        unsafe { std::slice::from_raw_parts_mut(self.buffer.as_mut_ptr(), self.writable_len) }
-    }
-
     /// Append data to the buffer (accumulator mode)
     ///
     /// Used when `PooledBuffer` is acquired from capture pool for accumulating
@@ -206,7 +180,7 @@ impl Deref for PooledBuffer {
     }
 }
 
-// Intentionally NO DerefMut or AsMut - forces explicit use of read_from() or as_mut_slice()
+// Intentionally NO DerefMut or AsMut - forces explicit use of read_from()/read_more()
 
 impl AsRef<[u8]> for PooledBuffer {
     #[inline]
@@ -480,12 +454,8 @@ impl BufferPool {
     /// **INTERNAL USE ONLY.** This function is not exposed publicly and is only used
     /// within the buffer pool implementation where the safety contract is guaranteed.
     ///
-    /// The returned buffer has initialized spare storage for the fixed I/O view, but a logical
-    /// length of zero. Only bytes added to the `BytesMut` logical length are exposed through the
-    /// public initialized slice APIs.
-    ///
-    /// The public API (`acquire()`) returns a `PooledBuffer` which is a safe wrapper that
-    /// enforces this contract through the type system and usage patterns.
+    /// The returned buffer has a logical length of zero. Only bytes added to the
+    /// `BytesMut` logical length are exposed through the public initialized slice APIs.
     fn create_aligned_buffer(size: usize) -> BytesMut {
         // Align to page boundaries (4KB) for better memory performance
         let page_size = 4096;
@@ -496,7 +466,7 @@ impl BufferPool {
         buffer
     }
 
-    /// Pre-fault pages by writing to each 4KB stride to map physical memory
+    /// Pre-fault pages by touching one byte per 4KB stride to map physical memory.
     ///
     /// This eliminates page faults during streaming by ensuring all pages are
     /// resident in physical memory. Without this, the first write to each page
@@ -504,23 +474,21 @@ impl BufferPool {
     ///
     /// # Safety
     ///
-    /// M2: We write within the buffer's allocated capacity (not beyond it).
+    /// We write within the buffer's allocated capacity (not beyond it).
     /// `write_volatile` touches one byte per 4KB page to trigger the OS page fault
-    /// at init time rather than during streaming I/O. Values are overwritten by
-    /// actual I/O before being read.
+    /// at init time rather than during streaming I/O. We deliberately do NOT zero
+    /// the full allocation first; scratch buffers are filled via `read_buf` before
+    /// their bytes become part of the initialized slice.
     fn prefault_pages(buf: &mut BytesMut) {
         let cap = buf.capacity();
-        buf.resize(cap, 0);
-        // SAFETY: We write within the buffer's allocated capacity.
-        // Each write_volatile touches one byte per 4KB page to trigger page faults.
-        // These sentinel values (1) are overwritten by real I/O data before being read.
+        // SAFETY: We write within the buffer's allocated capacity. `BytesMut::with_capacity`
+        // reserves that storage even though the logical length remains zero.
         unsafe {
             let ptr = buf.as_mut_ptr();
             for offset in (0..cap).step_by(4096) {
                 std::ptr::write_volatile(ptr.add(offset), 1);
             }
         }
-        buf.clear();
     }
 
     /// Create a new buffer pool with pre-allocated buffers
@@ -800,7 +768,7 @@ mod tests {
     async fn test_read_from_is_limited_to_fixed_writable_region() {
         let pool = BufferPool::new(BufferSize::try_new(8).unwrap(), 1);
         let mut buffer = pool.acquire().await;
-        assert!(buffer.capacity() > buffer.as_mut_slice().len());
+        assert_eq!(buffer.capacity(), 4096);
 
         let (mut writer, mut reader) = tokio::io::duplex(64);
         writer
@@ -812,7 +780,7 @@ mod tests {
         let read = buffer.read_from(&mut reader).await.unwrap();
         assert_eq!(read, 8);
         assert_eq!(buffer.initialized(), 8);
-        assert_eq!(buffer.as_mut_slice()[..read].len(), read);
+        assert_eq!(buffer[..read].len(), read);
     }
 
     #[tokio::test]
@@ -1168,30 +1136,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_as_mut_slice() {
-        let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 5);
-        let mut buffer = pool.acquire().await;
-
-        // Get mutable slice and write to it
-        let slice = buffer.as_mut_slice();
-        assert_eq!(slice.len(), 1024);
-
-        // Write some data manually
-        slice[0] = b'H';
-        slice[1] = b'i';
-        slice[2] = b'!';
-
-        // Can write to the fixed I/O writable region
-        for (i, byte) in slice.iter_mut().enumerate() {
-            *byte = u8::try_from(i % 256).expect("modulo 256 always fits in u8");
-        }
-
-        // Note: initialized() doesn't track manual writes via as_mut_slice
-        // This is intentional - as_mut_slice is for low-level I/O
-        assert_eq!(buffer.initialized(), 0);
-    }
-
-    #[tokio::test]
     async fn test_buffer_pool_stress() {
         let pool = BufferPool::new(BufferSize::try_new(4096).unwrap(), 10);
 
@@ -1303,16 +1247,6 @@ mod tests {
         buffer.copy_from_slice(b"Small");
         assert_eq!(buffer.capacity(), 8192);
         assert_eq!(buffer.initialized(), 5);
-    }
-
-    #[tokio::test]
-    async fn test_as_mut_slice_capacity() {
-        let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 5);
-        let mut buffer = pool.acquire().await;
-
-        // as_mut_slice should return the fixed I/O writable region
-        let slice = buffer.as_mut_slice();
-        assert_eq!(slice.len(), 1024);
     }
 
     #[tokio::test]

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -257,18 +257,6 @@ impl ChunkedResponse {
         self.len = 0;
     }
 
-    /// Append an initialized owned chunk without copying its bytes.
-    #[inline]
-    pub fn push_chunk(&mut self, chunk: PooledBuffer) {
-        let chunk_len = chunk.initialized();
-        if chunk_len == 0 {
-            return;
-        }
-
-        self.len += chunk_len;
-        self.chunks.push(chunk);
-    }
-
     /// Append bytes using one or more pooled capture buffers.
     ///
     /// # Panics
@@ -962,47 +950,6 @@ mod tests {
         let mut prefix = SmallVec::<[u8; 128]>::new();
         response.copy_prefix_into(64, &mut prefix);
         assert_eq!(&prefix[..], b"430\r\n");
-    }
-
-    #[tokio::test]
-    async fn test_chunked_response_push_chunk_preserves_owned_boundaries() {
-        let pool = BufferPool::new(BufferSize::try_new(16).unwrap(), 4).with_capture_pool(1024, 1);
-        let mut first = pool.acquire().await;
-        let mut second = pool.acquire().await;
-        first.copy_from_slice(b"220 0 <id>\r\n");
-        second.copy_from_slice(b"Body\r\n.\r\n");
-
-        let mut response = ChunkedResponse::default();
-        response.push_chunk(first);
-        response.push_chunk(second);
-
-        let chunks: Vec<&[u8]> = response.iter_chunks().collect();
-        assert_eq!(
-            chunks,
-            vec![b"220 0 <id>\r\n".as_slice(), b"Body\r\n.\r\n".as_slice()]
-        );
-        assert_eq!(response.to_vec(), b"220 0 <id>\r\nBody\r\n.\r\n");
-    }
-
-    #[tokio::test]
-    async fn test_chunked_response_truncate_mid_owned_chunk() {
-        let pool = BufferPool::new(BufferSize::try_new(16).unwrap(), 4).with_capture_pool(1024, 1);
-        let mut first = pool.acquire().await;
-        let mut second = pool.acquire().await;
-        first.copy_from_slice(b"220 0 <id>\r\n");
-        second.copy_from_slice(b"Body\r\n.\r\n");
-
-        let mut response = ChunkedResponse::default();
-        response.push_chunk(first);
-        response.push_chunk(second);
-        response.truncate(b"220 0 <id>\r\nBody\r\n".len());
-
-        let chunks: Vec<&[u8]> = response.iter_chunks().collect();
-        assert_eq!(
-            chunks,
-            vec![b"220 0 <id>\r\n".as_slice(), b"Body\r\n".as_slice()]
-        );
-        assert_eq!(response.to_vec(), b"220 0 <id>\r\nBody\r\n");
     }
 
     #[tokio::test]

--- a/src/proxy/builder.rs
+++ b/src/proxy/builder.rs
@@ -237,22 +237,24 @@ impl NntpProxyBuilder {
     /// Log cache configuration details
     fn log_cache_config(cache_config: &crate::config::Cache, cache_articles: bool) {
         let capacity = cache_config.max_capacity.as_u64();
-        if capacity > 0 {
-            if cache_articles {
-                info!(
-                    "Article cache enabled: max_capacity={}, ttl={}s (full caching)",
-                    cache_config.max_capacity,
-                    cache_config.ttl.as_secs()
-                );
-            } else {
-                info!(
-                    "Article cache enabled: max_capacity={}, ttl={}s (availability-only, bodies not cached)",
-                    cache_config.max_capacity,
-                    cache_config.ttl.as_secs()
-                );
-            }
+        if cache_articles {
+            info!(
+                "Article cache enabled: max_capacity={}, ttl={}s (full caching)",
+                cache_config.max_capacity,
+                cache_config.ttl.as_secs()
+            );
+        } else if capacity < crate::cache::AvailabilityIndex::fixed_capacity_bytes() {
+            info!(
+                "Availability-only cache disabled: configured budget {} is smaller than fixed index size {} bytes",
+                cache_config.max_capacity,
+                crate::cache::AvailabilityIndex::fixed_capacity_bytes()
+            );
         } else {
-            info!("Backend availability tracking enabled (fixed-size availability index)");
+            info!(
+                "Backend availability tracking enabled: max_capacity={}, ttl={}s (fixed-size availability index, bodies not cached)",
+                cache_config.max_capacity,
+                cache_config.ttl.as_secs()
+            );
         }
     }
 
@@ -274,7 +276,13 @@ impl NntpProxyBuilder {
             let cache_articles = cache_config.cache_articles;
 
             let cache = if !cache_articles {
-                Arc::new(UnifiedCache::availability(cache_config.ttl))
+                Arc::new(
+                    if capacity < crate::cache::AvailabilityIndex::fixed_capacity_bytes() {
+                        UnifiedCache::availability_disabled(cache_config.ttl)
+                    } else {
+                        UnifiedCache::availability(cache_config.ttl)
+                    },
+                )
             } else if let Some(disk_config) = &cache_config.disk {
                 let hybrid_config = HybridCacheConfig {
                     memory_capacity: capacity,
@@ -340,7 +348,14 @@ impl NntpProxyBuilder {
                 let capacity = cache_config.max_capacity.as_u64();
                 Arc::new(UnifiedCache::memory(capacity, cache_config.ttl))
             } else {
-                Arc::new(UnifiedCache::availability(cache_config.ttl))
+                let capacity = cache_config.max_capacity.as_u64();
+                Arc::new(
+                    if capacity < crate::cache::AvailabilityIndex::fixed_capacity_bytes() {
+                        UnifiedCache::availability_disabled(cache_config.ttl)
+                    } else {
+                        UnifiedCache::availability(cache_config.ttl)
+                    },
+                )
             };
 
             Self::log_cache_config(cache_config, cache_articles);
@@ -441,9 +456,26 @@ impl BuildContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cache::AvailabilityIndex;
+    use crate::config::Cache;
+    use crate::types::CacheCapacity;
+    use std::time::Duration;
 
     fn create_test_config() -> Config {
         super::super::tests::create_test_config()
+    }
+
+    fn availability_only_config(capacity: u64) -> Config {
+        let mut config = create_test_config();
+        config.cache = Some(Cache {
+            max_capacity: CacheCapacity::try_new(capacity).unwrap(),
+            ttl: Duration::from_secs(60),
+            cache_articles: false,
+            adaptive_precheck: false,
+            disk: None,
+            availability_file: None,
+        });
+        config
     }
 
     #[test]
@@ -493,6 +525,49 @@ mod tests {
 
         assert_eq!(proxy.servers().len(), 3);
         assert_eq!(proxy.router.backend_count(), 3);
+    }
+
+    #[test]
+    fn test_build_sync_disables_availability_index_when_budget_is_too_small() {
+        let proxy = NntpProxyBuilder::new(availability_only_config(1))
+            .build_sync()
+            .expect("Failed to build proxy");
+
+        assert!(!proxy.cache_articles);
+        assert_eq!(proxy.cache.capacity(), 0);
+        assert_eq!(proxy.cache.weighted_size(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_build_disables_availability_index_when_budget_is_too_small() {
+        let proxy = NntpProxyBuilder::new(availability_only_config(1))
+            .build()
+            .await
+            .expect("Failed to build proxy");
+
+        assert!(!proxy.cache_articles);
+        assert_eq!(proxy.cache.capacity(), 0);
+        assert_eq!(proxy.cache.weighted_size(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_build_enables_fixed_availability_index_when_budget_can_hold_it() {
+        let proxy = NntpProxyBuilder::new(availability_only_config(
+            AvailabilityIndex::fixed_capacity_bytes(),
+        ))
+        .build()
+        .await
+        .expect("Failed to build proxy");
+
+        assert!(!proxy.cache_articles);
+        assert_eq!(
+            proxy.cache.capacity(),
+            AvailabilityIndex::fixed_capacity_bytes()
+        );
+        assert_eq!(
+            proxy.cache.weighted_size(),
+            AvailabilityIndex::fixed_capacity_bytes()
+        );
     }
 
     #[test]

--- a/src/proxy/builder.rs
+++ b/src/proxy/builder.rs
@@ -252,7 +252,7 @@ impl NntpProxyBuilder {
                 );
             }
         } else {
-            info!("Backend availability tracking enabled (cache disabled, capacity=0)");
+            info!("Backend availability tracking enabled (fixed-size availability index)");
         }
     }
 
@@ -274,7 +274,7 @@ impl NntpProxyBuilder {
             let cache_articles = cache_config.cache_articles;
 
             let cache = if !cache_articles {
-                Arc::new(UnifiedCache::availability(capacity, cache_config.ttl))
+                Arc::new(UnifiedCache::availability(cache_config.ttl))
             } else if let Some(disk_config) = &cache_config.disk {
                 let hybrid_config = HybridCacheConfig {
                     memory_capacity: capacity,
@@ -304,11 +304,8 @@ impl NntpProxyBuilder {
             Self::log_cache_config(cache_config, cache_articles);
             (cache, cache_articles)
         } else {
-            debug!("Cache not configured, using availability-only mode (capacity=0)");
-            (
-                Arc::new(UnifiedCache::availability(0, Duration::MAX)),
-                false,
-            )
+            debug!("Cache not configured, using fixed-size availability-only mode");
+            (Arc::new(UnifiedCache::availability(Duration::MAX)), false)
         };
 
         Ok(ctx.into_proxy(cache, cache_articles))
@@ -331,7 +328,6 @@ impl NntpProxyBuilder {
 
         // Create article cache (memory-only in sync version)
         let (cache, cache_articles) = if let Some(cache_config) = &cache_config {
-            let capacity = cache_config.max_capacity.as_u64();
             let cache_articles = cache_config.cache_articles;
 
             if cache_config.disk.is_some() && cache_articles {
@@ -341,19 +337,17 @@ impl NntpProxyBuilder {
             }
 
             let cache = if cache_articles {
+                let capacity = cache_config.max_capacity.as_u64();
                 Arc::new(UnifiedCache::memory(capacity, cache_config.ttl))
             } else {
-                Arc::new(UnifiedCache::availability(capacity, cache_config.ttl))
+                Arc::new(UnifiedCache::availability(cache_config.ttl))
             };
 
             Self::log_cache_config(cache_config, cache_articles);
             (cache, cache_articles)
         } else {
-            debug!("Cache not configured, using availability-only mode (capacity=0)");
-            (
-                Arc::new(UnifiedCache::availability(0, Duration::MAX)),
-                false,
-            )
+            debug!("Cache not configured, using fixed-size availability-only mode");
+            (Arc::new(UnifiedCache::availability(Duration::MAX)), false)
         };
 
         Ok(ctx.into_proxy(cache, cache_articles))

--- a/src/proxy/lifecycle.rs
+++ b/src/proxy/lifecycle.rs
@@ -635,7 +635,6 @@ mod tests {
         let proxy = NntpProxy::new_sync(config, RoutingMode::Hybrid).unwrap();
 
         let _empty_cache = Arc::new(crate::cache::UnifiedCache::availability(
-            100,
             std::time::Duration::MAX,
         ));
         assert_eq!(proxy.routing_mode_display_name(), "per-command");

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -44,7 +44,7 @@ pub struct NntpProxy {
     pub(super) metrics: MetricsCollector,
     /// Connection statistics aggregator (reduces log spam)
     pub(super) connection_stats: ConnectionStatsAggregator,
-    /// Article cache (always present - tracks backend availability even with capacity=0)
+    /// Article cache (always present - at minimum a fixed-size availability index)
     pub(super) cache: Arc<UnifiedCache>,
     /// Whether to cache article bodies (config-driven)
     pub(super) cache_articles: bool,

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -44,7 +44,7 @@ pub struct NntpProxy {
     pub(super) metrics: MetricsCollector,
     /// Connection statistics aggregator (reduces log spam)
     pub(super) connection_stats: ConnectionStatsAggregator,
-    /// Article cache (always present - at minimum a fixed-size availability index)
+    /// Article cache (always present - fixed-size, memory-backed, hybrid, or disabled)
     pub(super) cache: Arc<UnifiedCache>,
     /// Whether to cache article bodies (config-driven)
     pub(super) cache_articles: bool,
@@ -201,7 +201,7 @@ impl NntpProxy {
         &self.buffer_pool
     }
 
-    /// Get the article cache (always present - capacity 0 if not configured)
+    /// Get the article cache (always present, though availability-only mode may be disabled)
     #[must_use]
     #[inline]
     pub const fn cache(&self) -> &Arc<UnifiedCache> {

--- a/src/session/core.rs
+++ b/src/session/core.rs
@@ -34,7 +34,7 @@ pub struct ClientSession {
     /// Connection statistics aggregator for logging connection creation
     pub(super) connection_stats: Option<crate::metrics::ConnectionStatsAggregator>,
 
-    /// Article cache (always present - tracks backend availability even with capacity=0)
+    /// Article cache (always present - at minimum a fixed-size availability index)
     pub(super) cache: Arc<crate::cache::UnifiedCache>,
 
     /// Whether to cache article bodies (config-driven)
@@ -192,7 +192,6 @@ impl ClientSession {
     /// Create default cache for availability tracking only (no content caching)
     fn default_cache() -> Arc<crate::cache::UnifiedCache> {
         Arc::new(crate::cache::UnifiedCache::availability(
-            0,
             std::time::Duration::MAX,
         ))
     }
@@ -245,7 +244,6 @@ impl ClientSession {
             metrics,
             connection_stats: None,
             cache: Arc::new(crate::cache::UnifiedCache::availability(
-                0,
                 std::time::Duration::MAX,
             )),
             cache_articles: true,
@@ -290,7 +288,6 @@ impl ClientSession {
             metrics,
             connection_stats: None,
             cache: Arc::new(crate::cache::UnifiedCache::availability(
-                0,
                 std::time::Duration::MAX,
             )),
             cache_articles: true,

--- a/src/session/core.rs
+++ b/src/session/core.rs
@@ -34,7 +34,7 @@ pub struct ClientSession {
     /// Connection statistics aggregator for logging connection creation
     pub(super) connection_stats: Option<crate::metrics::ConnectionStatsAggregator>,
 
-    /// Article cache (always present - at minimum a fixed-size availability index)
+    /// Article cache (always present - fixed-size, memory-backed, hybrid, or disabled)
     pub(super) cache: Arc<crate::cache::UnifiedCache>,
 
     /// Whether to cache article bodies (config-driven)

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -71,9 +71,8 @@ struct RequestExecutionIo<'a, 'b> {
 enum PreparedRequest {
     /// The response was already written to the client.
     Served,
-    /// Continue with backend routing using the resolved message ID and availability.
+    /// Continue with backend routing using resolved availability state.
     Continue {
-        msg_id: Option<crate::types::MessageId<'static>>,
         availability: Option<ArticleAvailability>,
     },
 }
@@ -570,15 +569,12 @@ impl ClientSession {
             client_to_backend_bytes,
             backend_to_client_bytes,
         };
-        let (msg_id, mut availability) = match self
+        let mut availability = match self
             .prepare_request_execution(&router, request, &mut io)
             .await?
         {
             PreparedRequest::Served => return Ok(()),
-            PreparedRequest::Continue {
-                msg_id,
-                availability,
-            } => (msg_id, availability),
+            PreparedRequest::Continue { availability } => availability,
         };
 
         if !request.is_large_transfer()
@@ -589,7 +585,7 @@ impl ClientSession {
             return Ok(());
         }
 
-        self.execute_article_retry_loop(&router, request, msg_id, availability, &mut io)
+        self.execute_article_retry_loop(&router, request, availability, &mut io)
             .await
     }
 
@@ -624,19 +620,11 @@ impl ClientSession {
                 .map(Self::request_cache_availability),
             CacheLookupResult::Miss => None,
         };
-        let msg_id = request.message_id_value().map(|msg_id| msg_id.to_owned());
-
-        if self
-            .try_adaptive_precheck(router, request, io, msg_id.as_ref())
-            .await?
-        {
+        if self.try_adaptive_precheck(router, request, io).await? {
             return Ok(PreparedRequest::Served);
         }
 
-        Ok(PreparedRequest::Continue {
-            msg_id,
-            availability,
-        })
+        Ok(PreparedRequest::Continue { availability })
     }
 
     const fn request_cache_availability(
@@ -650,17 +638,16 @@ impl ClientSession {
         router: &Arc<BackendSelector>,
         request: &RequestContext,
         io: &mut RequestExecutionIo<'_, '_>,
-        msg_id: Option<&crate::types::MessageId<'static>>,
     ) -> Result<bool, SessionError> {
         if !self.adaptive_precheck || !(request.is_stat() || request.is_head()) {
             return Ok(false);
         }
-        let Some(msg_id) = msg_id else {
+        let Some(msg_id) = request.message_id_value() else {
             return Ok(false);
         };
 
         let deps = self.precheck_deps(router);
-        let bytes_written = if let Some(entry) = precheck::precheck(&deps, request, msg_id).await {
+        let bytes_written = if let Some(entry) = precheck::precheck(&deps, request, &msg_id).await {
             if let Some(write) = write_cached_article_response(
                 io.client_write,
                 &entry,
@@ -788,7 +775,6 @@ impl ClientSession {
         &self,
         router: &Arc<BackendSelector>,
         request: &mut RequestContext,
-        msg_id: Option<crate::types::MessageId<'static>>,
         availability: Option<ArticleAvailability>,
         io: &mut RequestExecutionIo<'_, '_>,
     ) -> Result<(), SessionError> {
@@ -813,7 +799,6 @@ impl ClientSession {
                 .try_backend_for_article(
                     router,
                     request,
-                    msg_id.as_ref(),
                     io.client_write,
                     &mut ArticleAttemptState {
                         availability: &mut availability,
@@ -829,6 +814,7 @@ impl ClientSession {
                         .expect("successful direct attempt records response metadata");
                     *io.backend_to_client_bytes =
                         io.backend_to_client_bytes.add(response.wire_len().get());
+                    let msg_id = request.message_id_value();
                     self.sync_availability_if_needed(msg_id.as_ref(), &availability)
                         .await;
                     return Ok(());
@@ -859,8 +845,10 @@ impl ClientSession {
 
         debug!(
             "Client {} all backends exhausted for {:?}, sending 430",
-            self.client_addr, msg_id
+            self.client_addr,
+            request.message_id_value()
         );
+        let msg_id = request.message_id_value();
         self.sync_availability_if_needed(msg_id.as_ref(), &availability)
             .await;
         self.send_430_to_client(io.client_write, io.backend_to_client_bytes)

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -105,7 +105,6 @@ impl ClientSession {
         &self,
         router: &Arc<BackendSelector>,
         request: &mut RequestContext,
-        msg_id: Option<&crate::types::MessageId<'_>>,
         client_write: &mut tokio::net::tcp::WriteHalf<'_>,
         state: &mut ArticleAttemptState<'_>,
     ) -> Result<BackendAttemptResult, SessionError> {
@@ -130,6 +129,7 @@ impl ClientSession {
             return Ok(BackendAttemptResult::ArticleNotFound { backend_id });
         }
 
+        let msg_id = request.message_id_value();
         let response = self
             .stream_successful_backend_response(
                 conn,
@@ -137,7 +137,7 @@ impl ClientSession {
                 backend_id,
                 ResponseStreamParams {
                     request,
-                    msg_id,
+                    msg_id: msg_id.as_ref(),
                     status_code,
                     first_chunk: &state.buffer[..cmd_response.bytes_read],
                 },
@@ -154,6 +154,7 @@ impl ClientSession {
         request: &RequestContext,
         state: &mut ArticleAttemptState<'_>,
     ) -> Result<PreparedBackendAttempt, SessionError> {
+        let request_wire_len = request.request_wire_len().get();
         let (conn, cmd_response, timings) = retry_once!(
             self.execute_backend_attempt(provider, backend_id, request, state.buffer)
                 .await,
@@ -165,9 +166,7 @@ impl ClientSession {
         if let Some((ttfb, send, recv)) = timings {
             self.record_timing_metrics(backend_id, ttfb, send, recv);
         }
-        *state.client_to_backend_bytes = state
-            .client_to_backend_bytes
-            .add(request.request_wire_len().get());
+        *state.client_to_backend_bytes = state.client_to_backend_bytes.add(request_wire_len);
 
         let Some(status_code) = cmd_response.status_code() else {
             self.handle_invalid_backend_response(

--- a/src/session/handlers/pipeline_worker.rs
+++ b/src/session/handlers/pipeline_worker.rs
@@ -536,6 +536,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_buffer_response_for_request_multiline_keeps_nonterminal_reads_chunked() {
+        let pool = BufferPool::new(crate::types::BufferSize::try_new(32).unwrap(), 4)
+            .with_capture_pool(1024, 1);
+        let mut buffer = pool.acquire().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
+
+        let response =
+            b"220 0 <msg@id> article\r\nSubject: test\r\n\r\nBody line one\r\nBody line two\r\n.\r\n";
+        let mut conn = mock_backend_conn(response).await;
+
+        let status = buffer_response_for_request(
+            ARTICLE_REQUEST,
+            &mut buffer,
+            &mut conn,
+            &mut result_buf,
+            &pool,
+        )
+        .await
+        .expect("should parse multiline response");
+
+        assert_eq!(status.as_u16(), 220);
+        assert_eq!(result_buf.to_vec(), response);
+        assert!(
+            result_buf.iter_chunks().count() > 1,
+            "whole non-terminal reads should stay as owned chunks instead of being recopied into one capture buffer"
+        );
+    }
+
+    #[tokio::test]
     async fn test_buffer_response_for_request_with_leftover() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
@@ -573,6 +602,50 @@ mod tests {
         )
         .await
         .expect("should parse second response from leftover");
+
+        assert_eq!(status2.as_u16(), 430);
+        assert_eq!(result_buf.to_vec(), b"430 No such article\r\n");
+    }
+
+    #[tokio::test]
+    async fn test_buffer_response_for_request_multiline_terminal_chunk_stashes_leftover() {
+        let pool = BufferPool::new(crate::types::BufferSize::try_new(32).unwrap(), 4)
+            .with_capture_pool(1024, 1);
+        let mut buffer = pool.acquire().await;
+        let mut result_buf = crate::pool::ChunkedResponse::default();
+
+        let first =
+            b"220 0 <a@b> article\r\nSubject: split\r\n\r\nBody line one\r\nBody line two\r\n.\r\n";
+        let packed = [first.as_slice(), b"430 No such article\r\n"].concat();
+        let mut conn = mock_backend_conn(&packed).await;
+
+        let status1 = buffer_response_for_request(
+            ARTICLE_REQUEST,
+            &mut buffer,
+            &mut conn,
+            &mut result_buf,
+            &pool,
+        )
+        .await
+        .expect("should parse first response");
+
+        assert_eq!(status1.as_u16(), 220);
+        assert_eq!(result_buf.to_vec(), first);
+        assert!(
+            result_buf.iter_chunks().count() > 1,
+            "owned non-terminal chunks should survive even when the final read also contains leftover"
+        );
+        assert!(conn.has_leftover(), "next response should remain stashed");
+
+        let status2 = buffer_response_for_request(
+            ARTICLE_REQUEST,
+            &mut buffer,
+            &mut conn,
+            &mut result_buf,
+            &pool,
+        )
+        .await
+        .expect("should parse leftover response");
 
         assert_eq!(status2.as_u16(), 430);
         assert_eq!(result_buf.to_vec(), b"430 No such article\r\n");

--- a/src/session/handlers/pipeline_worker.rs
+++ b/src/session/handlers/pipeline_worker.rs
@@ -536,35 +536,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_buffer_response_for_request_multiline_keeps_nonterminal_reads_chunked() {
-        let pool = BufferPool::new(crate::types::BufferSize::try_new(32).unwrap(), 4)
-            .with_capture_pool(1024, 1);
-        let mut buffer = pool.acquire().await;
-        let mut result_buf = crate::pool::ChunkedResponse::default();
-
-        let response =
-            b"220 0 <msg@id> article\r\nSubject: test\r\n\r\nBody line one\r\nBody line two\r\n.\r\n";
-        let mut conn = mock_backend_conn(response).await;
-
-        let status = buffer_response_for_request(
-            ARTICLE_REQUEST,
-            &mut buffer,
-            &mut conn,
-            &mut result_buf,
-            &pool,
-        )
-        .await
-        .expect("should parse multiline response");
-
-        assert_eq!(status.as_u16(), 220);
-        assert_eq!(result_buf.to_vec(), response);
-        assert!(
-            result_buf.iter_chunks().count() > 1,
-            "whole non-terminal reads should stay as owned chunks instead of being recopied into one capture buffer"
-        );
-    }
-
-    #[tokio::test]
     async fn test_buffer_response_for_request_with_leftover() {
         let pool = BufferPool::for_tests();
         let mut buffer = pool.acquire().await;
@@ -631,10 +602,6 @@ mod tests {
 
         assert_eq!(status1.as_u16(), 220);
         assert_eq!(result_buf.to_vec(), first);
-        assert!(
-            result_buf.iter_chunks().count() > 1,
-            "owned non-terminal chunks should survive even when the final read also contains leftover"
-        );
         assert!(conn.has_leftover(), "next response should remain stashed");
 
         let status2 = buffer_response_for_request(

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -563,7 +563,7 @@ mod tests {
         use crate::types::BackendId;
 
         let backend_id = BackendId::from_index(0);
-        let cache = UnifiedCache::availability(100, std::time::Duration::MAX);
+        let cache = UnifiedCache::availability(std::time::Duration::MAX);
         let msg_id = MessageId::new("<test@example.com>".to_string()).unwrap();
 
         cache_precheck_hit(

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -296,9 +296,7 @@ async fn fill_multiline_response(
         }
         TerminatorStatus::NotFound => {
             tail.update(&io_buffer[..initial_chunk_len]);
-            let mut owned_chunk = pool.acquire().await;
-            std::mem::swap(io_buffer, &mut owned_chunk);
-            response.push_chunk(owned_chunk);
+            response.extend_from_slice(pool, &io_buffer[..initial_chunk_len]);
         }
     }
 
@@ -331,9 +329,7 @@ async fn fill_multiline_response(
             "non-terminal multiline chunk should consume full read"
         );
         tail.update(&io_buffer[..write_len]);
-        let mut owned_chunk = pool.acquire().await;
-        std::mem::swap(io_buffer, &mut owned_chunk);
-        response.push_chunk(owned_chunk);
+        response.extend_from_slice(pool, &io_buffer[..write_len]);
     }
 }
 
@@ -465,9 +461,7 @@ pub(crate) async fn buffer_multiline_response(
                     "non-terminal multiline chunk should consume full read"
                 );
                 tail.update(&io_buffer[..write_len]);
-                let mut owned_chunk = ctx.buffer_pool.acquire().await;
-                std::mem::swap(&mut io_buffer, &mut owned_chunk);
-                captured.push_chunk(owned_chunk);
+                captured.extend_from_slice(ctx.buffer_pool, &io_buffer[..write_len]);
             }
         }
     }

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -284,20 +284,21 @@ async fn fill_multiline_response(
 ) -> Result<(), StreamingError> {
     use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
 
-    let initial_chunk = &io_buffer[..initial_chunk_len];
     let mut tail = TailBuffer::default();
 
-    match tail.detect_terminator(initial_chunk) {
+    match tail.detect_terminator(&io_buffer[..initial_chunk_len]) {
         TerminatorStatus::FoundAt(pos) => {
-            response.extend_from_slice(pool, &initial_chunk[..pos]);
-            if pos < initial_chunk.len() {
-                stash_leftover(conn, &initial_chunk[pos..])?;
+            response.extend_from_slice(pool, &io_buffer[..pos]);
+            if pos < initial_chunk_len {
+                stash_leftover(conn, &io_buffer[pos..initial_chunk_len])?;
             }
             return Ok(());
         }
         TerminatorStatus::NotFound => {
-            response.extend_from_slice(pool, initial_chunk);
-            tail.update(initial_chunk);
+            tail.update(&io_buffer[..initial_chunk_len]);
+            let mut owned_chunk = pool.acquire().await;
+            std::mem::swap(io_buffer, &mut owned_chunk);
+            response.push_chunk(owned_chunk);
         }
     }
 
@@ -314,19 +315,25 @@ async fn fill_multiline_response(
             });
         }
 
-        let chunk = &io_buffer[..n];
-        let status = tail.detect_terminator(chunk);
+        let status = tail.detect_terminator(&io_buffer[..n]);
         let write_len = status.write_len(n);
-        response.extend_from_slice(pool, &chunk[..write_len]);
 
         if status.is_found() {
+            response.extend_from_slice(pool, &io_buffer[..write_len]);
             if write_len < n {
-                stash_leftover(conn, &chunk[write_len..n])?;
+                stash_leftover(conn, &io_buffer[write_len..n])?;
             }
             return Ok(());
         }
 
-        tail.update(&chunk[..write_len]);
+        debug_assert_eq!(
+            write_len, n,
+            "non-terminal multiline chunk should consume full read"
+        );
+        tail.update(&io_buffer[..write_len]);
+        let mut owned_chunk = pool.acquire().await;
+        std::mem::swap(io_buffer, &mut owned_chunk);
+        response.push_chunk(owned_chunk);
     }
 }
 
@@ -442,19 +449,25 @@ pub(crate) async fn buffer_multiline_response(
                     });
                 }
 
-                let chunk = &io_buffer[..n];
-                let status = tail.detect_terminator(chunk);
+                let status = tail.detect_terminator(&io_buffer[..n]);
                 let write_len = status.write_len(n);
-                captured.extend_from_slice(ctx.buffer_pool, &chunk[..write_len]);
 
                 if status.is_found() {
+                    captured.extend_from_slice(ctx.buffer_pool, &io_buffer[..write_len]);
                     if write_len < n {
-                        stash_leftover(conn, &chunk[write_len..n])?;
+                        stash_leftover(conn, &io_buffer[write_len..n])?;
                     }
                     break;
                 }
 
-                tail.update(&chunk[..write_len]);
+                debug_assert_eq!(
+                    write_len, n,
+                    "non-terminal multiline chunk should consume full read"
+                );
+                tail.update(&io_buffer[..write_len]);
+                let mut owned_chunk = ctx.buffer_pool.acquire().await;
+                std::mem::swap(&mut io_buffer, &mut owned_chunk);
+                captured.push_chunk(owned_chunk);
             }
         }
     }

--- a/tests/cache/unified_cache.rs
+++ b/tests/cache/unified_cache.rs
@@ -7,7 +7,9 @@
 //! - `ArticleAvailability::from_bits()`
 //! - `DiskCache` configuration defaults and validation
 
-use nntp_proxy::cache::{ArticleAvailability, ArticleCache, BackendStatus, UnifiedCache};
+use nntp_proxy::cache::{
+    ArticleAvailability, ArticleCache, AvailabilityIndex, BackendStatus, UnifiedCache,
+};
 use nntp_proxy::protocol::RequestKind;
 use nntp_proxy::types::{BackendId, MessageId};
 use std::time::Duration;
@@ -26,9 +28,9 @@ async fn test_unified_cache_memory_construction() {
 
 #[tokio::test]
 async fn test_unified_cache_availability_construction() {
-    let cache = UnifiedCache::availability(4096, std::time::Duration::MAX);
+    let cache = UnifiedCache::availability(std::time::Duration::MAX);
     assert!(!cache.is_hybrid());
-    assert_eq!(cache.capacity(), 4096);
+    assert_eq!(cache.capacity(), AvailabilityIndex::new().capacity_bytes());
     assert_eq!(cache.entry_count(), 0);
 }
 
@@ -43,7 +45,7 @@ async fn test_unified_cache_memory_get_miss() {
 
 #[tokio::test]
 async fn test_unified_cache_availability_get_miss() {
-    let cache = UnifiedCache::availability(4096, std::time::Duration::MAX);
+    let cache = UnifiedCache::availability(std::time::Duration::MAX);
     let msg_id = MessageId::from_str_or_wrap("test@example.com").unwrap();
 
     let result = cache.get(&msg_id).await;
@@ -88,7 +90,7 @@ async fn test_unified_cache_memory_record_missing() {
 
 #[tokio::test]
 async fn test_unified_cache_availability_record_missing() {
-    let cache = UnifiedCache::availability(8192, std::time::Duration::MAX);
+    let cache = UnifiedCache::availability(std::time::Duration::MAX);
     let msg_id = MessageId::from_str_or_wrap("missing@example.com").unwrap();
     let backend_id = BackendId::from_index(0);
 
@@ -129,7 +131,7 @@ async fn test_unified_cache_sync_availability() {
 
 #[tokio::test]
 async fn test_unified_cache_availability_sync_persists_only_missing_bits() {
-    let cache = UnifiedCache::availability(8192, std::time::Duration::MAX);
+    let cache = UnifiedCache::availability(std::time::Duration::MAX);
     let msg_id = MessageId::from_str_or_wrap("test@example.com").unwrap();
     let mut availability = ArticleAvailability::new();
     availability.record_missing(BackendId::from_index(1));

--- a/tests/proxy/routing/stale_connection.rs
+++ b/tests/proxy/routing/stale_connection.rs
@@ -521,7 +521,7 @@ async fn test_430_cache_is_authoritative() -> Result<()> {
     use nntp_proxy::router::BackendCount;
     use nntp_proxy::types::{BackendId, MessageId};
 
-    let cache = UnifiedCache::availability(1024 * 1024, std::time::Duration::MAX);
+    let cache = UnifiedCache::availability(std::time::Duration::MAX);
     let msg_id = MessageId::from_borrowed("<auth430@test.com>")?;
 
     // Record backends as 430 using the public API


### PR DESCRIPTION
- **perf: hand off owned multiline chunks**
- **perf: remove scratch buffer zero-fill**
- **perf: add adaptive availability shards**
- **bench: simplify iai cache-miss benchmark**

## Benchmark update

Latest rerun on `53af6bb`.

### Adaptive current tip vs lazy baseline (`7d96d76`)

| Benchmark | Adaptive current | Lazy baseline | Delta vs lazy |
| --- | ---: | ---: | ---: |
| divan `cache_miss_roundtrip` 64k median | 32.82 us | 32.58 us | +0.7% |
| divan `cache_miss_roundtrip` 768k median | 194.4 us | 211.3 us | -8.0% |
| divan `cache_miss_roundtrip` 788k avg median | 202.3 us | 215.9 us | -6.3% |
| divan `cache_miss_roundtrip` 1536k median | 366.3 us | 381.4 us | -4.0% |
| divan `cache_miss_roundtrip` 64k median throughput | 1.996 GB/s | 2.011 GB/s | -0.7% |
| divan `cache_miss_roundtrip` 768k median throughput | 4.044 GB/s | 3.721 GB/s | +8.7% |
| divan `cache_miss_roundtrip` 788k avg median throughput | 3.987 GB/s | 3.737 GB/s | +6.7% |
| divan `cache_miss_roundtrip` 1536k median throughput | 4.293 GB/s | 4.123 GB/s | +4.1% |

### Fixed `iai-callgrind` rerun

The earlier `cache_miss_roundtrip_callgrind` harness was overstated because it forced `--instr-atstart=yes` and manually batched multiple requests per benchmark. That setup is now removed, and the bench relies on normal `iai-callgrind` setup semantics.

| Benchmark | Adaptive current | Lazy baseline | Delta vs lazy |
| --- | ---: | ---: | ---: |
| proxy miss 64k | 143,892 Ir | 146,809 Ir | -1.99% |
| proxy miss 768k | 273,790 Ir | 284,195 Ir | -3.66% |
| direct backend 64k | 19,138 Ir | 19,138 Ir | flat |
| direct backend 768k | 97,249 Ir | 97,246 Ir | flat |

### Current profile notes

- The fixed 64k run is still dominated by `memcpy` / `memset` and allocator/runtime work; the 768k run is dominated by `memchr`-based multiline terminator scanning plus `memcpy`.
- The availability index is no longer a visible top hotspot in the corrected profile, which matches the adaptive-vs-lazy improvement shown above.
