### PR TITLE
Add NixOS module and credentials overlay config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,7 +1556,7 @@ dependencies = [
 
 [[package]]
 name = "nntp-proxy"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nntp-proxy"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 description = "High-performance NNTP proxy server with connection pooling and authentication"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -375,6 +375,51 @@ Use the included Nix shell if desired:
 nix develop
 ```
 
+Build the packaged binary with Nix:
+
+```bash
+nix build .#default
+```
+
+For NixOS, the flake exports `nixosModules.default`, which adds a
+`services.nntp-proxy` module. It can either use an existing `config.toml`, or
+render one from `services.nntp-proxy.settings`:
+
+```nix
+{
+  inputs.nntp-proxy.url = "github:mjc/nntp-proxy";
+
+  outputs = { nixpkgs, nntp-proxy, ... }: {
+    nixosConfigurations.proxy = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        nntp-proxy.nixosModules.default
+        {
+          services.nntp-proxy = {
+            enable = true;
+            openFirewall = true;
+            settings = {
+              proxy.port = 8119;
+              routing.mode = "hybrid";
+              servers = [
+                {
+                  host = "news.example.com";
+                  port = 563;
+                  name = "Primary";
+                  use_tls = true;
+                  tls_verify_cert = true;
+                  max_connections = 20;
+                }
+              ];
+            };
+          };
+        }
+      ];
+    };
+  };
+}
+```
+
 Common checks:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -383,7 +383,9 @@ nix build .#default
 
 For NixOS, the flake exports `nixosModules.default`, which adds a
 `services.nntp-proxy` module. It can either use an existing `config.toml`, or
-render one from `services.nntp-proxy.settings`:
+render one from `services.nntp-proxy.settings`. A separate
+`services.nntp-proxy.credentialsFile` can provide secret backend/client
+passwords at runtime:
 
 ```nix
 {
@@ -398,6 +400,7 @@ render one from `services.nntp-proxy.settings`:
           services.nntp-proxy = {
             enable = true;
             openFirewall = true;
+            credentialsFile = "/var/lib/nntp-proxy/credentials.toml";
             settings = {
               proxy.port = 8119;
               routing.mode = "hybrid";
@@ -418,6 +421,19 @@ render one from `services.nntp-proxy.settings`:
     };
   };
 }
+```
+
+Example credentials overlay:
+
+```toml
+[[servers]]
+name = "Primary"
+username = "backend-user"
+password = "backend-pass"
+
+[[client_auth.users]]
+username = "reader"
+password = "reader-password"
 ```
 
 Common checks:

--- a/flake.nix
+++ b/flake.nix
@@ -15,7 +15,9 @@
     nixpkgs,
     flake-utils,
     rust-overlay,
-  }:
+  }: let
+    cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+  in
     flake-utils.lib.eachDefaultSystem (system: let
       overlays = [(import rust-overlay)];
       pkgs = import nixpkgs {
@@ -62,7 +64,7 @@
         [
           rustToolchain
           pkg-config
-          cmake  # Required for zlib-ng feature in flate2
+          cmake # Required for zlib-ng feature in flate2
 
           # Code quality & linting
           cargo-deny
@@ -87,14 +89,13 @@
           cargo-flamegraph
 
           # Build acceleration
-          sccache  # Build cache
+          sccache # Build cache
         ]
         ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
           perf
           cargo-llvm-cov
-          mold  # Fast linker (Linux only)
+          mold # Fast linker (Linux only)
         ];
-
 
       # Cross-compilation tools (separate to avoid environment pollution)
       crossCompilationTools = with pkgs; [
@@ -111,10 +112,20 @@
         pkgsCross.mingwW64.buildPackages.binutils
       ];
 
-      buildInputs = with pkgs; [
+      devBuildInputs = with pkgs; [
         openssl
         zlib
         bashInteractive
+      ];
+
+      packageNativeBuildInputs = with pkgs; [
+        pkg-config
+        cmake
+      ];
+
+      packageBuildInputs = with pkgs; [
+        openssl
+        zlib
       ];
 
       # Map system to Rust target triple env var prefix
@@ -124,10 +135,40 @@
         else if system == "x86_64-darwin" then "CARGO_TARGET_X86_64_APPLE_DARWIN"
         else if system == "aarch64-darwin" then "CARGO_TARGET_AARCH64_APPLE_DARWIN"
         else throw "Unsupported system: ${system}";
+
+      package = pkgs.rustPlatform.buildRustPackage {
+        pname = cargoToml.package.name;
+        version = cargoToml.package.version;
+        src = ./.;
+
+        cargoLock = {
+          lockFile = ./Cargo.lock;
+        };
+
+        nativeBuildInputs = packageNativeBuildInputs;
+        buildInputs = packageBuildInputs;
+        cargoBuildFlags = ["--bin" "nntp-proxy"];
+
+        OPENSSL_DIR = "${pkgs.openssl.dev}";
+        OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
+        PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig:${pkgs.zlib.dev}/lib/pkgconfig";
+
+        meta = with pkgs.lib; {
+          description = cargoToml.package.description;
+          homepage = cargoToml.package.homepage;
+          license = licenses.mit;
+          mainProgram = cargoToml.package.name;
+          platforms = platforms.all;
+        };
+      };
     in {
+      apps.default = flake-utils.lib.mkApp {
+        drv = package;
+      };
+
       devShells.default = pkgs.mkShell {
         nativeBuildInputs = basicNativeBuildInputs;
-        inherit buildInputs;
+        buildInputs = devBuildInputs;
 
         shellHook = ''
           export RUST_SRC_PATH="${rustToolchain}/lib/rustlib/src/rust/library"
@@ -196,7 +237,7 @@
 
         # tikv-jemalloc-sys builds jemalloc from source; its configure script
         # fails strerror_r detection when _FORTIFY_SOURCE is set at -O0 (NixOS default).
-        hardeningDisable = [ "fortify" ];
+        hardeningDisable = ["fortify"];
       };
 
       # Cross-compilation shell with all the tooling
@@ -205,7 +246,7 @@
       # and cause conflicts with CMAKE builds. Zig handles all cross-compilation itself.
       devShells.cross = pkgs.mkShell {
         nativeBuildInputs = basicNativeBuildInputs ++ crossCompilationTools;
-        inherit buildInputs;
+        buildInputs = devBuildInputs;
 
         shellHook = ''
           export RUST_SRC_PATH="${rustToolchain}/lib/rustlib/src/rust/library"
@@ -243,28 +284,12 @@
         OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
         PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig:${pkgs.zlib.dev}/lib/pkgconfig";
       };
-      packages.default = pkgs.rustPlatform.buildRustPackage {
-        pname = "nntp-proxy";
-        version = "0.1.0";
-        src = ./.;
 
-        cargoLock = {
-          lockFile = ./Cargo.lock;
-        };
-
-        nativeBuildInputs = basicNativeBuildInputs;
-        inherit buildInputs;
-
-        # Environment variables for building with OpenSSL
-        OPENSSL_DIR = "${pkgs.openssl.dev}";
-        OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
-        PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig:${pkgs.zlib.dev}/lib/pkgconfig";
-
-        meta = with pkgs.lib; {
-          description = "A round-robin NNTP proxy server";
-          license = licenses.mit;
-          platforms = platforms.all;
-        };
-      };
-    });
+      packages.default = package;
+      packages.nntp-proxy = package;
+    })
+    // {
+      nixosModules.default = import ./nix/module.nix {inherit self;};
+      nixosModules.nntp-proxy = self.nixosModules.default;
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -121,6 +121,10 @@
       packageNativeBuildInputs = with pkgs; [
         pkg-config
         cmake
+      ]
+      ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
+        clang
+        mold
       ];
 
       packageBuildInputs = with pkgs; [
@@ -136,7 +140,7 @@
         else if system == "aarch64-darwin" then "CARGO_TARGET_AARCH64_APPLE_DARWIN"
         else throw "Unsupported system: ${system}";
 
-      package = pkgs.rustPlatform.buildRustPackage {
+      package = pkgs.rustPlatform.buildRustPackage ({
         pname = cargoToml.package.name;
         version = cargoToml.package.version;
         src = ./.;
@@ -160,7 +164,13 @@
           mainProgram = cargoToml.package.name;
           platforms = platforms.all;
         };
-      };
+      }
+      // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+        # Match the dev-shell linker setup for packaged builds without forcing
+        # non-portable CPU tuning into release artifacts.
+        "${cargoTargetEnvPrefix}_LINKER" = "clang";
+        "${cargoTargetEnvPrefix}_RUSTFLAGS" = "-C link-arg=-fuse-ld=mold";
+      });
     in {
       apps.default = flake-utils.lib.mkApp {
         drv = package;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -7,6 +7,11 @@
   cfg = config.services.nntp-proxy;
   tomlFormat = pkgs.formats.toml {};
   defaultPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  serviceEnvironment =
+    cfg.environment
+    // lib.optionalAttrs (cfg.credentialsFile != null) {
+      NNTP_PROXY_CREDENTIALS_FILE = toString cfg.credentialsFile;
+    };
 
   hasCache = lib.hasAttrByPath ["cache"] cfg.settings;
   storesArticleBodies = lib.attrByPath ["cache" "store_article_bodies"] false cfg.settings;
@@ -95,6 +100,18 @@ in {
       description = "Environment variables exported to the systemd service.";
     };
 
+    credentialsFile = lib.mkOption {
+      type = with lib.types; nullOr (either path str);
+      default = null;
+      example = "/var/lib/nntp-proxy/credentials.toml";
+      description = ''
+        Optional credentials-only TOML overlay. When set, the service loads the
+        main config from `settings` or `configFile`, then merges backend and
+        client-auth passwords from this runtime file via
+        `NNTP_PROXY_CREDENTIALS_FILE`.
+      '';
+    };
+
     openFirewall = lib.mkEnableOption "opening the NNTP listener port in the firewall";
 
     listenPort = lib.mkOption {
@@ -124,7 +141,7 @@ in {
       wantedBy = ["multi-user.target"];
       wants = ["network-online.target"];
       after = ["network-online.target"];
-      environment = cfg.environment;
+      environment = serviceEnvironment;
 
       serviceConfig = {
         Type = "simple";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -29,7 +29,7 @@
             cache.availability_index_path = "/var/cache/nntp-proxy/availability.idx";
           })
           (lib.optionalAttrs hasDiskCache {
-            cache.disk.path = "/var/cache/nntp-proxy/articles";
+            cache.disk.path = "/var/cache/nntp-proxy/disk-cache";
           })
           cfg.settings
         ]
@@ -134,14 +134,15 @@ in {
 
     networking.firewall.allowedTCPPorts = lib.optional cfg.openFirewall listenPort;
 
-    systemd.tmpfiles.rules = lib.optional (cfg.configFile == null && hasDiskCache) "d /var/cache/nntp-proxy/articles 0750 - - - -";
-
     systemd.services.nntp-proxy = {
       description = "NNTP proxy service";
       wantedBy = ["multi-user.target"];
       wants = ["network-online.target"];
       after = ["network-online.target"];
       environment = serviceEnvironment;
+      preStart = lib.optionalString (cfg.configFile == null && hasDiskCache) ''
+        ${pkgs.coreutils}/bin/mkdir -p /var/cache/nntp-proxy/disk-cache
+      '';
 
       serviceConfig = {
         Type = "simple";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -49,6 +49,39 @@
     if cfg.configFile == null && generatedDiskCachePath != null && asAbsoluteString generatedDiskCachePath != null && asAbsoluteString generatedDiskCachePath != managedDiskCachePath
     then asAbsoluteString generatedDiskCachePath
     else null;
+  customGeneratedStatsDir =
+    if customGeneratedStatsPath != null
+    then builtins.dirOf customGeneratedStatsPath
+    else null;
+  customGeneratedAvailabilityDir =
+    if customGeneratedAvailabilityPath != null
+    then builtins.dirOf customGeneratedAvailabilityPath
+    else null;
+  customGeneratedDiskCacheParentDir =
+    if customGeneratedDiskCachePath != null
+    then builtins.dirOf customGeneratedDiskCachePath
+    else null;
+  extraWritablePaths =
+    lib.filter (path: path != null) [
+      customGeneratedStatsDir
+      customGeneratedAvailabilityDir
+      customGeneratedDiskCachePath
+      customGeneratedDiskCacheParentDir
+    ];
+  extraPreStartCommands =
+    lib.concatStringsSep "\n" (
+      lib.filter (cmd: cmd != "") [
+        (lib.optionalString (customGeneratedStatsDir != null) ''
+          ${pkgs.coreutils}/bin/mkdir -p ${lib.escapeShellArg customGeneratedStatsDir}
+        '')
+        (lib.optionalString (customGeneratedAvailabilityDir != null) ''
+          ${pkgs.coreutils}/bin/mkdir -p ${lib.escapeShellArg customGeneratedAvailabilityDir}
+        '')
+        (lib.optionalString (customGeneratedDiskCachePath != null) ''
+          ${pkgs.coreutils}/bin/mkdir -p ${lib.escapeShellArg customGeneratedDiskCachePath}
+        '')
+      ]
+    );
   configPath =
     if cfg.configFile != null
     then managedExternalConfigPath
@@ -173,9 +206,14 @@ in {
       wants = ["network-online.target"];
       after = ["network-online.target"];
       environment = serviceEnvironment;
-      preStart = lib.optionalString hasDiskCache ''
-        ${pkgs.coreutils}/bin/mkdir -p ${lib.escapeShellArg managedDiskCachePath}
-      '';
+      preStart = lib.concatStringsSep "\n" (
+        lib.filter (cmd: cmd != "") [
+          (lib.optionalString hasDiskCache ''
+            ${pkgs.coreutils}/bin/mkdir -p ${lib.escapeShellArg managedDiskCachePath}
+          '')
+          extraPreStartCommands
+        ]
+      );
 
       serviceConfig = {
         Type = "simple";
@@ -203,13 +241,8 @@ in {
         ReadWritePaths = [
           managedStateDir
           managedCacheDir
-        ];
+        ] ++ extraWritablePaths;
       };
     };
-
-    systemd.tmpfiles.rules =
-      (lib.optional (customGeneratedStatsPath != null) "L+ ${customGeneratedStatsPath} - - - - ${managedStatsPath}")
-      ++ (lib.optional (customGeneratedAvailabilityPath != null) "L+ ${customGeneratedAvailabilityPath} - - - - ${managedAvailabilityPath}")
-      ++ (lib.optional (customGeneratedDiskCachePath != null) "L+ ${customGeneratedDiskCachePath} - - - - ${managedDiskCachePath}");
   };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -7,6 +7,18 @@
   cfg = config.services.nntp-proxy;
   tomlFormat = pkgs.formats.toml {};
   defaultPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  managedStateDir = "/var/lib/nntp-proxy";
+  managedCacheDir = "/var/cache/nntp-proxy";
+  managedStatsPath = "${managedStateDir}/stats.json";
+  managedAvailabilityPath = "${managedCacheDir}/availability.idx";
+  managedDiskCachePath = "${managedCacheDir}/disk-cache";
+  managedExternalConfigPath = "${managedStateDir}/external-config.toml";
+  asAbsoluteString = value: let
+    rendered = toString value;
+  in
+    if lib.hasPrefix "/" rendered
+    then rendered
+    else null;
   serviceEnvironment =
     cfg.environment
     // lib.optionalAttrs (cfg.credentialsFile != null) {
@@ -16,20 +28,41 @@
   hasCache = lib.hasAttrByPath ["cache"] cfg.settings;
   storesArticleBodies = lib.attrByPath ["cache" "store_article_bodies"] false cfg.settings;
   hasDiskCache = lib.hasAttrByPath ["cache" "disk"] cfg.settings;
+  generatedStatsPath = lib.attrByPath ["proxy" "stats_file"] managedStatsPath cfg.settings;
+  generatedAvailabilityPath =
+    if hasCache && !storesArticleBodies
+    then lib.attrByPath ["cache" "availability_index_path"] managedAvailabilityPath cfg.settings
+    else null;
+  generatedDiskCachePath =
+    if hasDiskCache
+    then lib.attrByPath ["cache" "disk" "path"] managedDiskCachePath cfg.settings
+    else null;
+  customGeneratedStatsPath =
+    if cfg.configFile == null && asAbsoluteString generatedStatsPath != null && asAbsoluteString generatedStatsPath != managedStatsPath
+    then asAbsoluteString generatedStatsPath
+    else null;
+  customGeneratedAvailabilityPath =
+    if cfg.configFile == null && generatedAvailabilityPath != null && asAbsoluteString generatedAvailabilityPath != null && asAbsoluteString generatedAvailabilityPath != managedAvailabilityPath
+    then asAbsoluteString generatedAvailabilityPath
+    else null;
+  customGeneratedDiskCachePath =
+    if cfg.configFile == null && generatedDiskCachePath != null && asAbsoluteString generatedDiskCachePath != null && asAbsoluteString generatedDiskCachePath != managedDiskCachePath
+    then asAbsoluteString generatedDiskCachePath
+    else null;
   configPath =
     if cfg.configFile != null
-    then cfg.configFile
+    then managedExternalConfigPath
     else
       tomlFormat.generate "nntp-proxy.toml" (
         lib.foldl' lib.recursiveUpdate {} [
           {
-            proxy.stats_file = "/var/lib/nntp-proxy/stats.json";
+            proxy.stats_file = managedStatsPath;
           }
           (lib.optionalAttrs (hasCache && !storesArticleBodies) {
-            cache.availability_index_path = "/var/cache/nntp-proxy/availability.idx";
+            cache.availability_index_path = managedAvailabilityPath;
           })
           (lib.optionalAttrs hasDiskCache {
-            cache.disk.path = "/var/cache/nntp-proxy/disk-cache";
+            cache.disk.path = managedDiskCachePath;
           })
           cfg.settings
         ]
@@ -140,8 +173,8 @@ in {
       wants = ["network-online.target"];
       after = ["network-online.target"];
       environment = serviceEnvironment;
-      preStart = lib.optionalString (cfg.configFile == null && hasDiskCache) ''
-        ${pkgs.coreutils}/bin/mkdir -p /var/cache/nntp-proxy/disk-cache
+      preStart = lib.optionalString hasDiskCache ''
+        ${pkgs.coreutils}/bin/mkdir -p ${lib.escapeShellArg managedDiskCachePath}
       '';
 
       serviceConfig = {
@@ -153,7 +186,7 @@ in {
         DynamicUser = true;
         StateDirectory = "nntp-proxy";
         CacheDirectory = "nntp-proxy";
-        WorkingDirectory = "/var/lib/nntp-proxy";
+        WorkingDirectory = managedStateDir;
         Restart = "on-failure";
         RestartSec = "5s";
         NoNewPrivileges = true;
@@ -166,11 +199,17 @@ in {
         LockPersonality = true;
         MemoryDenyWriteExecute = true;
         RestrictSUIDSGID = true;
+        BindReadOnlyPaths = lib.optional (cfg.configFile != null) "${toString cfg.configFile}:${managedExternalConfigPath}";
         ReadWritePaths = [
-          "/var/lib/nntp-proxy"
-          "/var/cache/nntp-proxy"
+          managedStateDir
+          managedCacheDir
         ];
       };
     };
+
+    systemd.tmpfiles.rules =
+      (lib.optional (customGeneratedStatsPath != null) "L+ ${customGeneratedStatsPath} - - - - ${managedStatsPath}")
+      ++ (lib.optional (customGeneratedAvailabilityPath != null) "L+ ${customGeneratedAvailabilityPath} - - - - ${managedAvailabilityPath}")
+      ++ (lib.optional (customGeneratedDiskCachePath != null) "L+ ${customGeneratedDiskCachePath} - - - - ${managedDiskCachePath}");
   };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,158 @@
+{self}: {
+  config,
+  lib,
+  pkgs,
+  ...
+}: let
+  cfg = config.services.nntp-proxy;
+  tomlFormat = pkgs.formats.toml {};
+  defaultPackage = self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+
+  hasCache = lib.hasAttrByPath ["cache"] cfg.settings;
+  storesArticleBodies = lib.attrByPath ["cache" "store_article_bodies"] false cfg.settings;
+  hasDiskCache = lib.hasAttrByPath ["cache" "disk"] cfg.settings;
+  configPath =
+    if cfg.configFile != null
+    then cfg.configFile
+    else
+      tomlFormat.generate "nntp-proxy.toml" (
+        lib.foldl' lib.recursiveUpdate {} [
+          {
+            proxy.stats_file = "/var/lib/nntp-proxy/stats.json";
+          }
+          (lib.optionalAttrs (hasCache && !storesArticleBodies) {
+            cache.availability_index_path = "/var/cache/nntp-proxy/availability.idx";
+          })
+          (lib.optionalAttrs hasDiskCache {
+            cache.disk.path = "/var/cache/nntp-proxy/articles";
+          })
+          cfg.settings
+        ]
+      );
+  listenPort = lib.attrByPath ["proxy" "port"] cfg.listenPort cfg.settings;
+in {
+  disabledModules = ["services/networking/nntp-proxy.nix"];
+
+  options.services.nntp-proxy = {
+    enable = lib.mkEnableOption "the nntp-proxy service";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = defaultPackage;
+      defaultText = lib.literalExpression "inputs.nntp-proxy.packages.\${pkgs.system}.default";
+      description = "Package providing the `nntp-proxy` executable.";
+    };
+
+    configFile = lib.mkOption {
+      type = with lib.types; nullOr (either path str);
+      default = null;
+      example = "/run/secrets/nntp-proxy.toml";
+      description = ''
+        Existing TOML config file to pass to `nntp-proxy --config`.
+        When unset, the module renders one from `services.nntp-proxy.settings`.
+      '';
+    };
+
+    settings = lib.mkOption {
+      type = tomlFormat.type;
+      default = {};
+      example = lib.literalExpression ''
+        {
+          proxy.port = 8119;
+          routing.mode = "hybrid";
+          servers = [
+            {
+              host = "news.example.com";
+              port = 563;
+              name = "Primary";
+              use_tls = true;
+              tls_verify_cert = true;
+              max_connections = 20;
+            }
+          ];
+        }
+      '';
+      description = ''
+        Declarative `config.toml` contents. The module injects writable defaults for
+        `proxy.stats_file`, availability persistence, and disk-cache storage so the
+        generated config works under systemd without pointing into the Nix store.
+      '';
+    };
+
+    extraArgs = lib.mkOption {
+      type = with lib.types; listOf str;
+      default = [];
+      example = ["--routing-mode" "stateful"];
+      description = "Additional arguments appended to the `nntp-proxy` command line.";
+    };
+
+    environment = lib.mkOption {
+      type = with lib.types; attrsOf str;
+      default = {};
+      example = {
+        RUST_LOG = "info";
+      };
+      description = "Environment variables exported to the systemd service.";
+    };
+
+    openFirewall = lib.mkEnableOption "opening the NNTP listener port in the firewall";
+
+    listenPort = lib.mkOption {
+      type = lib.types.port;
+      default = 8119;
+      description = ''
+        Firewall port fallback when `openFirewall` is enabled and the service port
+        cannot be derived from `services.nntp-proxy.settings.proxy.port`.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = cfg.configFile == null || cfg.settings == {};
+        message = "services.nntp-proxy.configFile and services.nntp-proxy.settings are mutually exclusive.";
+      }
+    ];
+
+    networking.firewall.allowedTCPPorts = lib.optional cfg.openFirewall listenPort;
+
+    systemd.tmpfiles.rules = lib.optional (cfg.configFile == null && hasDiskCache) "d /var/cache/nntp-proxy/articles 0750 - - - -";
+
+    systemd.services.nntp-proxy = {
+      description = "NNTP proxy service";
+      wantedBy = ["multi-user.target"];
+      wants = ["network-online.target"];
+      after = ["network-online.target"];
+      environment = cfg.environment;
+
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = lib.escapeShellArgs (
+          [(lib.getExe cfg.package) "--ui" "headless" "--config" (toString configPath)]
+          ++ cfg.extraArgs
+        );
+        DynamicUser = true;
+        StateDirectory = "nntp-proxy";
+        CacheDirectory = "nntp-proxy";
+        WorkingDirectory = "/var/lib/nntp-proxy";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        NoNewPrivileges = true;
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+        ProtectControlGroups = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        LockPersonality = true;
+        MemoryDenyWriteExecute = true;
+        RestrictSUIDSGID = true;
+        ReadWritePaths = [
+          "/var/lib/nntp-proxy"
+          "/var/cache/nntp-proxy"
+        ];
+      };
+    };
+  };
+}

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -12,6 +12,30 @@ use super::defaults;
 use super::types::{Config, Server, UserCredentials};
 
 type TomlTable = toml::map::Map<String, toml::Value>;
+const CREDENTIALS_FILE_ENV: &str = "NNTP_PROXY_CREDENTIALS_FILE";
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct CredentialsOverlay {
+    #[serde(default)]
+    servers: Vec<ServerCredentialsOverlay>,
+    #[serde(default)]
+    client_auth: ClientAuthCredentialsOverlay,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct ServerCredentialsOverlay {
+    name: String,
+    #[serde(default)]
+    username: Option<String>,
+    #[serde(default)]
+    password: Option<String>,
+}
+
+#[derive(Debug, Default, serde::Deserialize)]
+struct ClientAuthCredentialsOverlay {
+    #[serde(default)]
+    users: Vec<UserCredentials>,
+}
 
 fn table<'a>(value: &'a toml::Value, key: &str) -> Option<&'a TomlTable> {
     value.get(key)?.as_table()
@@ -29,6 +53,62 @@ fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
     let mut path = path.as_os_str().to_os_string();
     path.push(suffix);
     PathBuf::from(path)
+}
+
+fn apply_credentials_overlay(config: &mut Config, overlay_path: &str) -> Result<()> {
+    let overlay_content = fs::read_to_string(overlay_path)
+        .with_context(|| format!("Failed to read credentials overlay file '{overlay_path}'"))?;
+    let overlay: CredentialsOverlay = toml::from_str(&overlay_content)
+        .with_context(|| format!("Failed to parse credentials overlay file '{overlay_path}'"))?;
+
+    for server_overlay in overlay.servers {
+        let server = config
+            .servers
+            .iter_mut()
+            .find(|server| server.name.as_str() == server_overlay.name)
+            .with_context(|| {
+                format!(
+                    "Credentials overlay '{}' references unknown server '{}'",
+                    overlay_path, server_overlay.name
+                )
+            })?;
+
+        if let Some(username) = server_overlay.username {
+            server.username = Some(username);
+        }
+        if let Some(password) = server_overlay.password {
+            server.password = Some(password);
+        }
+    }
+
+    for user in overlay.client_auth.users {
+        if let Some(existing) = config
+            .client_auth
+            .users
+            .iter_mut()
+            .find(|existing| existing.username == user.username)
+        {
+            existing.password = user.password;
+        } else {
+            config.client_auth.users.push(user);
+        }
+    }
+
+    Ok(())
+}
+
+fn apply_credentials_overlay_from_env<E: EnvProvider>(config: &mut Config, env: &E) -> Result<()> {
+    let Some(overlay_path) = env.get(CREDENTIALS_FILE_ENV) else {
+        return Ok(());
+    };
+
+    apply_credentials_overlay(config, &overlay_path)?;
+    tracing::info!(
+        "Loaded credentials overlay from '{}' via {}",
+        overlay_path,
+        CREDENTIALS_FILE_ENV
+    );
+    Ok(())
 }
 
 fn write_canonical_config(config_path: &str, config: &Config) -> Result<()> {
@@ -306,20 +386,6 @@ pub fn parse_server_from_env<E: EnvProvider>(index: usize, env: &E) -> Option<Se
     })
 }
 
-/// Load backend server configuration from environment variables
-///
-/// Supports indexed environment variables for Docker/container deployments:
-/// - `NNTP_SERVER_0_HOST`, `NNTP_SERVER_0_PORT`, `NNTP_SERVER_0_NAME`, etc.
-/// - `NNTP_SERVER_1_HOST`, `NNTP_SERVER_1_PORT`, `NNTP_SERVER_1_NAME`, etc.
-///
-/// Optional per-server variables:
-/// - `NNTP_SERVER_N_USERNAME` - Backend authentication username
-/// - `NNTP_SERVER_N_PASSWORD` - Backend authentication password
-/// - `NNTP_SERVER_N_MAX_CONNECTIONS` - Max connections (default: 10)
-fn load_servers_from_env() -> Option<Vec<Server>> {
-    load_servers_from_env_provider(&StdEnvProvider)
-}
-
 /// Load servers using a custom environment provider (testable version)
 pub fn load_servers_from_env_provider<E: EnvProvider>(env: &E) -> Option<Vec<Server>> {
     let servers: Vec<Server> = (0..)
@@ -349,15 +415,21 @@ pub fn has_server_env_vars() -> bool {
 ///
 /// Returns an error if no backend servers are configured via environment variables.
 pub fn load_config_from_env() -> Result<Config> {
+    load_config_from_env_provider(&StdEnvProvider)
+}
+
+fn load_config_from_env_provider<E: EnvProvider>(env: &E) -> Result<Config> {
     use anyhow::Context;
 
-    let servers = load_servers_from_env()
+    let servers = load_servers_from_env_provider(env)
         .context("No backend servers configured via environment variables. Set NNTP_SERVER_0_HOST, NNTP_SERVER_0_PORT, etc.")?;
 
-    let config = Config {
+    let mut config = Config {
         servers,
         ..Default::default()
     };
+
+    apply_credentials_overlay_from_env(&mut config, env)?;
 
     // Validate the loaded configuration
     config.validate()?;
@@ -422,6 +494,8 @@ fn load_config_with_env_provider<E: EnvProvider>(config_path: &str, env: &E) -> 
         );
         config.servers = env_servers;
     }
+
+    apply_credentials_overlay_from_env(&mut config, env)?;
 
     // Validate the loaded configuration
     config.validate()?;
@@ -867,6 +941,133 @@ name = "Test Server"
         assert_eq!(source, ConfigSource::File);
         assert_eq!(config.servers.len(), 1);
         assert_eq!(config.servers[0].host.as_str(), "test.example.com");
+    }
+
+    #[test]
+    fn test_load_config_applies_credentials_overlay() {
+        let mut config_file = NamedTempFile::new().unwrap();
+        let config_content = r#"
+[[servers]]
+host = "news.example.com"
+port = 563
+name = "Primary"
+use_tls = true
+
+[proxy]
+port = 8121
+"#;
+        config_file.write_all(config_content.as_bytes()).unwrap();
+        config_file.flush().unwrap();
+
+        let mut credentials_file = NamedTempFile::new().unwrap();
+        let credentials_content = r#"
+[[servers]]
+name = "Primary"
+username = "backend-user"
+password = "backend-pass"
+
+[[client_auth.users]]
+username = "sabnzbd"
+password = "client-pass"
+"#;
+        credentials_file
+            .write_all(credentials_content.as_bytes())
+            .unwrap();
+        credentials_file.flush().unwrap();
+
+        let mut env = MockEnv::new();
+        env.set(
+            CREDENTIALS_FILE_ENV,
+            credentials_file.path().to_str().unwrap(),
+        );
+
+        let config =
+            load_config_with_env_provider(config_file.path().to_str().unwrap(), &env).unwrap();
+
+        assert_eq!(config.servers[0].username.as_deref(), Some("backend-user"));
+        assert_eq!(config.servers[0].password.as_deref(), Some("backend-pass"));
+        assert_eq!(config.client_auth.users.len(), 1);
+        assert_eq!(config.client_auth.users[0].username, "sabnzbd");
+        assert_eq!(config.client_auth.users[0].password, "client-pass");
+    }
+
+    #[test]
+    fn test_load_config_overlay_updates_existing_client_auth_user() {
+        let mut config_file = NamedTempFile::new().unwrap();
+        let config_content = r#"
+[[servers]]
+host = "news.example.com"
+port = 563
+name = "Primary"
+
+[[client_auth.users]]
+username = "sabnzbd"
+password = "old-pass"
+"#;
+        config_file.write_all(config_content.as_bytes()).unwrap();
+        config_file.flush().unwrap();
+
+        let mut credentials_file = NamedTempFile::new().unwrap();
+        let credentials_content = r#"
+[[client_auth.users]]
+username = "sabnzbd"
+password = "new-pass"
+"#;
+        credentials_file
+            .write_all(credentials_content.as_bytes())
+            .unwrap();
+        credentials_file.flush().unwrap();
+
+        let mut env = MockEnv::new();
+        env.set(
+            CREDENTIALS_FILE_ENV,
+            credentials_file.path().to_str().unwrap(),
+        );
+
+        let config =
+            load_config_with_env_provider(config_file.path().to_str().unwrap(), &env).unwrap();
+
+        assert_eq!(config.client_auth.users.len(), 1);
+        assert_eq!(config.client_auth.users[0].password, "new-pass");
+    }
+
+    #[test]
+    fn test_load_config_overlay_errors_on_unknown_server() {
+        let mut config_file = NamedTempFile::new().unwrap();
+        let config_content = r#"
+[[servers]]
+host = "news.example.com"
+port = 563
+name = "Primary"
+"#;
+        config_file.write_all(config_content.as_bytes()).unwrap();
+        config_file.flush().unwrap();
+
+        let mut credentials_file = NamedTempFile::new().unwrap();
+        let credentials_content = r#"
+[[servers]]
+name = "Missing"
+username = "backend-user"
+"#;
+        credentials_file
+            .write_all(credentials_content.as_bytes())
+            .unwrap();
+        credentials_file.flush().unwrap();
+
+        let mut env = MockEnv::new();
+        env.set(
+            CREDENTIALS_FILE_ENV,
+            credentials_file.path().to_str().unwrap(),
+        );
+
+        let error =
+            load_config_with_env_provider(config_file.path().to_str().unwrap(), &env).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("references unknown server 'Missing'")
+        );
     }
 
     #[test]

--- a/src/network.rs
+++ b/src/network.rs
@@ -17,9 +17,11 @@ use tracing::debug;
 const LINGER_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// `TCP_USER_TIMEOUT` - faster dead connection detection on Linux
+#[cfg(target_os = "linux")]
 const TCP_USER_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// `IP_TOS` value for throughput optimization
+#[cfg(target_os = "linux")]
 const TOS_THROUGHPUT: u32 = 0x08;
 
 /// Trait for network optimization strategies
@@ -545,11 +547,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn test_tcp_user_timeout_constant() {
         assert_eq!(TCP_USER_TIMEOUT, Duration::from_secs(30));
     }
 
     #[test]
+    #[cfg(target_os = "linux")]
     fn test_tos_throughput_constant() {
         assert_eq!(TOS_THROUGHPUT, 0x08);
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -708,14 +708,13 @@ async fn test_hybrid_mode_stateful_switching() -> Result<()> {
 #[tokio::test]
 async fn test_hybrid_mode_multiple_clients() -> Result<()> {
     // Test multiple concurrent clients in hybrid mode
-    let mock_port = get_available_port()
-        .await
-        .expect("Failed to get available port");
-    let proxy_port = get_available_port()
-        .await
-        .expect("Failed to get available port");
+    let mock_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let mock_port = mock_listener.local_addr()?.port();
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let proxy_port = proxy_listener.local_addr()?.port();
 
-    let _mock = create_smart_mock_builder(mock_port, "MultiServer").spawn();
+    let _mock =
+        create_smart_mock_builder(mock_port, "MultiServer").spawn_on_listener(mock_listener);
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 
@@ -731,11 +730,10 @@ async fn test_hybrid_mode_multiple_clients() -> Result<()> {
 
     let proxy = NntpProxy::new(config, RoutingMode::Hybrid).await?;
     let proxy_addr = format!("127.0.0.1:{proxy_port}");
-    let listener = TcpListener::bind(&proxy_addr).await?;
 
     tokio::spawn(async move {
         loop {
-            if let Ok((stream, addr)) = listener.accept().await {
+            if let Ok((stream, addr)) = proxy_listener.accept().await {
                 let proxy_clone = proxy.clone();
                 tokio::spawn(async move {
                     let _ = proxy_clone.handle_client(stream, addr.into()).await;

--- a/tests/proxy/compression.rs
+++ b/tests/proxy/compression.rs
@@ -15,20 +15,18 @@ use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::Duration;
 
-use crate::test_helpers::{get_available_port, wait_for_server};
+use crate::test_helpers::wait_for_server;
 
 /// Mock NNTP server that tracks whether COMPRESS DEFLATE was received
 struct CompressionMockServer {
-    port: u16,
     compress_received: Arc<AtomicBool>,
     /// Response to send when COMPRESS DEFLATE is received
     compress_response: String,
 }
 
 impl CompressionMockServer {
-    fn new(port: u16, compress_response: &str) -> Self {
+    fn new(compress_response: &str) -> Self {
         Self {
-            port,
             compress_received: Arc::new(AtomicBool::new(false)),
             compress_response: compress_response.to_string(),
         }
@@ -38,57 +36,62 @@ impl CompressionMockServer {
         Arc::clone(&self.compress_received)
     }
 
-    fn spawn(self) -> tokio::task::AbortHandle {
-        let port = self.port;
+    async fn run_on_listener(
+        listener: TcpListener,
+        compress_received: Arc<AtomicBool>,
+        compress_response: String,
+    ) {
+        while let Ok((mut stream, _)) = listener.accept().await {
+            let compress_received = compress_received.clone();
+            let compress_response = compress_response.clone();
+
+            tokio::spawn(async move {
+                if stream
+                    .write_all(b"200 CompressionTest Ready\r\n")
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+
+                let mut buffer = [0u8; 4096];
+
+                loop {
+                    let n = match stream.read(&mut buffer).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(n) => n,
+                    };
+
+                    let cmd = String::from_utf8_lossy(&buffer[..n]);
+                    let cmd_upper = cmd.trim().to_uppercase();
+
+                    if cmd_upper.starts_with("COMPRESS") {
+                        compress_received.store(true, Ordering::SeqCst);
+                        let _ = stream.write_all(compress_response.as_bytes()).await;
+                    } else if cmd_upper.starts_with("QUIT") {
+                        let _ = stream.write_all(b"205 Goodbye\r\n").await;
+                        break;
+                    } else if cmd_upper.starts_with("STAT") {
+                        let _ = stream
+                            .write_all(b"223 0 <test@example.com> exists\r\n")
+                            .await;
+                    } else {
+                        let _ = stream.write_all(b"200 OK\r\n").await;
+                    }
+                }
+            });
+        }
+    }
+
+    fn spawn_on_listener(self, listener: TcpListener) -> tokio::task::AbortHandle {
         let compress_received = self.compress_received;
         let compress_response = self.compress_response;
 
-        tokio::spawn(async move {
-            let listener = TcpListener::bind(format!("127.0.0.1:{port}"))
-                .await
-                .expect("Failed to bind");
-
-            while let Ok((mut stream, _)) = listener.accept().await {
-                let compress_received = compress_received.clone();
-                let compress_response = compress_response.clone();
-
-                tokio::spawn(async move {
-                    if stream
-                        .write_all(b"200 CompressionTest Ready\r\n")
-                        .await
-                        .is_err()
-                    {
-                        return;
-                    }
-
-                    let mut buffer = [0u8; 4096];
-
-                    loop {
-                        let n = match stream.read(&mut buffer).await {
-                            Ok(0) | Err(_) => break,
-                            Ok(n) => n,
-                        };
-
-                        let cmd = String::from_utf8_lossy(&buffer[..n]);
-                        let cmd_upper = cmd.trim().to_uppercase();
-
-                        if cmd_upper.starts_with("COMPRESS") {
-                            compress_received.store(true, Ordering::SeqCst);
-                            let _ = stream.write_all(compress_response.as_bytes()).await;
-                        } else if cmd_upper.starts_with("QUIT") {
-                            let _ = stream.write_all(b"205 Goodbye\r\n").await;
-                            break;
-                        } else if cmd_upper.starts_with("STAT") {
-                            let _ = stream
-                                .write_all(b"223 0 <test@example.com> exists\r\n")
-                                .await;
-                        } else {
-                            let _ = stream.write_all(b"200 OK\r\n").await;
-                        }
-                    }
-                });
-            }
-        })
+        tokio::spawn(Self::run_on_listener(
+            listener,
+            compress_received,
+            compress_response,
+        ))
         .abort_handle()
     }
 }
@@ -105,12 +108,14 @@ fn build_server_config(port: u16, compress: Option<bool>) -> Server {
 /// When compress is disabled, the proxy should never send COMPRESS DEFLATE
 #[tokio::test]
 async fn test_compression_disabled_skips_negotiation() -> Result<()> {
-    let mock_port = get_available_port().await?;
-    let proxy_port = get_available_port().await?;
+    let mock_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let mock_port = mock_listener.local_addr()?.port();
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let proxy_port = proxy_listener.local_addr()?.port();
 
-    let mock = CompressionMockServer::new(mock_port, "206 Compression active\r\n");
+    let mock = CompressionMockServer::new("206 Compression active\r\n");
     let compress_received = mock.compress_was_received();
-    let _handle = mock.spawn();
+    let _handle = mock.spawn_on_listener(mock_listener);
 
     tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -121,12 +126,11 @@ async fn test_compression_disabled_skips_negotiation() -> Result<()> {
 
     let proxy = NntpProxy::new(config, RoutingMode::PerCommand).await?;
     let proxy_addr = format!("127.0.0.1:{proxy_port}");
-    let listener = TcpListener::bind(&proxy_addr).await?;
 
     tokio::spawn({
         let proxy = proxy.clone();
         async move {
-            while let Ok((stream, addr)) = listener.accept().await {
+            while let Ok((stream, addr)) = proxy_listener.accept().await {
                 let p = proxy.clone();
                 tokio::spawn(async move {
                     let _ = p
@@ -166,13 +170,15 @@ async fn test_compression_disabled_skips_negotiation() -> Result<()> {
 /// When compress is auto (None) and server doesn't support it, proxy falls back gracefully
 #[tokio::test]
 async fn test_compression_auto_fallback_on_unsupported() -> Result<()> {
-    let mock_port = get_available_port().await?;
-    let proxy_port = get_available_port().await?;
+    let mock_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let mock_port = mock_listener.local_addr()?.port();
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let proxy_port = proxy_listener.local_addr()?.port();
 
     // Server responds 500 to COMPRESS DEFLATE
-    let mock = CompressionMockServer::new(mock_port, "500 Command not recognized\r\n");
+    let mock = CompressionMockServer::new("500 Command not recognized\r\n");
     let compress_received = mock.compress_was_received();
-    let _handle = mock.spawn();
+    let _handle = mock.spawn_on_listener(mock_listener);
 
     tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -183,12 +189,11 @@ async fn test_compression_auto_fallback_on_unsupported() -> Result<()> {
 
     let proxy = NntpProxy::new(config, RoutingMode::PerCommand).await?;
     let proxy_addr = format!("127.0.0.1:{proxy_port}");
-    let listener = TcpListener::bind(&proxy_addr).await?;
 
     tokio::spawn({
         let proxy = proxy.clone();
         async move {
-            while let Ok((stream, addr)) = listener.accept().await {
+            while let Ok((stream, addr)) = proxy_listener.accept().await {
                 let p = proxy.clone();
                 tokio::spawn(async move {
                     let _ = p
@@ -227,12 +232,14 @@ async fn test_compression_auto_fallback_on_unsupported() -> Result<()> {
 /// When compress is required and server doesn't support it, proxy should fail the connection
 #[tokio::test]
 async fn test_compression_required_fails_on_unsupported() -> Result<()> {
-    let mock_port = get_available_port().await?;
-    let proxy_port = get_available_port().await?;
+    let mock_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let mock_port = mock_listener.local_addr()?.port();
+    let proxy_listener = TcpListener::bind("127.0.0.1:0").await?;
+    let proxy_port = proxy_listener.local_addr()?.port();
 
     // Server rejects COMPRESS DEFLATE
-    let mock = CompressionMockServer::new(mock_port, "500 Command not recognized\r\n");
-    let _handle = mock.spawn();
+    let mock = CompressionMockServer::new("500 Command not recognized\r\n");
+    let _handle = mock.spawn_on_listener(mock_listener);
 
     tokio::time::sleep(Duration::from_millis(50)).await;
 
@@ -243,12 +250,11 @@ async fn test_compression_required_fails_on_unsupported() -> Result<()> {
 
     let proxy = NntpProxy::new(config, RoutingMode::PerCommand).await?;
     let proxy_addr = format!("127.0.0.1:{proxy_port}");
-    let listener = TcpListener::bind(&proxy_addr).await?;
 
     tokio::spawn({
         let proxy = proxy.clone();
         async move {
-            while let Ok((stream, addr)) = listener.accept().await {
+            while let Ok((stream, addr)) = proxy_listener.accept().await {
                 let p = proxy.clone();
                 tokio::spawn(async move {
                     let _ = p


### PR DESCRIPTION
## Summary
- export a first-class Nix flake package/app and NixOS module for `nntp-proxy`
- add runtime credentials-overlay support via `NNTP_PROXY_CREDENTIALS_FILE` and `services.nntp-proxy.credentialsFile`
- bump the project version to `0.5.0` and document the Nix/NixOS flow

## Testing
- cargo check
- cargo nextest run
- cargo clippy --all-targets --all-features -- -D warnings
- nix module evaluation for exported NixOS options