### PR TITLE
Async debloat cleanup pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,17 +100,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1559,7 +1548,6 @@ name = "nntp-proxy"
 version = "0.5.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "bytes",
  "bytesize",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ crossbeam = { version = "0.8", features = ["alloc", "std"] }  # Lock-free data s
 tikv-jemallocator = "0.6"  # jemalloc allocator for reduced page allocation overhead
 nix = { version = "0.31", features = ["sched", "process"] }  # Low-level system calls for CPU pinning
 deadpool = "0.13"
-async-trait = "0.1.89"
 memchr = { version = "2.7", features = ["libc"] }  # Fast byte searching with system optimizations
 uuid = { version = "1.0", features = ["v4"] }  # Unique IDs for request tracking
 moka = { version = "0.12", features = ["future"], default-features = false }  # Async LRU cache, minimal features

--- a/src/bin/nntp-proxy.rs
+++ b/src/bin/nntp-proxy.rs
@@ -69,7 +69,7 @@ async fn run_proxy(
 
     // Prewarm connections BEFORE accepting clients (must complete first to avoid exceeding limits)
     info!("Prewarming connection pools...");
-    nntp_proxy::pool::prewarm_pools(proxy.connection_providers(), proxy.servers()).await?;
+    proxy.prewarm_connections().await?;
     info!("Connection pools ready, accepting clients");
 
     runtime::spawn_stats_flusher(proxy.connection_stats());

--- a/src/bin/nntp-proxy.rs
+++ b/src/bin/nntp-proxy.rs
@@ -69,7 +69,7 @@ async fn run_proxy(
 
     // Prewarm connections BEFORE accepting clients (must complete first to avoid exceeding limits)
     info!("Prewarming connection pools...");
-    proxy.prewarm_connections().await?;
+    nntp_proxy::pool::prewarm_pools(proxy.connection_providers(), proxy.servers()).await?;
     info!("Connection pools ready, accepting clients");
 
     runtime::spawn_stats_flusher(proxy.connection_stats());

--- a/src/cache/article.rs
+++ b/src/cache/article.rs
@@ -10,7 +10,9 @@ use crate::protocol::{
 };
 use crate::router::BackendCount;
 use crate::types::{BackendId, MessageId};
+use moka::Entry;
 use moka::future::Cache;
+use moka::ops::compute::Op;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -1018,6 +1020,93 @@ impl ArticleCache {
         }
     }
 
+    fn merge_ingest_entry(
+        maybe_entry: Option<Entry<Arc<str>, CachedArticle>>,
+        new_entry_template: &CachedArticle,
+        backend_id: BackendId,
+    ) -> CachedArticle {
+        if let Some(existing) = maybe_entry {
+            let mut entry = existing.into_value();
+
+            let existing_complete = entry.is_complete_article();
+            let new_complete = new_entry_template.is_complete_article();
+            let should_replace = match (existing_complete, new_complete) {
+                (false, true) => true,
+                (true, false) => false,
+                (true, true) | (false, false) => {
+                    new_entry_template.payload_len() > entry.payload_len()
+                }
+            };
+
+            if should_replace {
+                entry.status_code = new_entry_template.status_code;
+                entry.payload = new_entry_template.payload.clone();
+                entry.tier = new_entry_template.tier;
+            }
+
+            entry.inserted_at = ttl::CacheTimestampMillis::now();
+            entry.record_backend_has(backend_id);
+            entry
+        } else {
+            let mut entry = new_entry_template.clone();
+            entry.record_backend_has(backend_id);
+            entry
+        }
+    }
+
+    fn merge_backend_has_status_entry(
+        maybe_entry: Option<Entry<Arc<str>, CachedArticle>>,
+        new_entry_template: &CachedArticle,
+        status_code: StatusCode,
+        backend_id: BackendId,
+        tier: ttl::CacheTier,
+    ) -> CachedArticle {
+        let mut entry = maybe_entry.map_or_else(
+            || new_entry_template.clone(),
+            |existing| existing.into_value(),
+        );
+        if !entry.is_complete_article() {
+            entry.status_code = status_code;
+            entry.tier = tier;
+            entry.payload = CachedPayload::AvailabilityOnly;
+        }
+        entry.inserted_at = ttl::CacheTimestampMillis::now();
+        entry.record_backend_has(backend_id);
+        entry
+    }
+
+    fn merge_backend_missing_entry(
+        maybe_entry: Option<Entry<Arc<str>, CachedArticle>>,
+        backend_id: BackendId,
+    ) -> CachedArticle {
+        if let Some(existing) = maybe_entry {
+            let mut entry = existing.into_value();
+            entry.record_backend_missing(backend_id);
+            entry
+        } else {
+            let mut entry = CachedArticle::missing(ttl::CacheTier::new(0));
+            entry.record_backend_missing(backend_id);
+            entry
+        }
+    }
+
+    fn compute_availability_update(
+        maybe_entry: Option<Entry<Arc<str>, CachedArticle>>,
+        availability: ArticleAvailability,
+    ) -> Op<CachedArticle> {
+        if let Some(existing) = maybe_entry {
+            let mut entry = existing.into_value();
+            entry.backend_availability.merge_from(&availability);
+            Op::Put(entry)
+        } else if availability.any_backend_has_article() {
+            Op::Nop
+        } else {
+            let mut entry = CachedArticle::missing(ttl::CacheTier::new(0));
+            entry.backend_availability = availability;
+            Op::Put(entry)
+        }
+    }
+
     /// Upsert cache entry (insert or update) - ATOMIC OPERATION
     ///
     /// Uses moka's `entry().and_upsert_with()` for atomic get-modify-store.
@@ -1045,42 +1134,12 @@ impl ArticleCache {
         // the race condition between get() and insert() calls
         self.cache
             .entry(key)
-            .and_upsert_with(|maybe_entry| {
-                let new_entry = if let Some(existing) = maybe_entry {
-                    let mut entry = existing.into_value();
-
-                    // Decide whether to update buffer based on completeness
-                    let existing_complete = entry.is_complete_article();
-                    let new_complete = new_entry_template.is_complete_article();
-
-                    let should_replace = match (existing_complete, new_complete) {
-                        (false, true) => true,  // Availability-only -> complete: always replace
-                        (true, false) => false, // Complete -> availability-only: never replace
-                        (true, true) | (false, false) => {
-                            new_entry_template.payload_len() > entry.payload_len()
-                        }
-                    };
-
-                    if should_replace {
-                        entry.status_code = new_entry_template.status_code;
-                        entry.payload = new_entry_template.payload.clone();
-                        entry.tier = tier;
-                    }
-
-                    // Refresh TTL on every successful upsert, independent of buffer replacement
-                    entry.inserted_at = ttl::CacheTimestampMillis::now();
-
-                    // Mark backend as having the article
-                    entry.record_backend_has(backend_id);
-                    entry
-                } else {
-                    // New entry with tier
-                    let mut entry = new_entry_template.clone();
-                    entry.record_backend_has(backend_id);
-                    entry
-                };
-
-                std::future::ready(new_entry)
+            .and_upsert_with(move |maybe_entry| {
+                std::future::ready(Self::merge_ingest_entry(
+                    maybe_entry,
+                    &new_entry_template,
+                    backend_id,
+                ))
             })
             .await;
     }
@@ -1098,19 +1157,14 @@ impl ArticleCache {
 
         self.cache
             .entry(key)
-            .and_upsert_with(|maybe_entry| {
-                let mut entry = maybe_entry.map_or_else(
-                    || new_entry_template.clone(),
-                    |existing| existing.into_value(),
-                );
-                if !entry.is_complete_article() {
-                    entry.status_code = status_code;
-                    entry.tier = tier;
-                    entry.payload = CachedPayload::AvailabilityOnly;
-                }
-                entry.inserted_at = ttl::CacheTimestampMillis::now();
-                entry.record_backend_has(backend_id);
-                std::future::ready(entry)
+            .and_upsert_with(move |maybe_entry| {
+                std::future::ready(Self::merge_backend_has_status_entry(
+                    maybe_entry,
+                    &new_entry_template,
+                    status_code,
+                    backend_id,
+                    tier,
+                ))
             })
             .await;
     }
@@ -1136,19 +1190,8 @@ impl ArticleCache {
         let entry = self
             .cache
             .entry(key)
-            .and_upsert_with(|maybe_entry| {
-                let new_entry = if let Some(existing) = maybe_entry {
-                    let mut entry = existing.into_value();
-                    entry.record_backend_missing(backend_id);
-                    entry
-                } else {
-                    // First 430 for this article - create typed missing entry.
-                    let mut entry = CachedArticle::missing(ttl::CacheTier::new(0));
-                    entry.record_backend_missing(backend_id);
-                    entry
-                };
-
-                std::future::ready(new_entry)
+            .and_upsert_with(move |maybe_entry| {
+                std::future::ready(Self::merge_backend_missing_entry(maybe_entry, backend_id))
             })
             .await;
 
@@ -1176,8 +1219,6 @@ impl ArticleCache {
         message_id: MessageId<'_>,
         availability: &ArticleAvailability,
     ) {
-        use moka::ops::compute::Op;
-
         // Only sync if we actually tried some backends
         if availability.checked_bits() == 0 {
             return;
@@ -1191,27 +1232,8 @@ impl ArticleCache {
         let result = self
             .cache
             .entry(key)
-            .and_compute_with(|maybe_entry| {
-                let op = if let Some(existing) = maybe_entry {
-                    // Merge availability into existing entry
-                    let mut entry = existing.into_value();
-                    entry.backend_availability.merge_from(&availability);
-                    Op::Put(entry)
-                } else {
-                    // No existing entry - only create a missing entry if all checked backends returned 430.
-                    if availability.any_backend_has_article() {
-                        // A backend successfully provided the article.
-                        // Don't create a missing entry - let upsert() handle it with the real article data.
-                        Op::Nop
-                    } else {
-                        // All checked backends returned 430 - create a missing entry to track this.
-                        let mut entry = CachedArticle::missing(ttl::CacheTier::new(0));
-                        entry.backend_availability = availability;
-                        Op::Put(entry)
-                    }
-                };
-
-                std::future::ready(op)
+            .and_compute_with(move |maybe_entry| {
+                std::future::ready(Self::compute_availability_update(maybe_entry, availability))
             })
             .await;
 

--- a/src/cache/article.rs
+++ b/src/cache/article.rs
@@ -1061,10 +1061,7 @@ impl ArticleCache {
         backend_id: BackendId,
         tier: ttl::CacheTier,
     ) -> CachedArticle {
-        let mut entry = maybe_entry.map_or_else(
-            || new_entry_template.clone(),
-            |existing| existing.into_value(),
-        );
+        let mut entry = maybe_entry.map_or_else(|| new_entry_template.clone(), Entry::into_value);
         if !entry.is_complete_article() {
             entry.status_code = status_code;
             entry.tier = tier;

--- a/src/cache/availability_index.rs
+++ b/src/cache/availability_index.rs
@@ -565,7 +565,10 @@ impl AvailabilityIndex {
         entries.sort_by_key(|entry| entry.inserted_at);
 
         let now = ttl::now_millis();
-        let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+        let mut state = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         state.reset();
         let mut evicted = 0usize;
         for entry in entries {
@@ -604,7 +607,10 @@ impl AvailabilityIndex {
 
         let now = ttl::now_millis();
         let snapshot = {
-            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             state.snapshot_entries(now)
         };
         if snapshot.evicted != 0 {
@@ -658,7 +664,10 @@ impl AvailabilityIndex {
             return 0;
         }
         let result = {
-            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             let evicted = state.rotate_if_needed(ttl::now_millis());
             (state.occupied_slots() as u64, evicted)
         };
@@ -700,7 +709,10 @@ impl AvailabilityIndex {
         let (hash, tag) = hash_key(key.as_bytes());
         let now = ttl::now_millis();
         let lookup = {
-            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             if state.blocks_per_generation == 0 {
                 LookupResult {
                     missing_bits: 0,
@@ -738,7 +750,10 @@ impl AvailabilityIndex {
 
         let (hash, tag) = hash_key(key.as_bytes());
         let outcome = {
-            let mut state = self.state.lock().unwrap_or_else(|e| e.into_inner());
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
             if state.blocks_per_generation == 0 {
                 StateInsertOutcome::default()
             } else {

--- a/src/cache/hybrid.rs
+++ b/src/cache/hybrid.rs
@@ -105,7 +105,7 @@ impl Default for HybridCacheConfig {
             memory_capacity: 256 * 1024 * 1024,     // 256 MB memory
             disk_capacity: 10 * 1024 * 1024 * 1024, // 10 GB disk
             disk_path: std::path::PathBuf::from("/var/cache/nntp-proxy"),
-            ttl: Duration::from_secs(3600), // 1 hour
+            ttl: Duration::from_hours(1), // 1 hour
             compression: CompressionCodec::Lz4,
             shards: 16, // Match indexer shards for consistent lock contention
         }

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -147,7 +147,7 @@ mod tests {
             crate::pool::BufferPool::new(crate::types::BufferSize::try_new(1024).unwrap(), 1)
                 .with_capture_pool(8, 4);
 
-        let mut pooled = pool.acquire().await;
+        let mut pooled = pool.acquire();
         pooled.copy_from_slice(bytes);
 
         let mut chunked = crate::pool::ChunkedResponse::default();
@@ -172,7 +172,7 @@ mod tests {
             crate::pool::BufferPool::new(crate::types::BufferSize::try_new(1024).unwrap(), 1)
                 .with_capture_pool(8, 4);
 
-        let mut pooled = pool.acquire().await;
+        let mut pooled = pool.acquire();
         pooled.copy_from_slice(bytes);
 
         let mut chunked = crate::pool::ChunkedResponse::default();

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -548,9 +548,8 @@ impl UnifiedCache {
     /// Ensures all async maintenance tasks complete for deterministic testing.
     pub async fn sync(&self) {
         match self {
-            Self::Availability(_) => {}
+            Self::Availability(_) | Self::Hybrid(_) => {}
             Self::Memory(cache) => cache.sync().await,
-            Self::Hybrid(_) => {} // foyer handles this differently
         }
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -80,11 +80,11 @@ impl NntpClient {
     /// Returns any connection, write, or backend-response error encountered while
     /// fetching the BODY response.
     #[inline]
-    pub async fn fetch_body(
+    pub fn fetch_body(
         &self,
         message_id: &crate::types::MessageId<'_>,
-    ) -> Result<PooledBuffer> {
-        self.fetch_response(&body_request(message_id)).await
+    ) -> impl std::future::Future<Output = Result<PooledBuffer>> + '_ {
+        self.fetch_response(body_request(message_id))
     }
 
     /// Fetch article headers (HEAD command)
@@ -99,11 +99,11 @@ impl NntpClient {
     /// Returns any connection, write, or backend-response error encountered while
     /// fetching the HEAD response.
     #[inline]
-    pub async fn fetch_head(
+    pub fn fetch_head(
         &self,
         message_id: &crate::types::MessageId<'_>,
-    ) -> Result<PooledBuffer> {
-        self.fetch_response(&head_request(message_id)).await
+    ) -> impl std::future::Future<Output = Result<PooledBuffer>> + '_ {
+        self.fetch_response(head_request(message_id))
     }
 
     /// Fetch full article (ARTICLE command)
@@ -118,11 +118,11 @@ impl NntpClient {
     /// Returns any connection, write, or backend-response error encountered while
     /// fetching the ARTICLE response.
     #[inline]
-    pub async fn fetch_article(
+    pub fn fetch_article(
         &self,
         message_id: &crate::types::MessageId<'_>,
-    ) -> Result<PooledBuffer> {
-        self.fetch_response(&article_request(message_id)).await
+    ) -> impl std::future::Future<Output = Result<PooledBuffer>> + '_ {
+        self.fetch_response(article_request(message_id))
     }
 
     /// Check if article exists (STAT command)
@@ -172,11 +172,11 @@ impl NntpClient {
     /// # Errors
     /// Returns any connection, write, read, or backend-status validation error
     /// encountered while fetching the NNTP response.
-    async fn fetch_response(&self, request: &RequestContext) -> Result<PooledBuffer> {
+    async fn fetch_response(&self, request: RequestContext) -> Result<PooledBuffer> {
         let mut conn = self.get_connection().await?;
         let mut io_buffer = self.buffer_pool.acquire();
 
-        let response = send_request(&mut *conn, request, &mut io_buffer).await?;
+        let response = send_request(&mut *conn, &request, &mut io_buffer).await?;
 
         // Validate response - early return on errors
         Self::validate_response(&response)?;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -312,6 +312,47 @@ mod tests {
         assert!(NntpClient::parse_stat_response(StatusCode::parse(b"400")).is_err());
     }
 
+    async fn spawn_fetch_test_server(
+        expected_command: &'static str,
+        response: &'static [u8],
+    ) -> std::net::SocketAddr {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            loop {
+                if let Ok((mut stream, _)) = listener.accept().await {
+                    tokio::spawn(async move {
+                        let _ = stream.write_all(b"200 mock\r\n").await;
+                        let mut cmd_buf = [0u8; 1024];
+                        loop {
+                            let Ok(n) = stream.read(&mut cmd_buf).await else {
+                                return;
+                            };
+                            if n == 0 {
+                                return;
+                            }
+
+                            let command = std::str::from_utf8(&cmd_buf[..n]).unwrap();
+                            if command.starts_with(expected_command) {
+                                let _ = stream.write_all(response).await;
+                                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+                                return;
+                            }
+
+                            let _ = stream.write_all(b"200 OK\r\n").await;
+                        }
+                    });
+                }
+            }
+        });
+
+        addr
+    }
+
     /// Spawn a minimal NNTP server that sends a greeting, then waits for
     /// `notify` before sending `article_data`. Returns (addr, notify).
     ///
@@ -423,6 +464,19 @@ mod tests {
             .max_size(2)
             .build()
             .unwrap()
+    }
+
+    fn make_test_client(addr: std::net::SocketAddr) -> NntpClient {
+        use crate::pool::BufferPool;
+        use crate::types::BufferSize;
+
+        let provider = DeadpoolConnectionProvider::builder(addr.ip().to_string(), addr.port())
+            .name("test")
+            .max_connections(2)
+            .build()
+            .unwrap();
+        let buffer_pool = BufferPool::new(BufferSize::try_new(4096).unwrap(), 2);
+        NntpClient::new(provider, buffer_pool)
     }
 
     /// Verify `drain_multiline_into` captures the complete response when it all
@@ -547,5 +601,29 @@ mod tests {
             !conn.has_leftover(),
             "stashed bytes should be consumed first"
         );
+    }
+
+    #[tokio::test]
+    async fn fetch_head_reads_complete_multiline_response() {
+        let response = b"221 0 <test@example.com>\r\nSubject: test\r\nFrom: tester\r\n\r\n.\r\n";
+        let addr = spawn_fetch_test_server("HEAD <test@example.com>", response).await;
+        let client = make_test_client(addr);
+        let msg_id = crate::types::MessageId::new("<test@example.com>".to_string()).unwrap();
+
+        let buffer = client.fetch_head(&msg_id).await.unwrap();
+
+        assert_eq!(&buffer[..], response);
+    }
+
+    #[tokio::test]
+    async fn fetch_body_reads_complete_multiline_response() {
+        let response = b"222 0 <test@example.com>\r\nhello world\r\n.\r\n";
+        let addr = spawn_fetch_test_server("BODY <test@example.com>", response).await;
+        let client = make_test_client(addr);
+        let msg_id = crate::types::MessageId::new("<test@example.com>".to_string()).unwrap();
+
+        let buffer = client.fetch_body(&msg_id).await.unwrap();
+
+        assert_eq!(&buffer[..], response);
     }
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -185,24 +185,31 @@ impl NntpClient {
             .status_code()
             .expect("validate_response returned Ok with parsed status");
         if request.expects_multiline_response(status_code) {
-            // Use a capture buffer as the accumulator: pooled, can grow beyond io_buffer
-            // capacity without panicking, returned to pool on drop.
-            let mut capture = self.buffer_pool.acquire_capture().await;
-            if let Err(err) = Self::drain_multiline_into(
-                &mut conn,
-                &mut io_buffer,
-                &mut capture,
-                response.bytes_read,
-            )
-            .await
-            {
-                self.conn_pool.remove_with_cooldown(conn);
-                return Err(err);
-            }
-            Ok(capture)
-        } else {
-            Ok(io_buffer)
+            return self
+                .fetch_multiline_response(conn, io_buffer, response.bytes_read)
+                .await;
         }
+
+        Ok(io_buffer)
+    }
+
+    async fn fetch_multiline_response(
+        &self,
+        mut conn: Object<TcpManager>,
+        mut io_buffer: PooledBuffer,
+        first_chunk_size: usize,
+    ) -> Result<PooledBuffer> {
+        // Use a capture buffer as the accumulator: pooled, can grow beyond io_buffer
+        // capacity without panicking, returned to pool on drop.
+        let mut capture = self.buffer_pool.acquire_capture().await;
+        if let Err(err) =
+            Self::drain_multiline_into(&mut conn, &mut io_buffer, &mut capture, first_chunk_size)
+                .await
+        {
+            self.conn_pool.remove_with_cooldown(conn);
+            return Err(err);
+        }
+        Ok(capture)
     }
 
     /// Stream remaining multiline response data into `capture`.

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -138,7 +138,11 @@ impl NntpClient {
     /// malformed or unexpected backend status codes.
     pub async fn stat(&self, message_id: &crate::types::MessageId<'_>) -> Result<bool> {
         let request = stat_request(message_id);
-        let mut conn = self.get_connection().await?;
+        let mut conn = self
+            .conn_pool
+            .get_pooled_connection()
+            .await
+            .context("Failed to get connection from pool")?;
         let mut buffer = self.buffer_pool.acquire();
 
         let response = send_request(&mut *conn, &request, &mut buffer).await?;
@@ -158,22 +162,17 @@ impl NntpClient {
             })
     }
 
-    /// Get a connection from the pool
-    #[inline]
-    async fn get_connection(&self) -> Result<Object<TcpManager>> {
-        self.conn_pool
-            .get_pooled_connection()
-            .await
-            .context("Failed to get connection from pool")
-    }
-
     /// Internal: fetch response into `PooledBuffer`
     ///
     /// # Errors
     /// Returns any connection, write, read, or backend-status validation error
     /// encountered while fetching the NNTP response.
     async fn fetch_response(&self, request: RequestContext) -> Result<PooledBuffer> {
-        let mut conn = self.get_connection().await?;
+        let mut conn = self
+            .conn_pool
+            .get_pooled_connection()
+            .await
+            .context("Failed to get connection from pool")?;
         let mut io_buffer = self.buffer_pool.acquire();
 
         let response = send_request(&mut *conn, &request, &mut io_buffer).await?;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -139,7 +139,7 @@ impl NntpClient {
     pub async fn stat(&self, message_id: &crate::types::MessageId<'_>) -> Result<bool> {
         let request = stat_request(message_id);
         let mut conn = self.get_connection().await?;
-        let mut buffer = self.buffer_pool.acquire().await;
+        let mut buffer = self.buffer_pool.acquire();
 
         let response = send_request(&mut *conn, &request, &mut buffer).await?;
 
@@ -174,7 +174,7 @@ impl NntpClient {
     /// encountered while fetching the NNTP response.
     async fn fetch_response(&self, request: &RequestContext) -> Result<PooledBuffer> {
         let mut conn = self.get_connection().await?;
-        let mut io_buffer = self.buffer_pool.acquire().await;
+        let mut io_buffer = self.buffer_pool.acquire();
 
         let response = send_request(&mut *conn, request, &mut io_buffer).await?;
 
@@ -201,7 +201,7 @@ impl NntpClient {
     ) -> Result<PooledBuffer> {
         // Use a capture buffer as the accumulator: pooled, can grow beyond io_buffer
         // capacity without panicking, returned to pool on drop.
-        let mut capture = self.buffer_pool.acquire_capture().await;
+        let mut capture = self.buffer_pool.acquire_capture();
         if let Err(err) =
             Self::drain_multiline_into(&mut conn, &mut io_buffer, &mut capture, first_chunk_size)
                 .await
@@ -442,8 +442,8 @@ mod tests {
         // Signal server to send article data now that the greeting is consumed
         notify.notify_one();
 
-        let mut io_buffer = buffer_pool.acquire().await;
-        let mut capture = buffer_pool.acquire_capture().await;
+        let mut io_buffer = buffer_pool.acquire();
+        let mut capture = buffer_pool.acquire_capture();
 
         // Simulate send_request pre-reading the full first response chunk
         let first_chunk_size = io_buffer.read_from(&mut *conn).await.unwrap();
@@ -477,8 +477,8 @@ mod tests {
         let mut conn = pool.get().await.unwrap();
         notify.notify_one();
 
-        let mut io_buffer = buffer_pool.acquire().await;
-        let mut capture = buffer_pool.acquire_capture().await;
+        let mut io_buffer = buffer_pool.acquire();
+        let mut capture = buffer_pool.acquire_capture();
 
         // first_chunk_size = 0: no pre-loaded data, all bytes arrive via the loop
         NntpClient::drain_multiline_into(&mut conn, &mut io_buffer, &mut capture, 0)
@@ -501,8 +501,8 @@ mod tests {
         let mut conn = pool.get().await.unwrap();
         notify.notify_one();
 
-        let mut io_buffer = buffer_pool.acquire().await;
-        let mut capture = buffer_pool.acquire_capture().await;
+        let mut io_buffer = buffer_pool.acquire();
+        let mut capture = buffer_pool.acquire_capture();
 
         let err = NntpClient::drain_multiline_into(&mut conn, &mut io_buffer, &mut capture, 0)
             .await
@@ -530,8 +530,8 @@ mod tests {
         let mut conn = pool.get().await.unwrap();
         notify.notify_one();
 
-        let mut io_buffer = buffer_pool.acquire().await;
-        let mut capture = buffer_pool.acquire_capture().await;
+        let mut io_buffer = buffer_pool.acquire();
+        let mut capture = buffer_pool.acquire_capture();
         let first_chunk_size = io_buffer.read_from(&mut *conn).await.unwrap();
 
         NntpClient::drain_multiline_into(&mut conn, &mut io_buffer, &mut capture, first_chunk_size)

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -84,6 +84,7 @@ pub fn init_dual_logging(file_level: &str) {
 ///
 /// Headless mode logs to line-buffered stdout and `debug.log`.
 /// TUI mode logs to the in-memory TUI buffer and `debug.log`.
+#[must_use]
 pub fn init_logging(ui_mode: UiMode, file_level: &str) -> Option<crate::tui::LogBuffer> {
     match ui_mode {
         UiMode::Headless => {

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -18,7 +18,7 @@ use tracing::{debug, info};
 ///
 /// ## Usage
 /// ```ignore
-/// let mut buffer = pool.acquire().await;
+/// let mut buffer = pool.acquire();
 /// let n = buffer.read_from(&mut stream).await?;  // Automatic tracking
 /// process(&*buffer);  // Deref returns only &buffer[..n]
 /// ```
@@ -648,8 +648,8 @@ impl BufferPool {
         }
     }
 
-    pub async fn acquire(&self) -> PooledBuffer {
-        std::future::ready(self.acquire_now()).await
+    pub fn acquire(&self) -> PooledBuffer {
+        self.acquire_now()
     }
 
     /// Get a capture buffer from the capture pool
@@ -697,8 +697,8 @@ impl BufferPool {
         }
     }
 
-    pub async fn acquire_capture(&self) -> PooledBuffer {
-        std::future::ready(self.acquire_capture_now()).await
+    pub fn acquire_capture(&self) -> PooledBuffer {
+        self.acquire_capture_now()
     }
 }
 
@@ -712,7 +712,7 @@ mod tests {
         let pool = BufferPool::new(BufferSize::try_new(8192).unwrap(), 10);
 
         // Pool should pre-allocate buffers
-        let buffer1 = pool.acquire().await;
+        let buffer1 = pool.acquire();
         assert_eq!(buffer1.capacity(), 8192);
         assert_eq!(buffer1.initialized(), 0); // No bytes initialized yet
         // Buffer automatically returned on drop
@@ -723,13 +723,13 @@ mod tests {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
 
         let capacity = {
-            let buffer = pool.acquire().await;
+            let buffer = pool.acquire();
             assert_eq!(buffer.initialized(), 0);
             assert_eq!(buffer.len(), 0);
             buffer.capacity()
         };
 
-        let buffer = pool.acquire().await;
+        let buffer = pool.acquire();
         assert_eq!(buffer.initialized(), 0);
         assert_eq!(buffer.len(), 0);
         assert_eq!(buffer.capacity(), capacity);
@@ -738,7 +738,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_from_sets_initialized_without_reducing_capacity() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let capacity = buffer.capacity();
         let (mut writer, mut reader) = tokio::io::duplex(64);
 
@@ -755,7 +755,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_from_is_limited_to_fixed_writable_region() {
         let pool = BufferPool::new(BufferSize::try_new(8).unwrap(), 1);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         assert_eq!(buffer.capacity(), 4096);
 
         let (mut writer, mut reader) = tokio::io::duplex(64);
@@ -774,7 +774,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_more_appends_after_initialized_bytes() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         buffer.copy_from_slice(b"22");
 
         let (mut writer, mut reader) = tokio::io::duplex(64);
@@ -790,7 +790,7 @@ mod tests {
     #[tokio::test]
     async fn test_read_more_is_limited_to_remaining_fixed_writable_region() {
         let pool = BufferPool::new(BufferSize::try_new(8).unwrap(), 1);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         buffer.copy_from_slice(b"22");
 
         let (mut writer, mut reader) = tokio::io::duplex(64);
@@ -806,7 +806,7 @@ mod tests {
     #[tokio::test]
     async fn test_copy_from_slice_overwrites_and_allows_up_to_capacity() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let capacity = buffer.capacity();
 
         buffer.copy_from_slice(b"previous bytes");
@@ -823,7 +823,7 @@ mod tests {
     #[should_panic(expected = "data exceeds buffer capacity")]
     async fn test_copy_from_slice_rejects_larger_than_capacity() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let too_large = vec![b'X'; buffer.capacity() + 1];
 
         buffer.copy_from_slice(&too_large);
@@ -832,7 +832,7 @@ mod tests {
     #[tokio::test]
     async fn test_clear_and_truncate_only_change_initialized_length() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let capacity = buffer.capacity();
 
         buffer.copy_from_slice(b"abcdef");
@@ -852,24 +852,24 @@ mod tests {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1).with_capture_pool(8, 1);
 
         let normal_capacity = {
-            let mut buffer = pool.acquire().await;
+            let mut buffer = pool.acquire();
             let capacity = buffer.capacity();
             buffer.extend_from_slice(&vec![b'N'; capacity + 1]);
             assert!(buffer.capacity() > capacity);
             capacity
         };
 
-        let buffer = pool.acquire().await;
+        let buffer = pool.acquire();
         assert_eq!(buffer.capacity(), normal_capacity);
         drop(buffer);
 
         {
-            let mut capture = pool.acquire_capture().await;
+            let mut capture = pool.acquire_capture();
             capture.extend_from_slice(&[b'C'; 9]);
             assert!(capture.capacity() > 8);
         }
 
-        let capture = pool.acquire_capture().await;
+        let capture = pool.acquire_capture();
         assert_eq!(capture.capacity(), 8);
     }
 
@@ -878,7 +878,7 @@ mod tests {
         let pool = BufferPool::new(BufferSize::try_new(4096).unwrap(), 5);
 
         // Get a buffer
-        let buffer = pool.acquire().await;
+        let buffer = pool.acquire();
         assert_eq!(buffer.capacity(), 4096);
         assert_eq!(buffer.initialized(), 0);
 
@@ -888,7 +888,7 @@ mod tests {
         drop(buffer);
 
         // Get it again - should be from pool
-        let buffer2 = pool.acquire().await;
+        let buffer2 = pool.acquire();
         assert_eq!(buffer2.capacity(), 4096);
     }
 
@@ -897,11 +897,11 @@ mod tests {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 2);
 
         // Get all pre-allocated buffers
-        let buf1 = pool.acquire().await;
-        let buf2 = pool.acquire().await;
+        let buf1 = pool.acquire();
+        let buf2 = pool.acquire();
 
         // Pool is exhausted, should create new buffer
-        let buf3 = pool.acquire().await;
+        let buf3 = pool.acquire();
         assert_eq!(buf3.capacity(), 4096);
 
         // Drop buffers (automatically returned)
@@ -915,12 +915,12 @@ mod tests {
         let pool =
             BufferPool::new(BufferSize::try_new(1024).unwrap(), 1).with_capture_pool(8192, 1);
 
-        let mut capture = pool.acquire_capture().await;
+        let mut capture = pool.acquire_capture();
         capture.extend_from_slice(&vec![b'X'; 8193]);
         assert!(capture.capacity() > 8192);
         drop(capture);
 
-        let capture2 = pool.acquire_capture().await;
+        let capture2 = pool.acquire_capture();
         assert_eq!(capture2.capacity(), 8192);
     }
 
@@ -962,7 +962,7 @@ mod tests {
         for _ in 0..20 {
             let pool_clone = pool.clone();
             let handle = tokio::spawn(async move {
-                let buffer = pool_clone.acquire().await;
+                let buffer = pool_clone.acquire();
                 assert_eq!(buffer.capacity(), 4096);
                 // Simulate some work
                 tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;
@@ -979,7 +979,7 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_alignment() {
         let pool = BufferPool::new(BufferSize::try_new(8192).unwrap(), 1);
-        let buffer = pool.acquire().await;
+        let buffer = pool.acquire();
 
         // Buffer capacity should be aligned to page boundaries (4KB)
         assert!(buffer.capacity() >= 8192);
@@ -991,7 +991,7 @@ mod tests {
     async fn test_buffer_clear_and_resize() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 2);
 
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
 
         // Write data using copy_from_slice
         let data = vec![42u8; 101];
@@ -1002,7 +1002,7 @@ mod tests {
         drop(buffer);
 
         // Get it again - may contain old data (performance optimization)
-        let buffer2 = pool.acquire().await;
+        let buffer2 = pool.acquire();
         assert_eq!(buffer2.capacity(), 4096);
         // Note: buffer may contain previous bytes outside the initialized range.
     }
@@ -1012,12 +1012,12 @@ mod tests {
         let pool = BufferPool::new(BufferSize::try_new(512).unwrap(), 3);
 
         // Get all buffers
-        let buf1 = pool.acquire().await;
-        let buf2 = pool.acquire().await;
-        let buf3 = pool.acquire().await;
+        let buf1 = pool.acquire();
+        let buf2 = pool.acquire();
+        let buf3 = pool.acquire();
 
         // Get one more (should create new)
-        let buf4 = pool.acquire().await;
+        let buf4 = pool.acquire();
 
         // Drop all buffers (automatically returned)
         drop(buf1);
@@ -1033,7 +1033,7 @@ mod tests {
     async fn test_buffer_wrong_size_not_returned() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 2);
 
-        let buffer = pool.acquire().await;
+        let buffer = pool.acquire();
         assert_eq!(buffer.capacity(), 4096);
 
         // PooledBuffer auto-returns on drop with correct size enforcement in Drop impl
@@ -1046,7 +1046,7 @@ mod tests {
 
         // Do multiple get/return cycles
         for i in 0u8..20 {
-            let mut buffer = pool.acquire().await;
+            let mut buffer = pool.acquire();
             assert_eq!(buffer.capacity(), 4096);
 
             // Write some data using copy_from_slice
@@ -1071,9 +1071,9 @@ mod tests {
         let medium_pool = BufferPool::new(BufferSize::try_new(8192).unwrap(), 5);
         let large_pool = BufferPool::new(BufferSize::try_new(65536).unwrap(), 5);
 
-        let small_buf = small_pool.acquire().await;
-        let medium_buf = medium_pool.acquire().await;
-        let large_buf = large_pool.acquire().await;
+        let small_buf = small_pool.acquire();
+        let medium_buf = medium_pool.acquire();
+        let large_buf = large_pool.acquire();
 
         assert_eq!(small_buf.capacity(), 4096);
         assert_eq!(medium_buf.capacity(), 8192);
@@ -1093,7 +1093,7 @@ mod tests {
             let pool_clone = pool.clone();
             let handle = tokio::spawn(async move {
                 for _ in 0..10 {
-                    let buffer = pool_clone.acquire().await;
+                    let buffer = pool_clone.acquire();
                     assert_eq!(buffer.capacity(), 4096);
                 }
             });
@@ -1108,7 +1108,7 @@ mod tests {
     #[tokio::test]
     async fn test_pooled_buffer_deref() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 5);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
 
         // Initially no initialized bytes
         assert_eq!(buffer.len(), 0);
@@ -1124,7 +1124,7 @@ mod tests {
     #[tokio::test]
     async fn test_pooled_buffer_as_ref() {
         let pool = BufferPool::new(BufferSize::try_new(512).unwrap(), 5);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
 
         buffer.copy_from_slice(b"Test data");
 
@@ -1137,7 +1137,7 @@ mod tests {
     #[tokio::test]
     async fn test_copy_from_slice_updates_initialized() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 5);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
 
         assert_eq!(buffer.initialized(), 0);
 
@@ -1152,7 +1152,7 @@ mod tests {
     #[should_panic(expected = "data exceeds buffer capacity")]
     async fn test_copy_from_slice_panic_on_overflow() {
         let pool = BufferPool::new(BufferSize::try_new(10).unwrap(), 5);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
 
         let too_large = vec![0u8; buffer.capacity() + 1];
         buffer.copy_from_slice(&too_large); // Should panic
@@ -1168,7 +1168,7 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_initialized_tracking() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 5);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
 
         // Test multiple writes update initialized correctly
         buffer.copy_from_slice(b"First");
@@ -1183,7 +1183,7 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_capacity_vs_initialized() {
         let pool = BufferPool::new(BufferSize::try_new(8192).unwrap(), 5);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
 
         // Capacity is full buffer size
         assert_eq!(buffer.capacity(), 8192);
@@ -1199,7 +1199,7 @@ mod tests {
     #[tokio::test]
     async fn test_empty_slice_copy() {
         let pool = BufferPool::new(BufferSize::try_new(512).unwrap(), 5);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
 
         // Copying empty slice should work
         buffer.copy_from_slice(&[]);
@@ -1212,12 +1212,12 @@ mod tests {
         let pool = BufferPool::new(BufferSize::try_new(2048).unwrap(), 5);
 
         {
-            let mut buffer = pool.acquire().await;
+            let mut buffer = pool.acquire();
             buffer.copy_from_slice(b"test");
             assert_eq!(buffer.capacity(), 4096);
         } // Drop returns to pool
 
-        let buffer2 = pool.acquire().await;
+        let buffer2 = pool.acquire();
         // Should have same capacity when reused
         assert_eq!(buffer2.capacity(), 4096);
     }

--- a/src/pool/connection_trait.rs
+++ b/src/pool/connection_trait.rs
@@ -1,5 +1,4 @@
 use crate::types::{AvailableConnections, CreatedConnections, MaxPoolSize};
-use async_trait::async_trait;
 
 /// Generic connection pool status information
 #[derive(Debug, Clone)]
@@ -10,7 +9,6 @@ pub struct PoolStatus {
 }
 
 /// Trait for connection management - makes it easy to swap implementations
-#[async_trait]
 pub trait ConnectionProvider: Send + Sync + Clone + std::fmt::Debug {
     /// Get current pool status for monitoring
     fn status(&self) -> PoolStatus;

--- a/src/pool/deadpool_connection.rs
+++ b/src/pool/deadpool_connection.rs
@@ -10,7 +10,6 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::connection_error::ConnectionError;
 use crate::protocol::{authinfo_pass, authinfo_user};
-use crate::session::backend;
 use crate::stream::ConnectionStream;
 use crate::tls::{TlsConfig, TlsManager};
 
@@ -305,7 +304,7 @@ impl TcpManager {
             return Ok(());
         };
 
-        backend::write_request(stream, &authinfo_user(username)).await?;
+        authinfo_user(username).write_wire_to(stream).await?;
         let n = stream.read(buffer).await?;
         let response = &buffer[..n];
         let response_str = String::from_utf8_lossy(response);
@@ -320,7 +319,7 @@ impl TcpManager {
                 });
             };
 
-            backend::write_request(stream, &authinfo_pass(password)).await?;
+            authinfo_pass(password).write_wire_to(stream).await?;
             let n = stream.read(buffer).await?;
             let response = &buffer[..n];
             let response_str = String::from_utf8_lossy(response);

--- a/src/pool/provider.rs
+++ b/src/pool/provider.rs
@@ -13,7 +13,6 @@ use super::health_check::{HealthCheckMetrics, check_date_response};
 use crate::pool::PoolStatus;
 use crate::tls::TlsConfig;
 use anyhow::Result;
-use async_trait::async_trait;
 use deadpool::managed;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
@@ -810,7 +809,6 @@ fn resize_then_drop(pool: &Pool, conn: managed::Object<TcpManager>, new_max: usi
     drop(conn);
 }
 
-#[async_trait]
 impl ConnectionProvider for DeadpoolConnectionProvider {
     fn status(&self) -> PoolStatus {
         use crate::types::{AvailableConnections, CreatedConnections, MaxPoolSize};

--- a/src/protocol/request.rs
+++ b/src/protocol/request.rs
@@ -616,22 +616,17 @@ impl RequestContext {
         self.response_payload = Some(response);
     }
 
-    pub(crate) async fn write_response_payload_to<W>(&self, writer: &mut W) -> std::io::Result<()>
-    where
-        W: tokio::io::AsyncWriteExt + Unpin,
-    {
-        self.response_payload
-            .as_ref()
-            .expect("completed request context carries response payload")
-            .write_all_to(writer)
-            .await
+    #[inline]
+    #[must_use]
+    pub(crate) fn response_payload(&self) -> Option<&crate::pool::ChunkedResponse> {
+        self.response_payload.as_ref()
     }
 
     #[inline]
     #[cfg(test)]
     #[must_use]
     pub(crate) fn response_payload_eq(&self, expected: &[u8]) -> Option<bool> {
-        let response = self.response_payload.as_ref()?;
+        let response = self.response_payload()?;
         if response.len() != expected.len() {
             return Some(false);
         }

--- a/src/protocol/request.rs
+++ b/src/protocol/request.rs
@@ -906,7 +906,7 @@ fn find_message_id(args: &[u8]) -> Option<(usize, usize)> {
         || !trimmed.ends_with(b">")
         || trimmed[1..trimmed.len() - 1]
             .iter()
-            .any(|byte| byte.is_ascii_whitespace())
+            .any(u8::is_ascii_whitespace)
     {
         return None;
     }

--- a/src/proxy/lifecycle.rs
+++ b/src/proxy/lifecycle.rs
@@ -202,7 +202,7 @@ impl NntpProxy {
         let server_idx = backend_id.as_index();
 
         self.log_routing_selection(client_addr, backend_id, &self.servers[server_idx]);
-        self.send_greeting(client_stream, client_addr).await?;
+        crate::protocol::send_proxy_greeting(client_stream, client_addr).await?;
         self.log_pool_status(server_idx);
         self.apply_tcp_optimizations(client_stream);
 
@@ -216,7 +216,7 @@ impl NntpProxy {
         client_addr: ClientAddress,
     ) -> Result<()> {
         self.record_connection_opened();
-        self.send_greeting(client_stream, client_addr).await?;
+        crate::protocol::send_proxy_greeting(client_stream, client_addr).await?;
         self.apply_tcp_optimizations(client_stream);
         Ok(())
     }
@@ -235,16 +235,6 @@ impl NntpProxy {
     #[inline]
     pub(super) fn generate_session_id(session: &ClientSession) -> String {
         crate::formatting::short_id(session.client_id().as_uuid())
-    }
-
-    /// Send greeting to client
-    #[inline]
-    pub(super) async fn send_greeting(
-        &self,
-        client_stream: &mut TcpStream,
-        client_addr: ClientAddress,
-    ) -> Result<()> {
-        crate::protocol::send_proxy_greeting(client_stream, client_addr).await
     }
 
     /// Apply TCP optimizations to client socket

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -24,7 +24,7 @@ use crate::auth::AuthHandler;
 use crate::cache::UnifiedCache;
 use crate::config::{Memory, RoutingMode, Server};
 use crate::metrics::{ConnectionStatsAggregator, MetricsCollector};
-use crate::pool::{BufferPool, DeadpoolConnectionProvider, prewarm_pools};
+use crate::pool::{BufferPool, DeadpoolConnectionProvider};
 use crate::router;
 
 #[derive(Debug, Clone)]
@@ -137,16 +137,6 @@ impl NntpProxy {
     #[must_use]
     pub const fn builder(config: crate::config::Config) -> NntpProxyBuilder {
         NntpProxyBuilder::new(config)
-    }
-
-    /// Prewarm all connection pools before accepting clients
-    /// Creates all connections concurrently and returns when ready
-    ///
-    /// # Errors
-    /// Returns any connection-establishment or backend-authentication error
-    /// encountered while prewarming the backend pools.
-    pub async fn prewarm_connections(&self) -> Result<()> {
-        prewarm_pools(&self.connection_providers, &self.servers).await
     }
 
     /// Gracefully shutdown all connection pools

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -169,6 +169,17 @@ impl NntpProxy {
         info!("All connection pools have been shut down gracefully");
     }
 
+    /// Establish the configured pooled backend connections up front.
+    ///
+    /// This keeps the provider/server index alignment invariant inside
+    /// `NntpProxy` instead of spreading it to callers.
+    ///
+    /// # Errors
+    /// Returns any backend connection or handshake error from pool prewarming.
+    pub async fn prewarm_connections(&self) -> Result<()> {
+        crate::pool::prewarm_pools(&self.connection_providers, &self.servers).await
+    }
+
     /// Get the list of servers
     #[must_use]
     #[inline]

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -310,7 +310,10 @@ pub async fn persist_runtime_state(
     let mut first_error = None;
 
     let metrics = proxy.metrics().clone();
-    match save_metrics_to_disk_blocking(metrics, stats_path.clone(), server_names).await {
+    let metrics_path = stats_path.clone();
+    match tokio::task::spawn_blocking(move || metrics.save_to_disk(&metrics_path, &server_names))
+        .await?
+    {
         Ok(()) => info!("Metrics saved to {}", stats_path.display()),
         Err(e) => {
             warn!("Failed to save metrics on shutdown: {}", e);
@@ -320,7 +323,8 @@ pub async fn persist_runtime_state(
 
     if let Some(path) = availability_path {
         let cache = proxy.cache().clone();
-        match save_availability_to_disk_blocking(cache, path.clone()).await {
+        let save_path = path.clone();
+        match tokio::task::spawn_blocking(move || cache.save_to_disk(&save_path)).await? {
             Ok(true) => info!("Availability index saved to {}", path.display()),
             Ok(false) => {}
             Err(e) => {
@@ -378,31 +382,6 @@ pub fn spawn_shutdown_handler(
     });
 
     shutdown_rx
-}
-
-/// Save metrics on Tokio's blocking thread pool.
-///
-/// `MetricsCollector::save_to_disk` uses `std::fs`, so callers from async
-/// tasks should delegate here instead of running filesystem work on a runtime
-/// worker.
-///
-/// # Errors
-/// Returns an error if the blocking task panics/cancels or if writing the
-/// metrics JSON fails.
-pub async fn save_metrics_to_disk_blocking(
-    metrics: crate::metrics::MetricsCollector,
-    stats_path: std::path::PathBuf,
-    server_names: Vec<String>,
-) -> Result<()> {
-    tokio::task::spawn_blocking(move || metrics.save_to_disk(&stats_path, &server_names)).await?
-}
-
-/// Save availability state on Tokio's blocking thread pool.
-pub async fn save_availability_to_disk_blocking(
-    cache: std::sync::Arc<crate::cache::UnifiedCache>,
-    availability_path: std::path::PathBuf,
-) -> Result<bool> {
-    tokio::task::spawn_blocking(move || cache.save_to_disk(&availability_path)).await?
 }
 
 /// Run the main accept loop for client connections
@@ -609,8 +588,13 @@ pub fn spawn_metrics_saver(
             let path = stats_path.clone();
             let names = server_names.clone();
             let metrics = proxy.metrics().clone();
-            if let Err(e) = save_metrics_to_disk_blocking(metrics, path, names).await {
-                warn!("Failed to save metrics to {}: {}", stats_path.display(), e);
+            let save_path = path.clone();
+            match tokio::task::spawn_blocking(move || metrics.save_to_disk(&save_path, &names))
+                .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => warn!("Failed to save metrics to {}: {}", stats_path.display(), e),
+                Err(e) => warn!("Failed to save metrics to {}: {}", stats_path.display(), e),
             }
         }
     });
@@ -638,12 +622,23 @@ pub fn spawn_availability_saver(
             interval.tick().await;
             let cache = proxy.cache().clone();
             let path = availability_path.clone();
-            if let Err(e) = save_availability_to_disk_blocking(cache, path.clone()).await {
-                warn!(
-                    "Failed to save availability index to {}: {}",
-                    path.display(),
-                    e
-                );
+            let save_path = path.clone();
+            match tokio::task::spawn_blocking(move || cache.save_to_disk(&save_path)).await {
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => {
+                    warn!(
+                        "Failed to save availability index to {}: {}",
+                        path.display(),
+                        e
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to save availability index to {}: {}",
+                        path.display(),
+                        e
+                    );
+                }
             }
         }
     });

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -305,51 +305,115 @@ pub async fn persist_runtime_state(
     availability_path: Option<std::path::PathBuf>,
     server_names: Vec<String>,
 ) -> Result<()> {
-    use tracing::{info, warn};
-
     let mut first_error = None;
 
     let metrics = proxy.metrics().clone();
     let metrics_path = stats_path.clone();
-    match tokio::task::spawn_blocking(move || metrics.save_to_disk(&metrics_path, &server_names))
-        .await
-    {
-        Ok(Ok(())) => info!("Metrics saved to {}", stats_path.display()),
-        Ok(Err(e)) => {
-            warn!("Failed to save metrics on shutdown: {}", e);
-            first_error = Some(e);
-        }
-        Err(e) => {
-            warn!("Failed to join metrics save task on shutdown: {}", e);
-            first_error = Some(e.into());
-        }
-    }
+    handle_shutdown_metrics_save_result(
+        &mut first_error,
+        &stats_path,
+        tokio::task::spawn_blocking(move || metrics.save_to_disk(&metrics_path, &server_names))
+            .await,
+    );
 
     if let Some(path) = availability_path {
         let cache = proxy.cache().clone();
         let save_path = path.clone();
-        match tokio::task::spawn_blocking(move || cache.save_to_disk(&save_path)).await {
-            Ok(Ok(true)) => info!("Availability index saved to {}", path.display()),
-            Ok(Ok(false)) => {}
-            Ok(Err(e)) => {
-                warn!("Failed to save availability index on shutdown: {}", e);
-                if first_error.is_none() {
-                    first_error = Some(e);
-                }
-            }
-            Err(e) => {
-                warn!("Failed to join availability save task on shutdown: {}", e);
-                if first_error.is_none() {
-                    first_error = Some(e.into());
-                }
-            }
-        }
+        handle_shutdown_availability_save_result(
+            &mut first_error,
+            &path,
+            tokio::task::spawn_blocking(move || cache.save_to_disk(&save_path)).await,
+        );
     }
 
     if let Some(error) = first_error {
         Err(error)
     } else {
         Ok(())
+    }
+}
+
+fn remember_first_persistence_error(slot: &mut Option<anyhow::Error>, error: anyhow::Error) {
+    if slot.is_none() {
+        *slot = Some(error);
+    }
+}
+
+fn handle_shutdown_metrics_save_result(
+    first_error: &mut Option<anyhow::Error>,
+    stats_path: &std::path::Path,
+    result: Result<Result<()>, tokio::task::JoinError>,
+) {
+    use tracing::{info, warn};
+
+    match result {
+        Ok(Ok(())) => info!("Metrics saved to {}", stats_path.display()),
+        Ok(Err(e)) => {
+            warn!("Failed to save metrics on shutdown: {}", e);
+            remember_first_persistence_error(first_error, e);
+        }
+        Err(e) => {
+            warn!("Failed to join metrics save task on shutdown: {}", e);
+            remember_first_persistence_error(first_error, e.into());
+        }
+    }
+}
+
+fn handle_shutdown_availability_save_result(
+    first_error: &mut Option<anyhow::Error>,
+    availability_path: &std::path::Path,
+    result: Result<Result<bool>, tokio::task::JoinError>,
+) {
+    use tracing::{info, warn};
+
+    match result {
+        Ok(Ok(true)) => info!(
+            "Availability index saved to {}",
+            availability_path.display()
+        ),
+        Ok(Ok(false)) => {}
+        Ok(Err(e)) => {
+            warn!("Failed to save availability index on shutdown: {}", e);
+            remember_first_persistence_error(first_error, e);
+        }
+        Err(e) => {
+            warn!("Failed to join availability save task on shutdown: {}", e);
+            remember_first_persistence_error(first_error, e.into());
+        }
+    }
+}
+
+fn handle_periodic_metrics_save_result(
+    stats_path: &std::path::Path,
+    result: Result<Result<()>, tokio::task::JoinError>,
+) {
+    use tracing::warn;
+
+    match result {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => warn!("Failed to save metrics to {}: {}", stats_path.display(), e),
+        Err(e) => warn!("Failed to save metrics to {}: {}", stats_path.display(), e),
+    }
+}
+
+fn handle_periodic_availability_save_result(
+    availability_path: &std::path::Path,
+    result: Result<Result<bool>, tokio::task::JoinError>,
+) {
+    use tracing::warn;
+
+    match result {
+        Ok(Ok(_)) => {}
+        Ok(Err(e)) => warn!(
+            "Failed to save availability index to {}: {}",
+            availability_path.display(),
+            e
+        ),
+        Err(e) => warn!(
+            "Failed to save availability index to {}: {}",
+            availability_path.display(),
+            e
+        ),
     }
 }
 
@@ -587,7 +651,6 @@ pub fn spawn_metrics_saver(
     server_names: Vec<String>,
 ) {
     use std::sync::Arc;
-    use tracing::warn;
 
     let proxy = Arc::clone(proxy);
     tokio::spawn(async move {
@@ -599,13 +662,10 @@ pub fn spawn_metrics_saver(
             let names = server_names.clone();
             let metrics = proxy.metrics().clone();
             let save_path = path.clone();
-            match tokio::task::spawn_blocking(move || metrics.save_to_disk(&save_path, &names))
-                .await
-            {
-                Ok(Ok(())) => {}
-                Ok(Err(e)) => warn!("Failed to save metrics to {}: {}", stats_path.display(), e),
-                Err(e) => warn!("Failed to save metrics to {}: {}", stats_path.display(), e),
-            }
+            handle_periodic_metrics_save_result(
+                &stats_path,
+                tokio::task::spawn_blocking(move || metrics.save_to_disk(&save_path, &names)).await,
+            );
         }
     });
 }
@@ -618,7 +678,6 @@ pub fn spawn_availability_saver(
     availability_path: Option<std::path::PathBuf>,
 ) {
     use std::sync::Arc;
-    use tracing::warn;
 
     let Some(availability_path) = availability_path else {
         return;
@@ -633,23 +692,10 @@ pub fn spawn_availability_saver(
             let cache = proxy.cache().clone();
             let path = availability_path.clone();
             let save_path = path.clone();
-            match tokio::task::spawn_blocking(move || cache.save_to_disk(&save_path)).await {
-                Ok(Ok(_)) => {}
-                Ok(Err(e)) => {
-                    warn!(
-                        "Failed to save availability index to {}: {}",
-                        path.display(),
-                        e
-                    );
-                }
-                Err(e) => {
-                    warn!(
-                        "Failed to save availability index to {}: {}",
-                        path.display(),
-                        e
-                    );
-                }
-            }
+            handle_periodic_availability_save_result(
+                &path,
+                tokio::task::spawn_blocking(move || cache.save_to_disk(&save_path)).await,
+            );
         }
     });
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -312,25 +312,35 @@ pub async fn persist_runtime_state(
     let metrics = proxy.metrics().clone();
     let metrics_path = stats_path.clone();
     match tokio::task::spawn_blocking(move || metrics.save_to_disk(&metrics_path, &server_names))
-        .await?
+        .await
     {
-        Ok(()) => info!("Metrics saved to {}", stats_path.display()),
-        Err(e) => {
+        Ok(Ok(())) => info!("Metrics saved to {}", stats_path.display()),
+        Ok(Err(e)) => {
             warn!("Failed to save metrics on shutdown: {}", e);
             first_error = Some(e);
+        }
+        Err(e) => {
+            warn!("Failed to join metrics save task on shutdown: {}", e);
+            first_error = Some(e.into());
         }
     }
 
     if let Some(path) = availability_path {
         let cache = proxy.cache().clone();
         let save_path = path.clone();
-        match tokio::task::spawn_blocking(move || cache.save_to_disk(&save_path)).await? {
-            Ok(true) => info!("Availability index saved to {}", path.display()),
-            Ok(false) => {}
-            Err(e) => {
+        match tokio::task::spawn_blocking(move || cache.save_to_disk(&save_path)).await {
+            Ok(Ok(true)) => info!("Availability index saved to {}", path.display()),
+            Ok(Ok(false)) => {}
+            Ok(Err(e)) => {
                 warn!("Failed to save availability index on shutdown: {}", e);
                 if first_error.is_none() {
                     first_error = Some(e);
+                }
+            }
+            Err(e) => {
+                warn!("Failed to join availability save task on shutdown: {}", e);
+                if first_error.is_none() {
+                    first_error = Some(e.into());
                 }
             }
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -231,7 +231,9 @@ pub fn spawn_connection_prewarming(proxy: &std::sync::Arc<crate::NntpProxy>) {
     let proxy = Arc::clone(proxy);
     tokio::spawn(async move {
         info!("Prewarming connection pools...");
-        if let Err(e) = proxy.prewarm_connections().await {
+        if let Err(e) =
+            crate::pool::prewarm_pools(proxy.connection_providers(), proxy.servers()).await
+        {
             warn!("Failed to prewarm connection pools: {}", e);
             return;
         }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -231,9 +231,7 @@ pub fn spawn_connection_prewarming(proxy: &std::sync::Arc<crate::NntpProxy>) {
     let proxy = Arc::clone(proxy);
     tokio::spawn(async move {
         info!("Prewarming connection pools...");
-        if let Err(e) =
-            crate::pool::prewarm_pools(proxy.connection_providers(), proxy.servers()).await
-        {
+        if let Err(e) = proxy.prewarm_connections().await {
             warn!("Failed to prewarm connection pools: {}", e);
             return;
         }

--- a/src/session/backend.rs
+++ b/src/session/backend.rs
@@ -357,7 +357,7 @@ mod tests {
         let mut stream = ChunkedStream::new(vec![b"20".to_vec(), b"0 OK\r\n".to_vec()]);
 
         let pool = crate::pool::BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
 
         let request = RequestContext::from_verb_args(b"DATE", b"");
         let result = send_request(&mut stream, &request, &mut buffer).await;
@@ -375,7 +375,7 @@ mod tests {
         let mut stream = ChunkedStream::new(vec![b"111".to_vec(), b" 20260501173336\r\n".to_vec()]);
 
         let pool = crate::pool::BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
 
         let request = RequestContext::from_verb_args(b"DATE", b"");
         let result = send_request(&mut stream, &request, &mut buffer).await;
@@ -398,7 +398,7 @@ mod tests {
         let mut stream = ChunkedStream::new(chunks);
 
         let pool = crate::pool::BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
 
         let request = RequestContext::from_verb_args(b"GROUP", b"alt.test");
         let result = send_request(&mut stream, &request, &mut buffer).await;

--- a/src/session/backend.rs
+++ b/src/session/backend.rs
@@ -212,14 +212,6 @@ impl BackendFirstResponse {
     }
 }
 
-/// Write a typed request to a backend without building a temporary command buffer.
-pub async fn write_request<C>(conn: &mut C, request: &RequestContext) -> std::io::Result<()>
-where
-    C: tokio::io::AsyncWrite + Unpin,
-{
-    request.write_wire_to(conn).await
-}
-
 /// Send a typed request and read the first response chunk.
 pub async fn send_request<C>(
     conn: &mut C,
@@ -229,7 +221,7 @@ pub async fn send_request<C>(
 where
     C: AsyncReadExt + AsyncWriteExt + Unpin,
 {
-    write_request(conn, request).await?;
+    request.write_wire_to(conn).await?;
 
     let n = buffer.read_from(conn).await?;
     if n == 0 {
@@ -260,7 +252,7 @@ where
     use std::time::Instant;
 
     let start = Instant::now();
-    write_request(conn, request).await?;
+    request.write_wire_to(conn).await?;
     let after_send = Instant::now();
 
     let n = buffer.read_from(conn).await?;

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -153,9 +153,9 @@ impl ClientSession {
         // Phase 2: Read and stream responses in order.
         // Buffer acquired once, reused across all responses.
         // Scratch buffers are needed only while backend responses are being read.
-        let mut buffer = self.buffer_pool.acquire().await;
-        let mut leftover = self.buffer_pool.acquire().await;
-        let mut chunk_data = self.buffer_pool.acquire().await;
+        let mut buffer = self.buffer_pool.acquire();
+        let mut leftover = self.buffer_pool.acquire();
+        let mut chunk_data = self.buffer_pool.acquire();
         debug!(
             client = %self.client_addr,
             backend = ?backend_id,
@@ -785,7 +785,7 @@ impl ClientSession {
             request.verb()
         );
 
-        let mut buffer = self.buffer_pool.acquire().await;
+        let mut buffer = self.buffer_pool.acquire();
         let mut availability = availability.unwrap_or_default();
         debug!(
             "Client {} availability routing: missing_bits={:08b}, backend_count={}",

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -739,11 +739,11 @@ impl ClientSession {
                                 "Client {} pipeline got 430 from backend {:?}, falling through to retry loop",
                                 self.client_addr, completed_backend_id
                             );
-                            availability
-                                .get_or_insert_default()
-                                .record_missing(completed_backend_id);
+                            self.handle_430_availability(
+                                completed_backend_id,
+                                availability.get_or_insert_default(),
+                            );
                             self.metrics.record_pipeline_complete();
-                            self.metrics.record_error_4xx(completed_backend_id);
                         }
                         Ok(Err(e)) => {
                             debug!(

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -712,7 +712,9 @@ impl ClientSession {
                         {
                             completed
                                 .context
-                                .write_response_payload_to(io.client_write)
+                                .response_payload()
+                                .expect("completed request context carries response payload")
+                                .write_all_to(io.client_write)
                                 .await
                                 .map_err(|e| SessionError::from(anyhow::Error::from(e)))?;
                             let response = completed

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -120,9 +120,7 @@ impl ClientSession {
 
         // Phase 1: Write all commands, then flush
         for i in 0..batch.len() {
-            if let Err(e) =
-                crate::session::backend::write_request(&mut **conn, batch.context(i)).await
-            {
+            if let Err(e) = batch.context(i).write_wire_to(&mut **conn).await {
                 warn!(
                     client = %self.client_addr,
                     backend = ?backend_id,

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -421,49 +421,17 @@ impl ClientSession {
 
         match (is_multiline_body, cache_action) {
             (true, CacheAction::CaptureArticle) => {
-                let captured =
-                    streaming::buffer_multiline_response(pooled_conn, params.first_chunk, ctx)
-                        .await?;
-                captured
-                    .write_all_to(client_write)
+                self.buffer_and_cache_multiline_response(pooled_conn, client_write, ctx, params)
                     .await
-                    .map_err(classify_buffered_response_write_err)?;
-                if let Some(msg_id_ref) = params.msg_id {
-                    debug!(
-                        "Client {} caching full article for {} ({} bytes captured)",
-                        self.client_addr,
-                        msg_id_ref,
-                        captured.len()
-                    );
-                }
-                let captured_len = captured.len();
-                self.maybe_cache_upsert_buffer(params.msg_id, captured.into(), ctx.backend_id);
-                Ok(captured_len as u64)
             }
             (true, CacheAction::TrackAvailability) => {
-                // Availability-only mode should not buffer the article body.
-                // Keep first-byte latency and memory bounded by streaming directly,
-                // then cache only typed availability metadata after the terminator is seen.
-                let bytes = streaming::stream_multiline_response(
-                    &mut **pooled_conn,
+                self.stream_multiline_with_availability_tracking(
+                    pooled_conn,
                     client_write,
-                    params.first_chunk,
                     ctx,
+                    params,
                 )
-                .await?;
-                if let Some(msg_id) = params.msg_id
-                    && !params
-                        .request
-                        .cache_records_backend_has_article(ctx.backend_id)
-                {
-                    self.spawn_cache_upsert_availability(
-                        msg_id,
-                        params.status_code,
-                        ctx.backend_id,
-                        self.tier_for_backend(ctx.backend_id),
-                    );
-                }
-                Ok(bytes)
+                .await
             }
             (true, _) => {
                 streaming::stream_multiline_response(
@@ -475,12 +443,8 @@ impl ClientSession {
                 .await
             }
             (false, CacheAction::TrackStat) => {
-                // Single-line: backend already has complete response in first_chunk,
-                // so any write failure is a client-side error (backend is always clean here).
-                client_write
-                    .write_all(params.first_chunk)
-                    .await
-                    .map_err(classify_buffered_response_write_err)?;
+                self.write_single_line_response(client_write, params.first_chunk)
+                    .await?;
                 self.maybe_cache_upsert_buffer(
                     params.msg_id,
                     crate::cache::CacheIngestResponse::from(b"223\r\n".as_slice()),
@@ -489,15 +453,81 @@ impl ClientSession {
                 Ok(params.first_chunk.len() as u64)
             }
             (false, _) => {
-                // Single-line, no caching.
-                // Backend is clean regardless of outcome — response was fully read.
-                client_write
-                    .write_all(params.first_chunk)
+                self.write_single_line_response(client_write, params.first_chunk)
                     .await
-                    .map_err(classify_buffered_response_write_err)?;
-                Ok(params.first_chunk.len() as u64)
             }
         }
+    }
+
+    async fn buffer_and_cache_multiline_response(
+        &self,
+        pooled_conn: &mut deadpool::managed::Object<crate::pool::deadpool_connection::TcpManager>,
+        client_write: &mut tokio::net::tcp::WriteHalf<'_>,
+        ctx: &streaming::StreamContext<'_>,
+        params: ResponseStreamParams<'_>,
+    ) -> Result<u64, StreamingError> {
+        let captured =
+            streaming::buffer_multiline_response(pooled_conn, params.first_chunk, ctx).await?;
+        captured
+            .write_all_to(client_write)
+            .await
+            .map_err(classify_buffered_response_write_err)?;
+        if let Some(msg_id_ref) = params.msg_id {
+            debug!(
+                "Client {} caching full article for {} ({} bytes captured)",
+                self.client_addr,
+                msg_id_ref,
+                captured.len()
+            );
+        }
+        let captured_len = captured.len();
+        self.maybe_cache_upsert_buffer(params.msg_id, captured.into(), ctx.backend_id);
+        Ok(captured_len as u64)
+    }
+
+    async fn stream_multiline_with_availability_tracking(
+        &self,
+        pooled_conn: &mut deadpool::managed::Object<crate::pool::deadpool_connection::TcpManager>,
+        client_write: &mut tokio::net::tcp::WriteHalf<'_>,
+        ctx: &streaming::StreamContext<'_>,
+        params: ResponseStreamParams<'_>,
+    ) -> Result<u64, StreamingError> {
+        // Availability-only mode should not buffer the article body.
+        // Keep first-byte latency and memory bounded by streaming directly,
+        // then cache only typed availability metadata after the terminator is seen.
+        let bytes = streaming::stream_multiline_response(
+            &mut **pooled_conn,
+            client_write,
+            params.first_chunk,
+            ctx,
+        )
+        .await?;
+        if let Some(msg_id) = params.msg_id
+            && !params
+                .request
+                .cache_records_backend_has_article(ctx.backend_id)
+        {
+            self.spawn_cache_upsert_availability(
+                msg_id,
+                params.status_code,
+                ctx.backend_id,
+                self.tier_for_backend(ctx.backend_id),
+            );
+        }
+        Ok(bytes)
+    }
+
+    async fn write_single_line_response(
+        &self,
+        client_write: &mut tokio::net::tcp::WriteHalf<'_>,
+        response: &[u8],
+    ) -> Result<u64, StreamingError> {
+        // Backend is already clean here because the full single-line response was read up front.
+        client_write
+            .write_all(response)
+            .await
+            .map_err(classify_buffered_response_write_err)?;
+        Ok(response.len() as u64)
     }
 
     /// Handle backend error (metrics and cleanup)

--- a/src/session/handlers/hybrid.rs
+++ b/src/session/handlers/hybrid.rs
@@ -112,7 +112,8 @@ impl ClientSession {
         );
 
         // Forward the triggering request (response handled by proxy loop)
-        crate::session::backend::write_request(&mut **conn_guard, initial_request)
+        initial_request
+            .write_wire_to(&mut **conn_guard)
             .await
             .context("Failed to send initial request to backend")?;
 

--- a/src/session/handlers/pipeline_worker.rs
+++ b/src/session/handlers/pipeline_worker.rs
@@ -129,7 +129,7 @@ async fn execute_pipeline_batch(
 
     // Phase 1: Write all commands
     for (i, req) in batch.iter().enumerate() {
-        if let Err(e) = crate::session::backend::write_request(conn, &req.context).await {
+        if let Err(e) = req.context.write_wire_to(conn).await {
             warn!(
                 "Pipeline worker backend {:?}: write failed at command {}/{}: {}",
                 backend_id,

--- a/src/session/handlers/pipeline_worker.rs
+++ b/src/session/handlers/pipeline_worker.rs
@@ -162,7 +162,7 @@ async fn execute_pipeline_batch(
     }
 
     // Phase 2: Read responses in order (with shared buffer + connection-stashed leftovers)
-    let mut buffer = buffer_pool.acquire().await;
+    let mut buffer = buffer_pool.acquire();
     // result_buf is passed in as a parameter (hoisted to worker loop)
 
     batch.reverse();
@@ -437,7 +437,7 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_response_for_request_single_line() {
         let pool = BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
         let mut conn = mock_backend_conn(b"430 No such article\r\n").await;
@@ -460,7 +460,7 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_response_for_request_single_line_split_after_status_code() {
         let pool = BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
         let mut conn =
@@ -484,7 +484,7 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_response_for_request_multiline() {
         let pool = BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
         let response = b"220 0 <msg@id> article\r\nSubject: test\r\n\r\nBody line\r\n.\r\n";
@@ -508,7 +508,7 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_response_for_request_multiline_across_chunks() {
         let pool = BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Split the terminator \r\n.\r\n across two chunks
@@ -538,7 +538,7 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_response_for_request_with_leftover() {
         let pool = BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Two responses packed together
@@ -582,7 +582,7 @@ mod tests {
     async fn test_buffer_response_for_request_multiline_terminal_chunk_stashes_leftover() {
         let pool = BufferPool::new(crate::types::BufferSize::try_new(32).unwrap(), 4)
             .with_capture_pool(1024, 1);
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
         let first =
@@ -621,7 +621,7 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_response_for_request_uses_request_context_for_same_status_framing() {
         let pool = BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
         let packed = b"211 3 10 12 group.name\r\n211 3 10 12 group.name\r\n10\r\n11\r\n12\r\n.\r\n";
@@ -659,7 +659,7 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_response_for_request_eof_mid_stream() {
         let pool = BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Multiline response without terminator — server disconnects
@@ -684,7 +684,7 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_response_for_request_invalid_status() {
         let pool = BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
         let mut conn = mock_backend_conn(b"garbage data here\r\n").await;
@@ -703,7 +703,7 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_response_for_request_short_leftover_triggers_h5() {
         let pool = BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Backend will provide the rest of the response
@@ -728,7 +728,7 @@ mod tests {
     #[tokio::test]
     async fn test_buffer_response_for_request_empty_connection() {
         let pool = BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Server immediately closes
@@ -1208,7 +1208,7 @@ mod tests {
             let rt = tokio::runtime::Runtime::new().unwrap();
             rt.block_on(async {
                 let pool = BufferPool::for_tests();
-                let mut buffer = pool.acquire().await;
+                let mut buffer = pool.acquire();
                 let mut result_buf = crate::pool::ChunkedResponse::default();
 
                 let responses: Vec<Vec<u8>> = codes
@@ -1311,7 +1311,7 @@ mod tests {
         use crate::constants::buffer::MAX_LEFTOVER_BYTES;
 
         let pool = BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Create a multiline response that accumulates in result_buf across chunks,
@@ -1369,7 +1369,7 @@ mod tests {
         use crate::constants::buffer::MAX_LEFTOVER_BYTES;
 
         let pool = BufferPool::for_tests();
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let mut result_buf = crate::pool::ChunkedResponse::default();
 
         // Create a response where leftover is within bounds (< MAX_LEFTOVER_BYTES)

--- a/src/session/handlers/stateful.rs
+++ b/src/session/handlers/stateful.rs
@@ -95,7 +95,7 @@ impl ClientSession {
 
         loop {
             line.clear();
-            let mut buffer = self.buffer_pool.acquire().await;
+            let mut buffer = self.buffer_pool.acquire();
 
             // Periodic metrics flush
             if state.check_and_maybe_flush_metrics() {

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -13,6 +13,7 @@ use crate::router::BackendSelector;
 use crate::session::backend;
 use crate::session::handlers::should_sample_backend_timing;
 use crate::types::{BackendId, MessageId};
+use futures::{StreamExt, stream::FuturesUnordered};
 
 #[derive(Debug)]
 #[cfg_attr(test, derive(PartialEq, Eq))]
@@ -245,24 +246,16 @@ async fn execute_backend_query(
 
 /// Query all backends, collecting results as they arrive
 async fn query_all_backends(deps: &OwnedDeps, request: &RequestContext) -> Vec<QueryResult> {
-    use futures::StreamExt;
+    let mut pending = spawn_backend_queries(deps, request);
+    let mut results = Vec::with_capacity(deps.router.backend_count().get());
 
-    let tasks: Vec<_> = (0..deps.router.backend_count().get())
-        .map(BackendId::from_index)
-        .map(|id| {
-            let deps = deps.clone();
-            let request = request.clone();
-            tokio::spawn(async move { query_backend(&deps, id, &request).await })
-        })
-        .collect();
+    while let Some(result) = pending.next().await {
+        if let Ok(result) = result {
+            results.push(result);
+        }
+    }
 
-    // Race all backends - collect results as they complete (fastest first)
-    let task_count = tasks.len();
-    futures::stream::iter(tasks)
-        .buffer_unordered(task_count)
-        .filter_map(|result| async move { result.ok() })
-        .collect()
-        .await
+    results
 }
 
 /// Query all backends racing, return first success immediately.
@@ -272,34 +265,18 @@ async fn query_all_backends_racing(
     request: &RequestContext,
     msg_id: &MessageId<'_>,
 ) -> Option<(BackendId, PrecheckHit)> {
-    use futures::StreamExt;
-
-    let tasks: Vec<_> = (0..deps.router.backend_count().get())
-        .map(BackendId::from_index)
-        .map(|id| {
-            let deps = deps.clone();
-            let request = request.clone();
-            tokio::spawn(async move { query_backend(&deps, id, &request).await })
-        })
-        .collect();
-
     let backend_count = deps.router.backend_count();
-
-    // Process results as they complete, return first success immediately
-    let mut pending = futures::stream::iter(tasks)
-        .buffer_unordered(backend_count.get())
-        .filter_map(|result| async move { result.ok() })
-        .boxed();
+    let mut pending = spawn_backend_queries(deps, request);
 
     let mut results = Vec::with_capacity(backend_count.get());
-    let mut first_found = None;
 
     // Collect results until we find a success
     while let Some(result) = pending.next().await {
+        let Ok(result) = result else {
+            continue;
+        };
         match result {
-            QueryResult::Found(id, response) if first_found.is_none() => {
-                first_found = Some((id, response));
-
+            QueryResult::Found(id, response) => {
                 // Spawn background task to complete remaining backends and update cache
                 let cache = deps.cache.clone();
                 let msg_id_owned = msg_id.to_owned();
@@ -307,7 +284,9 @@ async fn query_all_backends_racing(
                 let handle = tokio::spawn(async move {
                     // Collect remaining results
                     while let Some(result) = pending.next().await {
-                        results.push(result);
+                        if let Ok(result) = result {
+                            results.push(result);
+                        }
                     }
                     // Build availability from all results and sync to cache
                     let (_, mut availability) = summarize(results);
@@ -325,7 +304,7 @@ async fn query_all_backends_racing(
                         );
                     }
                 });
-                return first_found;
+                return Some((id, response));
             }
             _ => {
                 results.push(result);
@@ -335,6 +314,20 @@ async fn query_all_backends_racing(
 
     // No success found - all backends returned 430
     None
+}
+
+fn spawn_backend_queries(
+    deps: &OwnedDeps,
+    request: &RequestContext,
+) -> FuturesUnordered<tokio::task::JoinHandle<QueryResult>> {
+    (0..deps.router.backend_count().get())
+        .map(BackendId::from_index)
+        .map(|id| {
+            let deps = deps.clone();
+            let request = request.clone();
+            tokio::spawn(async move { query_backend(&deps, id, &request).await })
+        })
+        .collect()
 }
 
 /// Extract first found response and build availability from results.

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -270,7 +270,18 @@ fn classify_precheck_result(
             deps.metrics.record_error_4xx(backend_id);
             QueryResult::Missing(backend_id)
         }
-        _ => QueryResult::Error,
+        400..=499 => {
+            deps.metrics.record_error_4xx(backend_id);
+            QueryResult::Error
+        }
+        500..=599 => {
+            deps.metrics.record_error_5xx(backend_id);
+            QueryResult::Error
+        }
+        _ => {
+            deps.metrics.record_error(backend_id);
+            QueryResult::Error
+        }
     }
 }
 

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -121,7 +121,7 @@ async fn execute_backend_query(
     };
     let mut conn = crate::pool::ConnectionGuard::new(conn_raw, provider.clone());
 
-    let mut buffer = deps.buffer_pool.acquire().await;
+    let mut buffer = deps.buffer_pool.acquire();
 
     let response = if should_sample_backend_timing() {
         backend::send_request_timed(&mut **conn, request, &mut buffer)

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -479,6 +479,22 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use crate::cache::UnifiedCache;
+    use crate::metrics::MetricsCollector;
+    use crate::pool::BufferPool;
+    use crate::router::BackendSelector;
+    use crate::types::BufferSize;
+
+    fn test_owned_deps(num_backends: usize) -> OwnedDeps {
+        OwnedDeps {
+            router: Arc::new(BackendSelector::new()),
+            cache: Arc::new(UnifiedCache::memory(100, Duration::from_secs(60))),
+            buffer_pool: BufferPool::new(BufferSize::try_new(4096).unwrap(), 1),
+            metrics: MetricsCollector::new(num_backends),
+            cache_articles: true,
+        }
+    }
+
     #[test]
     fn summarize_finds_first() {
         let results = vec![
@@ -524,6 +540,51 @@ mod tests {
         assert_eq!(avail.checked_bits(), 0);
     }
 
+    #[test]
+    fn classify_precheck_result_records_non_430_4xx_as_error() {
+        let backend_id = BackendId::from_index(0);
+        let deps = test_owned_deps(1);
+
+        let result = classify_precheck_result(
+            &deps,
+            backend_id,
+            StatusCode::new(412),
+            Some((11, 22, 33)),
+            PrecheckHit::Availability(StatusCode::new(412)),
+        );
+
+        assert_eq!(result, QueryResult::Error);
+        let snapshot = deps.metrics.snapshot(None);
+        let backend = &snapshot.backend_stats[0];
+        assert_eq!(backend.total_commands.get(), 1);
+        assert_eq!(backend.ttfb_count.get(), 1);
+        assert_eq!(backend.errors_4xx.get(), 1);
+        assert_eq!(backend.errors_5xx.get(), 0);
+        assert_eq!(backend.errors.get(), 1);
+    }
+
+    #[test]
+    fn classify_precheck_result_records_5xx_as_error() {
+        let backend_id = BackendId::from_index(0);
+        let deps = test_owned_deps(1);
+
+        let result = classify_precheck_result(
+            &deps,
+            backend_id,
+            StatusCode::new(502),
+            None,
+            PrecheckHit::Availability(StatusCode::new(502)),
+        );
+
+        assert_eq!(result, QueryResult::Error);
+        let snapshot = deps.metrics.snapshot(None);
+        let backend = &snapshot.backend_stats[0];
+        assert_eq!(backend.total_commands.get(), 1);
+        assert_eq!(backend.errors_4xx.get(), 0);
+        assert_eq!(backend.errors_5xx.get(), 1);
+        assert_eq!(backend.errors.get(), 1);
+    }
+
     async fn spawn_truncated_precheck_server() -> std::net::SocketAddr {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         use tokio::net::TcpListener;
@@ -552,11 +613,9 @@ mod tests {
 
     #[tokio::test]
     async fn query_backend_returns_error_on_truncated_multiline_response() {
-        use crate::cache::UnifiedCache;
-        use crate::metrics::MetricsCollector;
-        use crate::pool::{BufferPool, DeadpoolConnectionProvider};
+        use crate::pool::DeadpoolConnectionProvider;
         use crate::router::BackendSelector;
-        use crate::types::{BackendId, BufferSize, ServerName};
+        use crate::types::{BackendId, ServerName};
 
         let addr = spawn_truncated_precheck_server().await;
 
@@ -593,7 +652,6 @@ mod tests {
 
     #[tokio::test]
     async fn cache_precheck_availability_hit_does_not_persist_positive_entry() {
-        use crate::cache::UnifiedCache;
         use crate::types::BackendId;
 
         let backend_id = BackendId::from_index(0);

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -141,98 +141,17 @@ async fn execute_backend_query(
                 return Err(());
             };
 
-            let response = if request.expects_multiline_response(status_code) {
-                use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
-                let mut response = deps
-                    .cache_articles
-                    .then(crate::pool::ChunkedResponse::default);
-                if let Some(response) = &mut response {
-                    response
-                        .extend_from_slice(&deps.buffer_pool, &buffer[..cmd_response.bytes_read]);
-                }
-                let mut tail = TailBuffer::default();
-                match tail.detect_terminator(buffer.as_ref()) {
-                    TerminatorStatus::FoundAt(pos) => {
-                        // pos is after the terminator (terminator included in [..pos])
-                        if pos < cmd_response.bytes_read
-                            && conn
-                                .stash_leftover(&buffer[pos..cmd_response.bytes_read])
-                                .is_err()
-                        {
-                            return Err(());
-                        }
-                        if let Some(response) = &mut response {
-                            response.truncate(pos);
-                        }
-                    }
-                    TerminatorStatus::NotFound => {
-                        tail.update(buffer.as_ref());
-                        loop {
-                            match buffer.read_from(conn.as_mut()).await {
-                                Ok(0) | Err(_) => return Err(()),
-                                Ok(n) => match tail.detect_terminator(&buffer[..n]) {
-                                    TerminatorStatus::FoundAt(pos) => {
-                                        if pos < n && conn.stash_leftover(&buffer[pos..n]).is_err()
-                                        {
-                                            return Err(());
-                                        }
-                                        if let Some(response) = &mut response {
-                                            response.extend_from_slice(
-                                                &deps.buffer_pool,
-                                                &buffer[..pos],
-                                            );
-                                        }
-                                        break;
-                                    }
-                                    TerminatorStatus::NotFound => {
-                                        tail.update(&buffer[..n]);
-                                        if let Some(response) = &mut response {
-                                            response
-                                                .extend_from_slice(&deps.buffer_pool, &buffer[..n]);
-                                        }
-                                    }
-                                },
-                            }
-                        }
-                    }
-                }
-                if let Some(response) = response {
-                    PrecheckHit::Payload(crate::cache::CacheIngestResponse::Chunked(response))
-                } else {
-                    PrecheckHit::Availability(status_code)
-                }
-            } else if deps.cache_articles {
-                PrecheckHit::Payload(crate::cache::CacheIngestResponse::from(
-                    &buffer[..cmd_response.bytes_read],
-                ))
-            } else {
-                PrecheckHit::Availability(status_code)
-            };
+            let response = build_precheck_hit(
+                deps,
+                request,
+                status_code,
+                &mut conn,
+                &mut buffer,
+                cmd_response.bytes_read,
+            )
+            .await?;
 
-            let result = match status_code.as_u16() {
-                220..=223 => {
-                    tracing::debug!(
-                        backend = backend_id.as_index(),
-                        "precheck recording command to metrics"
-                    );
-                    deps.metrics.record_command(backend_id);
-                    if let Some((ttfb, send, recv)) = timings {
-                        deps.metrics.record_ttfb_micros(backend_id, ttfb);
-                        deps.metrics.record_send_recv_micros(backend_id, send, recv);
-                    }
-                    QueryResult::Found(backend_id, response)
-                }
-                430 => {
-                    deps.metrics.record_command(backend_id);
-                    if let Some((ttfb, send, recv)) = timings {
-                        deps.metrics.record_ttfb_micros(backend_id, ttfb);
-                        deps.metrics.record_send_recv_micros(backend_id, send, recv);
-                    }
-                    deps.metrics.record_error_4xx(backend_id);
-                    QueryResult::Missing(backend_id)
-                }
-                _ => QueryResult::Error,
-            };
+            let result = classify_precheck_result(deps, backend_id, status_code, timings, response);
 
             let _ = conn.release(); // response received; connection healthy, return to pool
             Ok(result)
@@ -241,6 +160,117 @@ async fn execute_backend_query(
             // Connection error - conn drops → remove_with_cooldown
             Err(())
         }
+    }
+}
+
+async fn build_precheck_hit(
+    deps: &OwnedDeps,
+    request: &RequestContext,
+    status_code: StatusCode,
+    conn: &mut crate::pool::ConnectionGuard,
+    buffer: &mut crate::pool::PooledBuffer,
+    bytes_read: usize,
+) -> Result<PrecheckHit, ()> {
+    if request.expects_multiline_response(status_code) {
+        return read_multiline_precheck_hit(deps, status_code, conn, buffer, bytes_read).await;
+    }
+
+    if deps.cache_articles {
+        Ok(PrecheckHit::Payload(
+            crate::cache::CacheIngestResponse::from(&buffer[..bytes_read]),
+        ))
+    } else {
+        Ok(PrecheckHit::Availability(status_code))
+    }
+}
+
+async fn read_multiline_precheck_hit(
+    deps: &OwnedDeps,
+    status_code: StatusCode,
+    conn: &mut crate::pool::ConnectionGuard,
+    buffer: &mut crate::pool::PooledBuffer,
+    bytes_read: usize,
+) -> Result<PrecheckHit, ()> {
+    use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
+
+    let mut response = deps
+        .cache_articles
+        .then(crate::pool::ChunkedResponse::default);
+    if let Some(response) = &mut response {
+        response.extend_from_slice(&deps.buffer_pool, &buffer[..bytes_read]);
+    }
+    let mut tail = TailBuffer::default();
+    match tail.detect_terminator(buffer.as_ref()) {
+        TerminatorStatus::FoundAt(pos) => {
+            // pos is after the terminator (terminator included in [..pos])
+            if pos < bytes_read && conn.stash_leftover(&buffer[pos..bytes_read]).is_err() {
+                return Err(());
+            }
+            if let Some(response) = &mut response {
+                response.truncate(pos);
+            }
+        }
+        TerminatorStatus::NotFound => {
+            tail.update(buffer.as_ref());
+            loop {
+                match buffer.read_from(conn.as_mut()).await {
+                    Ok(0) | Err(_) => return Err(()),
+                    Ok(n) => match tail.detect_terminator(&buffer[..n]) {
+                        TerminatorStatus::FoundAt(pos) => {
+                            if pos < n && conn.stash_leftover(&buffer[pos..n]).is_err() {
+                                return Err(());
+                            }
+                            if let Some(response) = &mut response {
+                                response.extend_from_slice(&deps.buffer_pool, &buffer[..pos]);
+                            }
+                            break;
+                        }
+                        TerminatorStatus::NotFound => {
+                            tail.update(&buffer[..n]);
+                            if let Some(response) = &mut response {
+                                response.extend_from_slice(&deps.buffer_pool, &buffer[..n]);
+                            }
+                        }
+                    },
+                }
+            }
+        }
+    }
+    if let Some(response) = response {
+        Ok(PrecheckHit::Payload(
+            crate::cache::CacheIngestResponse::Chunked(response),
+        ))
+    } else {
+        Ok(PrecheckHit::Availability(status_code))
+    }
+}
+
+fn classify_precheck_result(
+    deps: &OwnedDeps,
+    backend_id: BackendId,
+    status_code: StatusCode,
+    timings: Option<(u64, u64, u64)>,
+    response: PrecheckHit,
+) -> QueryResult {
+    deps.metrics.record_command(backend_id);
+    if let Some((ttfb, send, recv)) = timings {
+        deps.metrics.record_ttfb_micros(backend_id, ttfb);
+        deps.metrics.record_send_recv_micros(backend_id, send, recv);
+    }
+
+    match status_code.as_u16() {
+        220..=223 => {
+            tracing::debug!(
+                backend = backend_id.as_index(),
+                "precheck recording command to metrics"
+            );
+            QueryResult::Found(backend_id, response)
+        }
+        430 => {
+            deps.metrics.record_error_4xx(backend_id);
+            QueryResult::Missing(backend_id)
+        }
+        _ => QueryResult::Error,
     }
 }
 

--- a/src/session/streaming/mod.rs
+++ b/src/session/streaming/mod.rs
@@ -193,7 +193,7 @@ async fn drain_until_terminator<R>(
 where
     R: AsyncReadExt + Unpin,
 {
-    let mut chunk = ctx.buffer_pool.acquire().await;
+    let mut chunk = ctx.buffer_pool.acquire();
     let mut tail = TailBuffer::default();
     tail.update(initial_tail);
     loop {
@@ -416,7 +416,7 @@ pub(crate) async fn buffer_multiline_response(
 ) -> Result<crate::pool::ChunkedResponse, StreamingError> {
     use crate::session::streaming::tail_buffer::{TailBuffer, TerminatorStatus};
 
-    let mut io_buffer = ctx.buffer_pool.acquire().await;
+    let mut io_buffer = ctx.buffer_pool.acquire();
     let mut captured = crate::pool::ChunkedResponse::default();
     validate_response_prefix(first_chunk, "prefetched")?;
 
@@ -670,10 +670,7 @@ where
         pipelined = leftover_out.is_some(),
         "Multiline Phase 2: first chunk incomplete, streaming remaining chunks"
     );
-    let mut buffers = [
-        ctx.buffer_pool.acquire().await,
-        ctx.buffer_pool.acquire().await,
-    ];
+    let mut buffers = [ctx.buffer_pool.acquire(), ctx.buffer_pool.acquire()];
     let mut idx = 0usize;
 
     loop {
@@ -1030,7 +1027,7 @@ mod tests {
     async fn test_read_response_into_context_completes_request() {
         let response = b"223 0 <test@example>\r\n";
         let pool = test_helpers::make_pool();
-        let mut io_buffer = pool.acquire().await;
+        let mut io_buffer = pool.acquire();
         let mut captured = crate::pool::ChunkedResponse::default();
         let mut conn = test_helpers::mock_backend_conn(vec![response.to_vec()]).await;
         let backend_id = crate::types::BackendId::from_index(1);
@@ -1167,7 +1164,7 @@ mod tests {
         let mut reader = Cursor::new(b"" as &[u8]);
         let mut writer = Vec::new();
         let pool = test_helpers::make_pool();
-        let mut leftover = pool.acquire().await;
+        let mut leftover = pool.acquire();
         let ctx = test_helpers::make_ctx(&pool);
 
         let result = stream_multiline_response_pipelined(
@@ -1197,7 +1194,7 @@ mod tests {
         let mut reader = Cursor::new(second_read.as_slice());
         let mut writer = Vec::new();
         let pool = test_helpers::make_pool();
-        let mut leftover = pool.acquire().await;
+        let mut leftover = pool.acquire();
         let ctx = test_helpers::make_ctx(&pool);
 
         let result = stream_multiline_response_pipelined(
@@ -1230,7 +1227,7 @@ mod tests {
         let mut reader = Cursor::new(b"" as &[u8]);
         let mut writer = Vec::new();
         let pool = test_helpers::make_pool();
-        let mut leftover = pool.acquire().await;
+        let mut leftover = pool.acquire();
         let ctx = test_helpers::make_ctx(&pool);
 
         let result = stream_multiline_response_pipelined(
@@ -1263,7 +1260,7 @@ mod tests {
         let mut reader = Cursor::new(b"" as &[u8]);
         let mut writer = Vec::new();
         let pool = test_helpers::make_pool();
-        let mut leftover = pool.acquire().await;
+        let mut leftover = pool.acquire();
         let ctx = test_helpers::make_ctx(&pool);
 
         let result = stream_multiline_response_pipelined(

--- a/tests/rfc3977/session_state.rs
+++ b/tests/rfc3977/session_state.rs
@@ -120,11 +120,9 @@ async fn test_mode_reader_sent_to_backend() -> Result<()> {
     };
 
     let proxy = NntpProxy::new(config, RoutingMode::PerCommand).await?;
-    nntp_proxy::pool::prewarm_pools(proxy.connection_providers(), proxy.servers())
-        .await
-        .ok();
+    proxy.prewarm_connections().await.ok();
 
-    // prewarm_pools(...).await returns after pool connections are established,
+    // prewarm_connections().await returns after pool connections are established,
     // which includes the full handshake (greeting → auth → MODE READER).
     // The backend task sends each command through the channel asynchronously,
     // so we drive the receiver until MODE READER arrives rather than sleeping.

--- a/tests/rfc3977/session_state.rs
+++ b/tests/rfc3977/session_state.rs
@@ -120,9 +120,11 @@ async fn test_mode_reader_sent_to_backend() -> Result<()> {
     };
 
     let proxy = NntpProxy::new(config, RoutingMode::PerCommand).await?;
-    proxy.prewarm_connections().await.ok();
+    nntp_proxy::pool::prewarm_pools(proxy.connection_providers(), proxy.servers())
+        .await
+        .ok();
 
-    // prewarm_connections().await returns after pool connections are established,
+    // prewarm_pools(...).await returns after pool connections are established,
     // which includes the full handshake (greeting → auth → MODE READER).
     // The backend task sends each command through the channel asynchronously,
     // so we drive the receiver until MODE READER arrives rather than sleeping.

--- a/tests/rfc4643/backend.rs
+++ b/tests/rfc4643/backend.rs
@@ -303,16 +303,16 @@ async fn test_buffer_pool_basic_usage() {
     let buffer_pool = BufferPool::new(BufferSize::try_new(8192).unwrap(), 2);
 
     // Get buffer
-    let buffer1 = buffer_pool.acquire().await;
+    let buffer1 = buffer_pool.acquire();
     assert_eq!(buffer1.capacity(), 8192);
 
     // Get another
-    let buffer2 = buffer_pool.acquire().await;
+    let buffer2 = buffer_pool.acquire();
     assert_eq!(buffer2.capacity(), 8192);
 
     // Drop and get again
     drop(buffer1);
-    let buffer3 = buffer_pool.acquire().await;
+    let buffer3 = buffer_pool.acquire();
     assert_eq!(buffer3.capacity(), 8192);
 }
 
@@ -323,7 +323,7 @@ async fn test_buffer_pool_different_sizes() {
 
     for size in &sizes {
         let buffer_pool = BufferPool::new(BufferSize::try_new(*size).unwrap(), 1);
-        let buffer = buffer_pool.acquire().await;
+        let buffer = buffer_pool.acquire();
         assert!(buffer.capacity() >= *size);
         assert_eq!(buffer.capacity() % 4096, 0);
     }
@@ -565,7 +565,7 @@ async fn test_buffer_pool_concurrent_access() {
     for _ in 0..20 {
         let pool = buffer_pool.clone();
         let handle = tokio::spawn(async move {
-            let buffer = pool.acquire().await;
+            let buffer = pool.acquire();
             assert_eq!(buffer.capacity(), 8192);
             // Simulate some work
             tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;

--- a/tests/rfc4643/review_claims.rs
+++ b/tests/rfc4643/review_claims.rs
@@ -298,7 +298,7 @@ async fn test_buffer_pool_safety_across_cycles() {
 
     // Get buffer, use it, return it
     {
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         let test_data = b"First use";
         buffer.copy_from_slice(test_data);
         assert_eq!(&buffer[..test_data.len()], test_data);
@@ -307,7 +307,7 @@ async fn test_buffer_pool_safety_across_cycles() {
 
     // Get buffer again (might be same buffer, might be new)
     {
-        let mut buffer = pool.acquire().await;
+        let mut buffer = pool.acquire();
         // Even if this is the same buffer from before, it's safe because:
         // 1. We'll overwrite it with new data via AsyncRead
         // 2. We only access buf[..n] where n is bytes actually read


### PR DESCRIPTION
## Summary
- remove fake async from buffer pool acquisition and update all call sites
- return standalone client fetch futures directly and split/simplify client multiline handling
- inline trivial async forwarding wrappers and keep the remaining real async streaming surfaces intact

## Validation
- cargo bench --bench end_to_end_proxy cache_miss_roundtrip
- cargo bench --bench cache_miss_roundtrip_callgrind
- cargo clippy --all-targets --all-features
- cargo nextest run