### PR TITLE
Add websocket-attached TUI for headless mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Websocket-attached TUI for headless mode** ([#67](https://github.com/mjc/nntp-proxy/pull/67))
+  - Added a headless dashboard publisher via `--tui-listen IP:PORT` and a read-only attached TUI client via `--tui-attach IP:PORT`.
+  - Attached dashboards reconnect automatically, keep the last good snapshot on disconnect, and show proxy CPU/memory alongside local TUI CPU/memory.
+  - Dashboard publish/attach mode is loopback-only and uses a redacted dashboard payload instead of exposing full backend configuration.
+
 - **RFC 8054 backend wire compression** ([#53](https://github.com/mjc/nntp-proxy/pull/53))
   - Added `COMPRESS DEFLATE` negotiation for proxy-to-backend links with configurable compression mode and level.
   - Backend responses can now be transparently compressed without changing client-side NNTP behavior.
@@ -46,6 +51,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Reworked cache response generation and ingestion to use borrowed bytes and typed cache parts, reducing copying on cache hits.
 
 ### Fixed
+
+- **Article retry fallback behavior** ([#67](https://github.com/mjc/nntp-proxy/pull/67))
+  - `ARTICLE`/`BODY` requests that are already known missing across eligible backends now return `430` instead of disconnecting the client.
+  - This also fixes the pipelined batch path so cached-missing article requests fail with protocol responses instead of dropping the session.
+
+- **Dashboard startup and connection handling** ([#67](https://github.com/mjc/nntp-proxy/pull/67))
+  - Dashboard listener bind failures now fail startup clearly instead of leaving the proxy running without the requested dashboard endpoint.
+  - Remote dashboard publishing and attach handling were hardened around shutdown, reconnects, and listener/test race conditions.
 
 - **Backend connection state and multiline response framing** ([#58](https://github.com/mjc/nntp-proxy/pull/58), [#59](https://github.com/mjc/nntp-proxy/pull/59))
   - Fixed pooled-connection read-ahead handling so bytes past `\r\n.\r\n` are preserved for the next response instead of desynchronizing reused backend connections.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deadpool"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1122,6 +1128,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "iai-callgrind"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1586,6 +1608,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-rustls",
+ "tokio-tungstenite",
  "toml",
  "tracing",
  "tracing-appender",
@@ -2430,6 +2453,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,6 +2876,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2938,6 +2984,22 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ dashmap = "6.1"  # Lock-free concurrent HashMap for metrics
 sysinfo = "0.38"  # System metrics (CPU, memory) for monitoring
 chrono = { version = "0.4", features = ["serde", "clock"], default-features = false }  # Timestamps for stats persistence
 serde_json = "1.0"  # JSON serialization for stats persistence
+tokio-tungstenite = "0.29"  # WebSocket transport for remote TUI attachment
 
 # Derive helpers to reduce newtype boilerplate
 nutype = { version = "0.7", features = ["serde"] }  # Validated newtypes with automatic derives

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ TLS, cache behavior, and live metrics in one place.
 - `nntp-proxy` is the runtime executable.
 - The same binary can run headless or with the terminal dashboard via `--ui headless` or `--ui tui`.
 - Headless mode can also publish the dashboard state over websocket with `--tui-listen 127.0.0.1:8120` (`HOST:PORT`).
-  This must be a different socket from the main NNTP listener.
+  This must be a different socket from the main NNTP listener and must stay on a loopback address.
 - A separate terminal can attach read-only with `--ui tui --tui-attach 127.0.0.1:8120` (`HOST:PORT`).
 - Article caching is configured via `[cache]`; there is no separate cache-only executable.
 - Client-facing connections are plain NNTP only. The proxy does not terminate inbound TLS or offer a TLS listening mode.
@@ -314,7 +314,7 @@ Common flags:
 | --- | --- | --- | --- |
 | `--config <FILE>` | `NNTP_PROXY_CONFIG` | Default: `config.toml` | Config file path. |
 | `--ui <MODE>` | `NNTP_PROXY_UI` | `headless` or `tui`; default: `headless` | Selects how the single `nntp-proxy` binary runs: plain server logging or the terminal dashboard. |
-| `--tui-listen <HOST:PORT>` | `NNTP_PROXY_TUI_LISTEN` | `HOST:PORT` | Bind the dashboard websocket publisher to a socket address in headless mode. |
+| `--tui-listen <HOST:PORT>` | `NNTP_PROXY_TUI_LISTEN` | `HOST:PORT` | Bind the dashboard websocket publisher to a loopback socket address in headless mode. |
 | `--tui-attach <HOST:PORT>` | `NNTP_PROXY_TUI_ATTACH` | `HOST:PORT` | Connect the read-only TUI client to a dashboard websocket at a socket address. |
 | `--host <HOST>` | `NNTP_PROXY_HOST` | Default from config; otherwise `0.0.0.0` | Override `[proxy].host`. |
 | `--port <PORT>` | `NNTP_PROXY_PORT` | Default from config; otherwise `8119` | Override `[proxy].port`. |

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ TLS, cache behavior, and live metrics in one place.
 
 - `nntp-proxy` is the runtime executable.
 - The same binary can run headless or with the terminal dashboard via `--ui headless` or `--ui tui`.
+- Headless mode can also publish the dashboard state over websocket with `--tui-listen 127.0.0.1:8120`.
+- A separate terminal can attach read-only with `--ui tui --tui-attach 127.0.0.1:8120`.
 - Article caching is configured via `[cache]`; there is no separate cache-only executable.
 - Client-facing connections are plain NNTP only. The proxy does not terminate inbound TLS or offer a TLS listening mode.
 
@@ -52,6 +54,18 @@ Run the proxy:
 ```
 
 To launch the dashboard-enabled UI, use the same `nntp-proxy` binary with `--ui tui`.
+
+To run headless and expose a remote dashboard:
+
+```bash
+./target/release/nntp-proxy --ui headless --tui-listen 127.0.0.1:8120
+```
+
+To attach a terminal client to that dashboard:
+
+```bash
+./target/release/nntp-proxy --ui tui --tui-attach 127.0.0.1:8120
+```
 
 Connect a client to `localhost:8119` unless you changed `[proxy].port`.
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ TLS, cache behavior, and live metrics in one place.
 
 - `nntp-proxy` is the runtime executable.
 - The same binary can run headless or with the terminal dashboard via `--ui headless` or `--ui tui`.
-- Headless mode can also publish the dashboard state over websocket with `--tui-listen 127.0.0.1:8120`.
-- A separate terminal can attach read-only with `--ui tui --tui-attach 127.0.0.1:8120`.
+- Headless mode can also publish the dashboard state over websocket with `--tui-listen 127.0.0.1:8120` (`HOST:PORT`).
+- A separate terminal can attach read-only with `--ui tui --tui-attach 127.0.0.1:8120` (`HOST:PORT`).
 - Article caching is configured via `[cache]`; there is no separate cache-only executable.
 - Client-facing connections are plain NNTP only. The proxy does not terminate inbound TLS or offer a TLS listening mode.
 
@@ -313,6 +313,8 @@ Common flags:
 | --- | --- | --- | --- |
 | `--config <FILE>` | `NNTP_PROXY_CONFIG` | Default: `config.toml` | Config file path. |
 | `--ui <MODE>` | `NNTP_PROXY_UI` | `headless` or `tui`; default: `headless` | Selects how the single `nntp-proxy` binary runs: plain server logging or the terminal dashboard. |
+| `--tui-listen <HOST:PORT>` | `NNTP_PROXY_TUI_LISTEN` | `HOST:PORT` | Bind the dashboard websocket publisher to a socket address in headless mode. |
+| `--tui-attach <HOST:PORT>` | `NNTP_PROXY_TUI_ATTACH` | `HOST:PORT` | Connect the read-only TUI client to a dashboard websocket at a socket address. |
 | `--host <HOST>` | `NNTP_PROXY_HOST` | Default from config; otherwise `0.0.0.0` | Override `[proxy].host`. |
 | `--port <PORT>` | `NNTP_PROXY_PORT` | Default from config; otherwise `8119` | Override `[proxy].port`. |
 | `--routing-mode <MODE>` | `NNTP_PROXY_ROUTING_MODE` | `hybrid`, `stateful`, or `per-command`; default from config | Override `[routing].mode`. |

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ TLS, cache behavior, and live metrics in one place.
 - Headless mode can also publish the dashboard state over websocket with `--tui-listen 127.0.0.1:8120` (`HOST:PORT`).
   This must be a different socket from the main NNTP listener and must stay on a loopback address.
 - A separate terminal can attach read-only with `--ui tui --tui-attach 127.0.0.1:8120` (`HOST:PORT`).
+  This also stays loopback-only.
 - Article caching is configured via `[cache]`; there is no separate cache-only executable.
 - Client-facing connections are plain NNTP only. The proxy does not terminate inbound TLS or offer a TLS listening mode.
 
@@ -315,7 +316,7 @@ Common flags:
 | `--config <FILE>` | `NNTP_PROXY_CONFIG` | Default: `config.toml` | Config file path. |
 | `--ui <MODE>` | `NNTP_PROXY_UI` | `headless` or `tui`; default: `headless` | Selects how the single `nntp-proxy` binary runs: plain server logging or the terminal dashboard. |
 | `--tui-listen <HOST:PORT>` | `NNTP_PROXY_TUI_LISTEN` | `HOST:PORT` | Bind the dashboard websocket publisher to a loopback socket address in headless mode. |
-| `--tui-attach <HOST:PORT>` | `NNTP_PROXY_TUI_ATTACH` | `HOST:PORT` | Connect the read-only TUI client to a dashboard websocket at a socket address. |
+| `--tui-attach <HOST:PORT>` | `NNTP_PROXY_TUI_ATTACH` | `HOST:PORT` | Connect the read-only TUI client to a dashboard websocket on a loopback socket address. |
 | `--host <HOST>` | `NNTP_PROXY_HOST` | Default from config; otherwise `0.0.0.0` | Override `[proxy].host`. |
 | `--port <PORT>` | `NNTP_PROXY_PORT` | Default from config; otherwise `8119` | Override `[proxy].port`. |
 | `--routing-mode <MODE>` | `NNTP_PROXY_ROUTING_MODE` | `hybrid`, `stateful`, or `per-command`; default from config | Override `[routing].mode`. |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ TLS, cache behavior, and live metrics in one place.
 - `nntp-proxy` is the runtime executable.
 - The same binary can run headless or with the terminal dashboard via `--ui headless` or `--ui tui`.
 - Headless mode can also publish the dashboard state over websocket with `--tui-listen 127.0.0.1:8120` (`HOST:PORT`).
+  This must be a different socket from the main NNTP listener.
 - A separate terminal can attach read-only with `--ui tui --tui-attach 127.0.0.1:8120` (`HOST:PORT`).
 - Article caching is configured via `[cache]`; there is no separate cache-only executable.
 - Client-facing connections are plain NNTP only. The proxy does not terminate inbound TLS or offer a TLS listening mode.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ TLS, cache behavior, and live metrics in one place.
 
 - `nntp-proxy` is the runtime executable.
 - The same binary can run headless or with the terminal dashboard via `--ui headless` or `--ui tui`.
-- Headless mode can also publish the dashboard state over websocket with `--tui-listen 127.0.0.1:8120` (`HOST:PORT`).
+- Headless mode can also publish the dashboard state over websocket with `--tui-listen 127.0.0.1:8120` (`IP:PORT`).
   This must be a different socket from the main NNTP listener and must stay on a loopback address.
-- A separate terminal can attach read-only with `--ui tui --tui-attach 127.0.0.1:8120` (`HOST:PORT`).
+- A separate terminal can attach read-only with `--ui tui --tui-attach 127.0.0.1:8120` (`IP:PORT`).
   This also stays loopback-only.
 - Article caching is configured via `[cache]`; there is no separate cache-only executable.
 - Client-facing connections are plain NNTP only. The proxy does not terminate inbound TLS or offer a TLS listening mode.
@@ -315,8 +315,8 @@ Common flags:
 | --- | --- | --- | --- |
 | `--config <FILE>` | `NNTP_PROXY_CONFIG` | Default: `config.toml` | Config file path. |
 | `--ui <MODE>` | `NNTP_PROXY_UI` | `headless` or `tui`; default: `headless` | Selects how the single `nntp-proxy` binary runs: plain server logging or the terminal dashboard. |
-| `--tui-listen <HOST:PORT>` | `NNTP_PROXY_TUI_LISTEN` | `HOST:PORT` | Bind the dashboard websocket publisher to a loopback socket address in headless mode. |
-| `--tui-attach <HOST:PORT>` | `NNTP_PROXY_TUI_ATTACH` | `HOST:PORT` | Connect the read-only TUI client to a dashboard websocket on a loopback socket address. |
+| `--tui-listen <IP:PORT>` | `NNTP_PROXY_TUI_LISTEN` | `IP:PORT` | Bind the dashboard websocket publisher to a loopback socket address in headless mode. |
+| `--tui-attach <IP:PORT>` | `NNTP_PROXY_TUI_ATTACH` | `IP:PORT` | Connect the read-only TUI client to a dashboard websocket on a loopback socket address. |
 | `--host <HOST>` | `NNTP_PROXY_HOST` | Default from config; otherwise `0.0.0.0` | Override `[proxy].host`. |
 | `--port <PORT>` | `NNTP_PROXY_PORT` | Default from config; otherwise `8119` | Override `[proxy].port`. |
 | `--routing-mode <MODE>` | `NNTP_PROXY_ROUTING_MODE` | `hybrid`, `stateful`, or `per-command`; default from config | Override `[routing].mode`. |

--- a/src/args.rs
+++ b/src/args.rs
@@ -374,10 +374,7 @@ fn proxy_listener_conflicts(
 }
 
 fn listener_ips_conflict(proxy_ip: IpAddr, dashboard_ip: IpAddr) -> bool {
-    proxy_ip.is_unspecified()
-        || dashboard_ip.is_unspecified()
-        || proxy_ip == dashboard_ip
-        || (proxy_ip.is_loopback() && dashboard_ip.is_loopback())
+    proxy_ip.is_unspecified() || dashboard_ip.is_unspecified() || proxy_ip == dashboard_ip
 }
 
 #[cfg(test)]
@@ -650,16 +647,14 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_dashboard_listen_rejects_loopback_alias_collision() {
+    fn test_validate_dashboard_listen_allows_distinct_loopback_ips() {
         let args = CommonArgs {
             tui_listen: Some("[::1]:8119".parse().unwrap()),
             ..default_args()
         };
 
-        assert!(
-            args.validate_dashboard_listen("127.0.0.1", Port::try_new(8119).unwrap())
-                .is_err()
-        );
+        args.validate_dashboard_listen("127.0.0.1", Port::try_new(8119).unwrap())
+            .unwrap();
     }
 
     #[test]

--- a/src/args.rs
+++ b/src/args.rs
@@ -6,7 +6,7 @@ use crate::config::{BackendSelectionStrategy, Config, RoutingMode};
 use crate::types::{CacheCapacity, ConfigPath, Port, ThreadCount};
 use anyhow::{Result, bail};
 use clap::{Parser, ValueEnum};
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::time::Duration;
 
 /// Parse port from command line argument
@@ -236,14 +236,7 @@ impl CommonArgs {
             return Ok(());
         }
 
-        let Ok(proxy_ip) = proxy_host.parse::<IpAddr>() else {
-            return Ok(());
-        };
-
-        if proxy_ip.is_unspecified()
-            || dashboard_listen.ip().is_unspecified()
-            || proxy_ip == dashboard_listen.ip()
-        {
+        if proxy_listener_conflicts(proxy_host, proxy_port, dashboard_listen) {
             bail!(
                 "--tui-listen {} conflicts with the proxy listener {}:{}; use a different port",
                 dashboard_listen,
@@ -343,6 +336,32 @@ impl CommonArgs {
     pub fn apply_overrides(&self, config: &mut Config) {
         self.apply_overrides_with_env(config, |key| std::env::var(key).ok());
     }
+}
+
+fn proxy_listener_conflicts(
+    proxy_host: &str,
+    proxy_port: Port,
+    dashboard_listen: SocketAddr,
+) -> bool {
+    let dashboard_ip = dashboard_listen.ip();
+    let proxy_target = (proxy_host, proxy_port.get());
+
+    proxy_target
+        .to_socket_addrs()
+        .ok()
+        .map(|addrs| {
+            addrs
+                .map(|addr| addr.ip())
+                .any(|proxy_ip| listener_ips_conflict(proxy_ip, dashboard_ip))
+        })
+        .unwrap_or_else(|| dashboard_ip.is_unspecified())
+}
+
+fn listener_ips_conflict(proxy_ip: IpAddr, dashboard_ip: IpAddr) -> bool {
+    proxy_ip.is_unspecified()
+        || dashboard_ip.is_unspecified()
+        || proxy_ip == dashboard_ip
+        || (proxy_ip.is_loopback() && dashboard_ip.is_loopback())
 }
 
 #[cfg(test)]
@@ -588,6 +607,32 @@ mod tests {
 
         args.validate_dashboard_listen("127.0.0.1", Port::try_new(8119).unwrap())
             .unwrap();
+    }
+
+    #[test]
+    fn test_validate_dashboard_listen_rejects_localhost_alias_collision() {
+        let args = CommonArgs {
+            tui_listen: Some("127.0.0.1:8119".parse().unwrap()),
+            ..default_args()
+        };
+
+        assert!(
+            args.validate_dashboard_listen("localhost", Port::try_new(8119).unwrap())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_validate_dashboard_listen_rejects_loopback_alias_collision() {
+        let args = CommonArgs {
+            tui_listen: Some("[::1]:8119".parse().unwrap()),
+            ..default_args()
+        };
+
+        assert!(
+            args.validate_dashboard_listen("127.0.0.1", Port::try_new(8119).unwrap())
+                .is_err()
+        );
     }
 
     #[test]

--- a/src/args.rs
+++ b/src/args.rs
@@ -223,6 +223,10 @@ impl CommonArgs {
             bail!("--tui-attach requires --ui tui");
         }
 
+        if self.tui_listen.is_some() && ui_mode != UiMode::Headless {
+            bail!("--tui-listen requires headless mode; use --ui headless");
+        }
+
         if self.tui_attach.is_some() && self.tui_listen.is_some() {
             bail!("--tui-attach cannot be combined with --tui-listen");
         }
@@ -608,6 +612,17 @@ mod tests {
         let args = CommonArgs {
             ui: UiMode::Tui,
             tui_attach: Some("10.0.0.5:8119".parse().unwrap()),
+            ..default_args()
+        };
+
+        assert!(args.validate_runtime_mode().is_err());
+    }
+
+    #[test]
+    fn test_validate_runtime_mode_rejects_tui_listen_with_local_tui() {
+        let args = CommonArgs {
+            ui: UiMode::Tui,
+            tui_listen: Some("127.0.0.1:8119".parse().unwrap()),
             ..default_args()
         };
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -74,7 +74,7 @@ pub struct CommonArgs {
     )]
     pub tui_listen: Option<SocketAddr>,
 
-    /// Connect the read-only TUI client to a dashboard websocket at HOST:PORT.
+    /// Connect the read-only TUI client to a loopback dashboard websocket at HOST:PORT.
     #[arg(
         long = "tui-attach",
         value_name = "HOST:PORT",
@@ -221,6 +221,15 @@ impl CommonArgs {
 
         if self.tui_attach.is_some() && self.tui_listen.is_some() {
             bail!("--tui-attach cannot be combined with --tui-listen");
+        }
+
+        if let Some(attach_addr) = self.tui_attach
+            && !attach_addr.ip().is_loopback()
+        {
+            bail!(
+                "--tui-attach {} must connect to a loopback address; use 127.0.0.1 or ::1",
+                attach_addr
+            );
         }
 
         Ok(())
@@ -586,6 +595,17 @@ mod tests {
             ui: UiMode::Tui,
             tui_attach: Some("127.0.0.1:8119".parse().unwrap()),
             tui_listen: Some("127.0.0.1:8120".parse().unwrap()),
+            ..default_args()
+        };
+
+        assert!(args.validate_runtime_mode().is_err());
+    }
+
+    #[test]
+    fn test_validate_runtime_mode_rejects_non_loopback_attach() {
+        let args = CommonArgs {
+            ui: UiMode::Tui,
+            tui_attach: Some("10.0.0.5:8119".parse().unwrap()),
             ..default_args()
         };
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -65,7 +65,7 @@ pub struct CommonArgs {
     #[arg(long, hide = true, help_heading = "General")]
     pub no_tui: bool,
 
-    /// Bind the dashboard websocket publisher to a free HOST:PORT distinct from the proxy listener.
+    /// Bind the dashboard websocket publisher to a free loopback HOST:PORT distinct from the proxy listener.
     #[arg(
         long = "tui-listen",
         value_name = "HOST:PORT",
@@ -231,6 +231,13 @@ impl CommonArgs {
         let Some(dashboard_listen) = self.tui_listen else {
             return Ok(());
         };
+
+        if !dashboard_listen.ip().is_loopback() {
+            bail!(
+                "--tui-listen {} must bind to a loopback address; use 127.0.0.1 or ::1",
+                dashboard_listen
+            );
+        }
 
         if dashboard_listen.port() != proxy_port.get() {
             return Ok(());
@@ -631,6 +638,19 @@ mod tests {
 
         assert!(
             args.validate_dashboard_listen("127.0.0.1", Port::try_new(8119).unwrap())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_validate_dashboard_listen_rejects_non_loopback_bind() {
+        let args = CommonArgs {
+            tui_listen: Some("0.0.0.0:8119".parse().unwrap()),
+            ..default_args()
+        };
+
+        assert!(
+            args.validate_dashboard_listen("127.0.0.1", Port::try_new(9120).unwrap())
                 .is_err()
         );
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -65,19 +65,19 @@ pub struct CommonArgs {
     #[arg(long, hide = true, help_heading = "General")]
     pub no_tui: bool,
 
-    /// Bind the dashboard websocket publisher to a free loopback HOST:PORT distinct from the proxy listener.
+    /// Bind the dashboard websocket publisher to a free loopback IP:PORT distinct from the proxy listener.
     #[arg(
         long = "tui-listen",
-        value_name = "HOST:PORT",
+        value_name = "IP:PORT",
         env = "NNTP_PROXY_TUI_LISTEN",
         help_heading = "General"
     )]
     pub tui_listen: Option<SocketAddr>,
 
-    /// Connect the read-only TUI client to a loopback dashboard websocket at HOST:PORT.
+    /// Connect the read-only TUI client to a loopback dashboard websocket at IP:PORT.
     #[arg(
         long = "tui-attach",
-        value_name = "HOST:PORT",
+        value_name = "IP:PORT",
         env = "NNTP_PROXY_TUI_ATTACH",
         help_heading = "General"
     )]
@@ -682,8 +682,8 @@ mod tests {
         command.write_long_help(&mut help).unwrap();
         let help = String::from_utf8(help).unwrap();
 
-        assert!(help.contains("--tui-listen <HOST:PORT>"));
-        assert!(help.contains("--tui-attach <HOST:PORT>"));
+        assert!(help.contains("--tui-listen <IP:PORT>"));
+        assert!(help.contains("--tui-attach <IP:PORT>"));
     }
 
     // Helper to create default args for testing

--- a/src/args.rs
+++ b/src/args.rs
@@ -54,6 +54,7 @@ pub struct CommonArgs {
     #[arg(
         long,
         value_enum,
+        value_name = "MODE",
         default_value_t = UiMode::DEFAULT,
         env = "NNTP_PROXY_UI",
         help_heading = "General"
@@ -64,17 +65,19 @@ pub struct CommonArgs {
     #[arg(long, hide = true, help_heading = "General")]
     pub no_tui: bool,
 
-    /// Bind address for the dashboard websocket publisher in headless mode.
+    /// Bind the dashboard websocket publisher to HOST:PORT in headless mode.
     #[arg(
         long = "tui-listen",
+        value_name = "HOST:PORT",
         env = "NNTP_PROXY_TUI_LISTEN",
         help_heading = "General"
     )]
     pub tui_listen: Option<SocketAddr>,
 
-    /// Connect the TUI client to a running dashboard websocket publisher.
+    /// Connect the read-only TUI client to a dashboard websocket at HOST:PORT.
     #[arg(
         long = "tui-attach",
+        value_name = "HOST:PORT",
         env = "NNTP_PROXY_TUI_ATTACH",
         help_heading = "General"
     )]
@@ -316,6 +319,7 @@ impl CommonArgs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
 
     #[test]
     fn test_common_args_defaults() {
@@ -531,6 +535,21 @@ mod tests {
         };
 
         assert!(args.validate_runtime_mode().is_err());
+    }
+
+    #[test]
+    fn test_help_shows_tui_socket_format() {
+        let mut command = CommonArgs::command();
+        let mut help = Vec::new();
+        command.write_long_help(&mut help).unwrap();
+        let help = String::from_utf8(help).unwrap();
+
+        assert!(help.contains("--tui-listen <HOST:PORT>"));
+        assert!(help.contains("--tui-attach <HOST:PORT>"));
+        assert!(help.contains("Bind the dashboard websocket publisher to HOST:PORT"));
+        assert!(
+            help.contains("Connect the read-only TUI client to a dashboard websocket at HOST:PORT")
+        );
     }
 
     // Helper to create default args for testing

--- a/src/args.rs
+++ b/src/args.rs
@@ -6,7 +6,7 @@ use crate::config::{BackendSelectionStrategy, Config, RoutingMode};
 use crate::types::{CacheCapacity, ConfigPath, Port, ThreadCount};
 use anyhow::{Result, bail};
 use clap::{Parser, ValueEnum};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
 /// Parse port from command line argument
@@ -65,7 +65,7 @@ pub struct CommonArgs {
     #[arg(long, hide = true, help_heading = "General")]
     pub no_tui: bool,
 
-    /// Bind the dashboard websocket publisher to HOST:PORT in headless mode.
+    /// Bind the dashboard websocket publisher to a free HOST:PORT distinct from the proxy listener.
     #[arg(
         long = "tui-listen",
         value_name = "HOST:PORT",
@@ -221,6 +221,35 @@ impl CommonArgs {
 
         if self.tui_attach.is_some() && self.tui_listen.is_some() {
             bail!("--tui-attach cannot be combined with --tui-listen");
+        }
+
+        Ok(())
+    }
+
+    /// Validate that the dashboard websocket listener does not reuse the proxy listen socket.
+    pub fn validate_dashboard_listen(&self, proxy_host: &str, proxy_port: Port) -> Result<()> {
+        let Some(dashboard_listen) = self.tui_listen else {
+            return Ok(());
+        };
+
+        if dashboard_listen.port() != proxy_port.get() {
+            return Ok(());
+        }
+
+        let Ok(proxy_ip) = proxy_host.parse::<IpAddr>() else {
+            return Ok(());
+        };
+
+        if proxy_ip.is_unspecified()
+            || dashboard_listen.ip().is_unspecified()
+            || proxy_ip == dashboard_listen.ip()
+        {
+            bail!(
+                "--tui-listen {} conflicts with the proxy listener {}:{}; use a different port",
+                dashboard_listen,
+                proxy_host,
+                proxy_port.get()
+            );
         }
 
         Ok(())
@@ -538,6 +567,30 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_dashboard_listen_rejects_same_socket() {
+        let args = CommonArgs {
+            tui_listen: Some("127.0.0.1:8119".parse().unwrap()),
+            ..default_args()
+        };
+
+        assert!(
+            args.validate_dashboard_listen("127.0.0.1", Port::try_new(8119).unwrap())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_validate_dashboard_listen_allows_distinct_socket() {
+        let args = CommonArgs {
+            tui_listen: Some("127.0.0.1:8120".parse().unwrap()),
+            ..default_args()
+        };
+
+        args.validate_dashboard_listen("127.0.0.1", Port::try_new(8119).unwrap())
+            .unwrap();
+    }
+
+    #[test]
     fn test_help_shows_tui_socket_format() {
         let mut command = CommonArgs::command();
         let mut help = Vec::new();
@@ -546,10 +599,6 @@ mod tests {
 
         assert!(help.contains("--tui-listen <HOST:PORT>"));
         assert!(help.contains("--tui-attach <HOST:PORT>"));
-        assert!(help.contains("Bind the dashboard websocket publisher to HOST:PORT"));
-        assert!(
-            help.contains("Connect the read-only TUI client to a dashboard websocket at HOST:PORT")
-        );
     }
 
     // Helper to create default args for testing

--- a/src/args.rs
+++ b/src/args.rs
@@ -4,7 +4,9 @@
 
 use crate::config::{BackendSelectionStrategy, Config, RoutingMode};
 use crate::types::{CacheCapacity, ConfigPath, Port, ThreadCount};
+use anyhow::{Result, bail};
 use clap::{Parser, ValueEnum};
+use std::net::SocketAddr;
 use std::time::Duration;
 
 /// Parse port from command line argument
@@ -61,6 +63,22 @@ pub struct CommonArgs {
     /// Disable the terminal dashboard and run in headless mode.
     #[arg(long, hide = true, help_heading = "General")]
     pub no_tui: bool,
+
+    /// Bind address for the dashboard websocket publisher in headless mode.
+    #[arg(
+        long = "tui-listen",
+        env = "NNTP_PROXY_TUI_LISTEN",
+        help_heading = "General"
+    )]
+    pub tui_listen: Option<SocketAddr>,
+
+    /// Connect the TUI client to a running dashboard websocket publisher.
+    #[arg(
+        long = "tui-attach",
+        env = "NNTP_PROXY_TUI_ATTACH",
+        help_heading = "General"
+    )]
+    pub tui_attach: Option<SocketAddr>,
 
     /// Port to listen on (overrides config file)
     #[arg(
@@ -188,6 +206,21 @@ impl CommonArgs {
         } else {
             self.ui
         }
+    }
+
+    /// Validate dashboard-related flag combinations.
+    pub fn validate_runtime_mode(&self) -> Result<()> {
+        let ui_mode = self.effective_ui_mode();
+
+        if self.tui_attach.is_some() && ui_mode != UiMode::Tui {
+            bail!("--tui-attach requires --ui tui");
+        }
+
+        if self.tui_attach.is_some() && self.tui_listen.is_some() {
+            bail!("--tui-attach cannot be combined with --tui-listen");
+        }
+
+        Ok(())
     }
 
     fn legacy_env_var<E>(env_get: &E, keys: &[&str]) -> Option<String>
@@ -467,12 +500,47 @@ mod tests {
         assert_eq!(legacy_args.effective_ui_mode(), UiMode::Headless);
     }
 
+    #[test]
+    fn test_validate_runtime_mode_accepts_attach_client() {
+        let args = CommonArgs {
+            ui: UiMode::Tui,
+            tui_attach: Some("127.0.0.1:8119".parse().unwrap()),
+            ..default_args()
+        };
+
+        args.validate_runtime_mode().unwrap();
+    }
+
+    #[test]
+    fn test_validate_runtime_mode_rejects_attach_without_tui() {
+        let args = CommonArgs {
+            tui_attach: Some("127.0.0.1:8119".parse().unwrap()),
+            ..default_args()
+        };
+
+        assert!(args.validate_runtime_mode().is_err());
+    }
+
+    #[test]
+    fn test_validate_runtime_mode_rejects_attach_and_listen() {
+        let args = CommonArgs {
+            ui: UiMode::Tui,
+            tui_attach: Some("127.0.0.1:8119".parse().unwrap()),
+            tui_listen: Some("127.0.0.1:8120".parse().unwrap()),
+            ..default_args()
+        };
+
+        assert!(args.validate_runtime_mode().is_err());
+    }
+
     // Helper to create default args for testing
     fn default_args() -> CommonArgs {
         CommonArgs {
             config: ConfigPath::new("config.toml").unwrap(),
             ui: UiMode::Headless,
             no_tui: false,
+            tui_listen: None,
+            tui_attach: None,
             port: None,
             host: None,
             routing_mode: None,

--- a/src/args.rs
+++ b/src/args.rs
@@ -211,7 +211,11 @@ impl CommonArgs {
         }
     }
 
-    /// Validate dashboard-related flag combinations.
+    /// Validate combinations of UI-related runtime flags.
+    ///
+    /// # Errors
+    /// Returns an error when attach/listen flags are combined illegally or when
+    /// attached mode targets a non-loopback address.
     pub fn validate_runtime_mode(&self) -> Result<()> {
         let ui_mode = self.effective_ui_mode();
 
@@ -227,8 +231,7 @@ impl CommonArgs {
             && !attach_addr.ip().is_loopback()
         {
             bail!(
-                "--tui-attach {} must connect to a loopback address; use 127.0.0.1 or ::1",
-                attach_addr
+                "--tui-attach {attach_addr} must connect to a loopback address; use 127.0.0.1 or ::1"
             );
         }
 
@@ -236,6 +239,10 @@ impl CommonArgs {
     }
 
     /// Validate that the dashboard websocket listener does not reuse the proxy listen socket.
+    ///
+    /// # Errors
+    /// Returns an error when the dashboard listener is non-loopback or would
+    /// collide with the proxy listener on the same socket.
     pub fn validate_dashboard_listen(&self, proxy_host: &str, proxy_port: Port) -> Result<()> {
         let Some(dashboard_listen) = self.tui_listen else {
             return Ok(());
@@ -243,8 +250,7 @@ impl CommonArgs {
 
         if !dashboard_listen.ip().is_loopback() {
             bail!(
-                "--tui-listen {} must bind to a loopback address; use 127.0.0.1 or ::1",
-                dashboard_listen
+                "--tui-listen {dashboard_listen} must bind to a loopback address; use 127.0.0.1 or ::1"
             );
         }
 
@@ -362,15 +368,14 @@ fn proxy_listener_conflicts(
     let dashboard_ip = dashboard_listen.ip();
     let proxy_target = (proxy_host, proxy_port.get());
 
-    proxy_target
-        .to_socket_addrs()
-        .ok()
-        .map(|addrs| {
+    proxy_target.to_socket_addrs().ok().map_or_else(
+        || dashboard_ip.is_unspecified(),
+        |addrs| {
             addrs
                 .map(|addr| addr.ip())
                 .any(|proxy_ip| listener_ips_conflict(proxy_ip, dashboard_ip))
-        })
-        .unwrap_or_else(|| dashboard_ip.is_unspecified())
+        },
+    )
 }
 
 fn listener_ips_conflict(proxy_ip: IpAddr, dashboard_ip: IpAddr) -> bool {

--- a/src/bin/nntp-proxy.rs
+++ b/src/bin/nntp-proxy.rs
@@ -28,6 +28,8 @@ fn main() -> Result<()> {
     if ui_mode == UiMode::Tui
         && let Some(connect_addr) = args.common.tui_attach
     {
+        let file_level = nntp_proxy::Config::default().proxy.log_file_level;
+        let _ = nntp_proxy::logging::init_logging(UiMode::Tui, &file_level);
         let threads = args.common.threads;
         return RuntimeConfig::from_args(threads)
             .build_runtime()?

--- a/src/bin/nntp-proxy.rs
+++ b/src/bin/nntp-proxy.rs
@@ -24,12 +24,14 @@ fn main() -> Result<()> {
     let args = Args::parse();
     args.common.validate_runtime_mode()?;
     let ui_mode = args.common.effective_ui_mode();
+    let capture_headless_tui_buffer =
+        ui_mode == UiMode::Headless && args.common.tui_listen.is_some();
 
     if ui_mode == UiMode::Tui
         && let Some(connect_addr) = args.common.tui_attach
     {
         let file_level = nntp_proxy::Config::default().proxy.log_file_level;
-        let _ = nntp_proxy::logging::init_logging(UiMode::Tui, &file_level);
+        let _ = nntp_proxy::logging::init_logging(UiMode::Tui, &file_level, false);
         let threads = args.common.threads;
         return RuntimeConfig::from_args(threads)
             .build_runtime()?
@@ -41,7 +43,11 @@ fn main() -> Result<()> {
     // Apply CLI argument overrides to config
     args.common.apply_overrides(&mut config);
 
-    let log_buffer = nntp_proxy::logging::init_logging(ui_mode, &config.proxy.log_file_level);
+    let log_buffer = nntp_proxy::logging::init_logging(
+        ui_mode,
+        &config.proxy.log_file_level,
+        capture_headless_tui_buffer,
+    );
 
     let threads = args.common.threads.or(Some(config.proxy.threads));
     RuntimeConfig::from_args(threads)

--- a/src/bin/nntp-proxy.rs
+++ b/src/bin/nntp-proxy.rs
@@ -83,7 +83,7 @@ async fn run_proxy(
     let (tui_handle, tui_shutdown_tx) =
         launch_tui(ui_mode, &proxy, log_buffer.clone(), shutdown_tx.clone())?;
     let (dashboard_handle, dashboard_shutdown_tx) =
-        launch_dashboard_publisher(args.common.tui_listen, &proxy, log_buffer)?;
+        launch_dashboard_publisher(args.common.tui_listen, &proxy, log_buffer).await?;
     let error_tui_shutdown_tx = tui_shutdown_tx.clone();
     let error_dashboard_shutdown_tx = dashboard_shutdown_tx.clone();
     spawn_signal_forwarder(shutdown_tx, tui_shutdown_tx, dashboard_shutdown_tx);
@@ -208,7 +208,7 @@ fn launch_tui(
     Ok((Some(handle), Some(tui_shutdown_tx)))
 }
 
-fn launch_dashboard_publisher(
+async fn launch_dashboard_publisher(
     listen_addr: Option<SocketAddr>,
     proxy: &Arc<NntpProxy>,
     log_buffer: Option<tui::LogBuffer>,
@@ -221,10 +221,11 @@ fn launch_dashboard_publisher(
 
     info!("Building websocket dashboard publisher...");
     let tui_app = build_dashboard_app(proxy, log_buffer);
+    let listener = tui::bind_dashboard_listener(listen_addr).await?;
     let handle = tokio::spawn(async move {
         info!("Initializing websocket dashboard on {}", listen_addr);
         if let Err(e) =
-            tui::run_dashboard_publisher(tui_app, listen_addr, dashboard_shutdown_rx).await
+            tui::run_dashboard_publisher_on_listener(tui_app, listener, dashboard_shutdown_rx).await
         {
             error!("Websocket dashboard error: {}", e);
         }

--- a/src/bin/nntp-proxy.rs
+++ b/src/bin/nntp-proxy.rs
@@ -55,7 +55,7 @@ async fn run_proxy(
     ui_mode: UiMode,
     log_buffer: Option<tui::LogBuffer>,
 ) -> Result<()> {
-    let launch = prepare_proxy_launch(&args, &config)?;
+    let launch = prepare_proxy_launch(&args, &config);
     args.common
         .validate_dashboard_listen(&launch.host, launch.port)?;
 
@@ -83,7 +83,7 @@ async fn run_proxy(
 
     let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>(1);
     let (tui_handle, tui_shutdown_tx) =
-        launch_tui(ui_mode, &proxy, log_buffer.clone(), shutdown_tx.clone())?;
+        launch_tui(ui_mode, &proxy, log_buffer.clone(), shutdown_tx.clone());
     let (dashboard_handle, dashboard_shutdown_tx) =
         launch_dashboard_publisher(args.common.tui_listen, &proxy, log_buffer).await?;
     let error_tui_shutdown_tx = tui_shutdown_tx.clone();
@@ -146,7 +146,8 @@ struct ProxyLaunch {
     metrics_store: Option<MetricsStore>,
 }
 
-fn prepare_proxy_launch(args: &Args, config: &nntp_proxy::config::Config) -> Result<ProxyLaunch> {
+/// Resolve the runtime launch parameters from CLI arguments and config.
+fn prepare_proxy_launch(args: &Args, config: &nntp_proxy::config::Config) -> ProxyLaunch {
     let routing_mode = args
         .common
         .routing_mode
@@ -166,7 +167,7 @@ fn prepare_proxy_launch(args: &Args, config: &nntp_proxy::config::Config) -> Res
         .collect();
     let metrics_store = runtime::load_metrics_from_disk(&stats_path, &server_names);
 
-    Ok(ProxyLaunch {
+    ProxyLaunch {
         routing_mode,
         host,
         port,
@@ -174,17 +175,18 @@ fn prepare_proxy_launch(args: &Args, config: &nntp_proxy::config::Config) -> Res
         availability_path,
         server_names,
         metrics_store,
-    })
+    }
 }
 
+/// Launch the local in-process TUI when `--ui tui` is selected.
 fn launch_tui(
     ui_mode: UiMode,
     proxy: &Arc<NntpProxy>,
     log_buffer: Option<tui::LogBuffer>,
     shutdown_tx: mpsc::Sender<()>,
-) -> Result<(Option<TuiHandle>, Option<mpsc::Sender<()>>)> {
+) -> (Option<TuiHandle>, Option<mpsc::Sender<()>>) {
     if !ui_mode.uses_tui() {
-        return Ok((None, None));
+        return (None, None);
     }
 
     let (tui_shutdown_tx, tui_shutdown_rx) = mpsc::channel::<()>(1);
@@ -205,9 +207,14 @@ fn launch_tui(
         info!("TUI closed");
     });
 
-    Ok((Some(handle), Some(tui_shutdown_tx)))
+    (Some(handle), Some(tui_shutdown_tx))
 }
 
+/// Launch the websocket dashboard publisher when `--tui-listen` is configured.
+///
+/// # Errors
+/// Returns an error if the dashboard listener cannot be bound or the task cannot
+/// be prepared.
 async fn launch_dashboard_publisher(
     listen_addr: Option<SocketAddr>,
     proxy: &Arc<NntpProxy>,
@@ -316,7 +323,7 @@ mod tests {
                 .unwrap(),
         ];
 
-        let launch = prepare_proxy_launch(&args, &config).unwrap();
+        let launch = prepare_proxy_launch(&args, &config);
 
         assert_eq!(launch.routing_mode, nntp_proxy::RoutingMode::Stateful);
         assert_eq!(launch.host, "127.0.0.1");

--- a/src/bin/nntp-proxy.rs
+++ b/src/bin/nntp-proxy.rs
@@ -91,13 +91,11 @@ async fn run_proxy(
     let accept_result =
         runtime::run_accept_loop(proxy.clone(), listener, shutdown_rx, launch.routing_mode).await;
 
-    if accept_result.is_err() {
-        if let Some(tx) = error_tui_shutdown_tx {
-            let _ = tx.send(()).await;
-        }
-        if let Some(tx) = error_dashboard_shutdown_tx {
-            let _ = tx.send(()).await;
-        }
+    if let Some(tx) = error_tui_shutdown_tx {
+        let _ = tx.send(()).await;
+    }
+    if let Some(tx) = error_dashboard_shutdown_tx {
+        let _ = tx.send(()).await;
     }
 
     if let Some(handle) = tui_handle {

--- a/src/bin/nntp-proxy.rs
+++ b/src/bin/nntp-proxy.rs
@@ -3,6 +3,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 use anyhow::Result;
 use clap::Parser;
+use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
@@ -20,12 +21,23 @@ struct Args {
 
 fn main() -> Result<()> {
     let args = Args::parse();
+    args.common.validate_runtime_mode()?;
+    let ui_mode = args.common.effective_ui_mode();
+
+    if ui_mode == UiMode::Tui
+        && let Some(connect_addr) = args.common.tui_attach
+    {
+        let threads = args.common.threads;
+        return RuntimeConfig::from_args(threads)
+            .build_runtime()?
+            .block_on(tui::run_attached_tui(connect_addr));
+    }
+
     let (mut config, _) = runtime::load_and_log_config(args.common.config.as_str())?;
 
     // Apply CLI argument overrides to config
     args.common.apply_overrides(&mut config);
 
-    let ui_mode = args.common.effective_ui_mode();
     let log_buffer = nntp_proxy::logging::init_logging(ui_mode, &config.proxy.log_file_level);
 
     let threads = args.common.threads.or(Some(config.proxy.threads));
@@ -80,20 +92,30 @@ async fn run_proxy(
 
     let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>(1);
     let (tui_handle, tui_shutdown_tx) =
-        launch_tui(ui_mode, &proxy, log_buffer, shutdown_tx.clone())?;
-    let error_shutdown_tx = tui_shutdown_tx.clone();
-    spawn_signal_forwarder(shutdown_tx, tui_shutdown_tx);
+        launch_tui(ui_mode, &proxy, log_buffer.clone(), shutdown_tx.clone())?;
+    let (dashboard_handle, dashboard_shutdown_tx) =
+        launch_dashboard_publisher(args.common.tui_listen, &proxy, log_buffer)?;
+    let error_tui_shutdown_tx = tui_shutdown_tx.clone();
+    let error_dashboard_shutdown_tx = dashboard_shutdown_tx.clone();
+    spawn_signal_forwarder(shutdown_tx, tui_shutdown_tx, dashboard_shutdown_tx);
 
     let accept_result =
         runtime::run_accept_loop(proxy.clone(), listener, shutdown_rx, routing_mode).await;
 
-    if accept_result.is_err()
-        && let Some(tx) = error_shutdown_tx
-    {
-        let _ = tx.send(()).await;
+    if accept_result.is_err() {
+        if let Some(tx) = error_tui_shutdown_tx {
+            let _ = tx.send(()).await;
+        }
+        if let Some(tx) = error_dashboard_shutdown_tx {
+            let _ = tx.send(()).await;
+        }
     }
 
     if let Some(handle) = tui_handle {
+        handle.await?;
+    }
+
+    if let Some(handle) = dashboard_handle {
         handle.await?;
     }
 
@@ -133,26 +155,13 @@ fn launch_tui(
     let (tui_shutdown_tx, tui_shutdown_rx) = mpsc::channel::<()>(1);
 
     info!("Building TUI dashboard...");
-    let mut builder = tui::TuiAppBuilder::new(
-        proxy.metrics().clone(),
-        proxy.router().clone(),
-        Arc::from(proxy.servers()),
-    );
-
-    if let Some(buffer) = log_buffer {
-        builder = builder.with_log_buffer(buffer);
-    }
-
     let cache = proxy.cache();
     info!(
         "Adding cache to TUI: entries={}, size={}",
         cache.entry_count(),
         cache.weighted_size()
     );
-    builder = builder.with_cache(cache.clone());
-    builder = builder.with_buffer_pool(proxy.buffer_pool().clone());
-
-    let tui_app = builder.build();
+    let tui_app = build_dashboard_app(proxy, log_buffer);
     let handle = tokio::spawn(async move {
         info!("Initializing TUI dashboard...");
         if let Err(e) = tui::run_tui(tui_app, shutdown_tx, tui_shutdown_rx).await {
@@ -164,15 +173,62 @@ fn launch_tui(
     Ok((Some(handle), Some(tui_shutdown_tx)))
 }
 
+fn launch_dashboard_publisher(
+    listen_addr: Option<SocketAddr>,
+    proxy: &Arc<NntpProxy>,
+    log_buffer: Option<tui::LogBuffer>,
+) -> Result<(Option<TuiHandle>, Option<mpsc::Sender<()>>)> {
+    let Some(listen_addr) = listen_addr else {
+        return Ok((None, None));
+    };
+
+    let (dashboard_shutdown_tx, dashboard_shutdown_rx) = mpsc::channel::<()>(1);
+
+    info!("Building websocket dashboard publisher...");
+    let tui_app = build_dashboard_app(proxy, log_buffer);
+    let handle = tokio::spawn(async move {
+        info!("Initializing websocket dashboard on {}", listen_addr);
+        if let Err(e) =
+            tui::run_dashboard_publisher(tui_app, listen_addr, dashboard_shutdown_rx).await
+        {
+            error!("Websocket dashboard error: {}", e);
+        }
+        info!("Websocket dashboard closed");
+    });
+
+    Ok((Some(handle), Some(dashboard_shutdown_tx)))
+}
+
+fn build_dashboard_app(proxy: &Arc<NntpProxy>, log_buffer: Option<tui::LogBuffer>) -> tui::TuiApp {
+    let mut builder = tui::TuiAppBuilder::new(
+        proxy.metrics().clone(),
+        proxy.router().clone(),
+        Arc::from(proxy.servers()),
+    );
+
+    if let Some(buffer) = log_buffer {
+        builder = builder.with_log_buffer(buffer);
+    }
+
+    builder
+        .with_cache(proxy.cache().clone())
+        .with_buffer_pool(proxy.buffer_pool().clone())
+        .build()
+}
+
 fn spawn_signal_forwarder(
     shutdown_tx: mpsc::Sender<()>,
     tui_shutdown_tx: Option<mpsc::Sender<()>>,
+    dashboard_shutdown_tx: Option<mpsc::Sender<()>>,
 ) {
     tokio::spawn(async move {
         runtime::shutdown_signal().await;
         info!("Shutdown signal received");
 
         if let Some(tx) = tui_shutdown_tx {
+            let _ = tx.send(()).await;
+        }
+        if let Some(tx) = dashboard_shutdown_tx {
             let _ = tx.send(()).await;
         }
         let _ = shutdown_tx.send(()).await;

--- a/src/bin/nntp-proxy.rs
+++ b/src/bin/nntp-proxy.rs
@@ -4,6 +4,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 use anyhow::Result;
 use clap::Parser;
 use std::net::SocketAddr;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
@@ -52,33 +53,16 @@ async fn run_proxy(
     ui_mode: UiMode,
     log_buffer: Option<tui::LogBuffer>,
 ) -> Result<()> {
-    let routing_mode = args
-        .common
-        .routing_mode
-        .unwrap_or(config.routing.routing_mode);
-    let (host, port) =
-        runtime::resolve_listen_address(args.common.host.as_deref(), args.common.port, &config);
-    args.common.validate_dashboard_listen(&host, port)?;
+    let launch = prepare_proxy_launch(&args, &config)?;
+    args.common
+        .validate_dashboard_listen(&launch.host, launch.port)?;
 
-    let stats_path = runtime::resolve_stats_file_path(
-        args.common.config.as_str(),
-        config.proxy.stats_file.as_ref(),
-    );
-    let availability_path =
-        runtime::resolve_availability_file_path(args.common.config.as_str(), config.cache.as_ref());
-    let server_names: Vec<String> = config
-        .servers
-        .iter()
-        .map(|s| s.name.as_ref().to_string())
-        .collect();
-    let metrics_store = runtime::load_metrics_from_disk(&stats_path, &server_names);
-
-    let proxy = build_proxy(config, routing_mode, metrics_store).await?;
-    if let Some(path) = availability_path.as_ref() {
+    let proxy = build_proxy(config, launch.routing_mode, launch.metrics_store).await?;
+    if let Some(path) = launch.availability_path.as_ref() {
         let _ = runtime::load_availability_from_disk(proxy.cache(), path);
     }
 
-    let listener = runtime::bind_listener(&host, port, routing_mode).await?;
+    let listener = runtime::bind_listener(&launch.host, launch.port, launch.routing_mode).await?;
 
     // Prewarm connections BEFORE accepting clients (must complete first to avoid exceeding limits)
     info!("Prewarming connection pools...");
@@ -87,8 +71,12 @@ async fn run_proxy(
 
     runtime::spawn_stats_flusher(proxy.connection_stats());
     runtime::spawn_cache_stats_logger(&proxy);
-    runtime::spawn_metrics_saver(&proxy, stats_path.clone(), server_names.clone());
-    runtime::spawn_availability_saver(&proxy, availability_path.clone());
+    runtime::spawn_metrics_saver(
+        &proxy,
+        launch.stats_path.clone(),
+        launch.server_names.clone(),
+    );
+    runtime::spawn_availability_saver(&proxy, launch.availability_path.clone());
     runtime::spawn_idle_connection_clearer(&proxy);
 
     let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>(1);
@@ -101,7 +89,7 @@ async fn run_proxy(
     spawn_signal_forwarder(shutdown_tx, tui_shutdown_tx, dashboard_shutdown_tx);
 
     let accept_result =
-        runtime::run_accept_loop(proxy.clone(), listener, shutdown_rx, routing_mode).await;
+        runtime::run_accept_loop(proxy.clone(), listener, shutdown_rx, launch.routing_mode).await;
 
     if accept_result.is_err() {
         if let Some(tx) = error_tui_shutdown_tx {
@@ -120,8 +108,13 @@ async fn run_proxy(
         handle.await?;
     }
 
-    if let Err(e) =
-        runtime::persist_runtime_state(&proxy, stats_path, availability_path, server_names).await
+    if let Err(e) = runtime::persist_runtime_state(
+        &proxy,
+        launch.stats_path,
+        launch.availability_path,
+        launch.server_names,
+    )
+    .await
     {
         warn!("Failed to persist runtime state after shutdown: {}", e);
     }
@@ -142,6 +135,47 @@ async fn build_proxy(
 }
 
 type TuiHandle = tokio::task::JoinHandle<()>;
+
+struct ProxyLaunch {
+    routing_mode: nntp_proxy::RoutingMode,
+    host: String,
+    port: nntp_proxy::types::Port,
+    stats_path: PathBuf,
+    availability_path: Option<PathBuf>,
+    server_names: Vec<String>,
+    metrics_store: Option<MetricsStore>,
+}
+
+fn prepare_proxy_launch(args: &Args, config: &nntp_proxy::config::Config) -> Result<ProxyLaunch> {
+    let routing_mode = args
+        .common
+        .routing_mode
+        .unwrap_or(config.routing.routing_mode);
+    let (host, port) =
+        runtime::resolve_listen_address(args.common.host.as_deref(), args.common.port, config);
+    let stats_path = runtime::resolve_stats_file_path(
+        args.common.config.as_str(),
+        config.proxy.stats_file.as_ref(),
+    );
+    let availability_path =
+        runtime::resolve_availability_file_path(args.common.config.as_str(), config.cache.as_ref());
+    let server_names: Vec<String> = config
+        .servers
+        .iter()
+        .map(|s| s.name.as_ref().to_string())
+        .collect();
+    let metrics_store = runtime::load_metrics_from_disk(&stats_path, &server_names);
+
+    Ok(ProxyLaunch {
+        routing_mode,
+        host,
+        port,
+        stats_path,
+        availability_path,
+        server_names,
+        metrics_store,
+    })
+}
 
 fn launch_tui(
     ui_mode: UiMode,
@@ -234,4 +268,59 @@ fn spawn_signal_forwarder(
         }
         let _ = shutdown_tx.send(()).await;
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use nntp_proxy::config::Config;
+    use nntp_proxy::types::Port;
+    use std::path::PathBuf;
+
+    fn test_common_args() -> CommonArgs {
+        CommonArgs {
+            config: "config.toml".parse().unwrap(),
+            ui: UiMode::Headless,
+            no_tui: false,
+            tui_listen: None,
+            tui_attach: None,
+            port: None,
+            host: None,
+            routing_mode: Some(nntp_proxy::RoutingMode::Stateful),
+            backend_selection: None,
+            article_cache_capacity: None,
+            article_cache_ttl_secs: None,
+            store_article_bodies: None,
+            threads: None,
+            backend_pipelining: None,
+        }
+    }
+
+    #[test]
+    fn prepare_proxy_launch_prefers_cli_routing_mode_and_host_port() {
+        let args = Args {
+            common: CommonArgs {
+                routing_mode: Some(nntp_proxy::RoutingMode::Stateful),
+                host: Some("127.0.0.1".to_string()),
+                port: Some(Port::try_new(9120).unwrap()),
+                ..test_common_args()
+            },
+        };
+        let mut config = Config::default();
+        config.proxy.stats_file = Some(PathBuf::from("proxy-stats.json"));
+        config.servers = vec![
+            nntp_proxy::config::Server::builder("server.example.com", Port::try_new(119).unwrap())
+                .name("Primary")
+                .build()
+                .unwrap(),
+        ];
+
+        let launch = prepare_proxy_launch(&args, &config).unwrap();
+
+        assert_eq!(launch.routing_mode, nntp_proxy::RoutingMode::Stateful);
+        assert_eq!(launch.host, "127.0.0.1");
+        assert_eq!(launch.port.get(), 9120);
+        assert_eq!(launch.server_names, vec!["Primary".to_string()]);
+        assert!(launch.metrics_store.is_none());
+    }
 }

--- a/src/bin/nntp-proxy.rs
+++ b/src/bin/nntp-proxy.rs
@@ -58,6 +58,7 @@ async fn run_proxy(
         .unwrap_or(config.routing.routing_mode);
     let (host, port) =
         runtime::resolve_listen_address(args.common.host.as_deref(), args.common.port, &config);
+    args.common.validate_dashboard_listen(&host, port)?;
 
     let stats_path = runtime::resolve_stats_file_path(
         args.common.config.as_str(),

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -27,13 +27,23 @@ fn leak_guard(guard: WorkerGuard) {
     std::mem::forget(guard);
 }
 
-fn init_headless_subscriber(file_level: &str) {
+fn init_headless_subscriber(file_level: &str) -> crate::tui::LogBuffer {
     let (debug_log, guard) = debug_log_writer();
+    let log_buffer = crate::tui::LogBuffer::new();
+    let log_writer = crate::tui::LogMakeWriter::new(log_buffer.clone());
 
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
                 .with_writer(|| std::io::LineWriter::new(std::io::stdout()))
+                .with_filter(env_filter()),
+        )
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(log_writer)
+                .with_ansi(false)
+                .with_target(false)
+                .compact()
                 .with_filter(env_filter()),
         )
         .with(
@@ -45,6 +55,7 @@ fn init_headless_subscriber(file_level: &str) {
         .init();
 
     leak_guard(guard);
+    log_buffer
 }
 
 fn init_tui_subscriber(file_level: &str) -> crate::tui::LogBuffer {
@@ -87,10 +98,7 @@ pub fn init_dual_logging(file_level: &str) {
 #[must_use]
 pub fn init_logging(ui_mode: UiMode, file_level: &str) -> Option<crate::tui::LogBuffer> {
     match ui_mode {
-        UiMode::Headless => {
-            init_headless_subscriber(file_level);
-            None
-        }
+        UiMode::Headless => Some(init_headless_subscriber(file_level)),
         UiMode::Tui => Some(init_tui_subscriber(file_level)),
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -27,12 +27,14 @@ fn leak_guard(guard: WorkerGuard) {
     std::mem::forget(guard);
 }
 
-fn init_headless_subscriber(file_level: &str) -> crate::tui::LogBuffer {
+fn init_headless_subscriber(
+    file_level: &str,
+    capture_tui_buffer: bool,
+) -> Option<crate::tui::LogBuffer> {
     let (debug_log, guard) = debug_log_writer();
-    let log_buffer = crate::tui::LogBuffer::new();
-    let log_writer = crate::tui::LogMakeWriter::new(log_buffer.clone());
+    let log_buffer = capture_tui_buffer.then(crate::tui::LogBuffer::new);
 
-    tracing_subscriber::registry()
+    let subscriber = tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
                 .with_writer(|| std::io::LineWriter::new(std::io::stdout()))
@@ -40,19 +42,24 @@ fn init_headless_subscriber(file_level: &str) -> crate::tui::LogBuffer {
         )
         .with(
             tracing_subscriber::fmt::layer()
-                .with_writer(log_writer)
-                .with_ansi(false)
-                .with_target(false)
-                .compact()
-                .with_filter(env_filter()),
-        )
-        .with(
-            tracing_subscriber::fmt::layer()
                 .with_writer(debug_log)
                 .with_ansi(false)
                 .with_filter(file_filter(file_level)),
-        )
-        .init();
+        );
+
+    match log_buffer.clone() {
+        Some(log_buffer) => subscriber
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_writer(crate::tui::LogMakeWriter::new(log_buffer))
+                    .with_ansi(false)
+                    .with_target(false)
+                    .compact()
+                    .with_filter(env_filter()),
+            )
+            .init(),
+        None => subscriber.init(),
+    }
 
     leak_guard(guard);
     log_buffer
@@ -88,7 +95,7 @@ fn init_tui_subscriber(file_level: &str) -> crate::tui::LogBuffer {
 ///
 /// Headless mode logs to line-buffered stdout and `debug.log`.
 pub fn init_dual_logging(file_level: &str) {
-    let _ = init_logging(UiMode::Headless, file_level);
+    let _ = init_logging(UiMode::Headless, file_level, false);
 }
 
 /// Initialize logging for the unified binary.
@@ -96,9 +103,13 @@ pub fn init_dual_logging(file_level: &str) {
 /// Headless mode logs to line-buffered stdout and `debug.log`.
 /// TUI mode logs to the in-memory TUI buffer and `debug.log`.
 #[must_use]
-pub fn init_logging(ui_mode: UiMode, file_level: &str) -> Option<crate::tui::LogBuffer> {
+pub fn init_logging(
+    ui_mode: UiMode,
+    file_level: &str,
+    capture_headless_tui_buffer: bool,
+) -> Option<crate::tui::LogBuffer> {
     match ui_mode {
-        UiMode::Headless => Some(init_headless_subscriber(file_level)),
+        UiMode::Headless => init_headless_subscriber(file_level, capture_headless_tui_buffer),
         UiMode::Tui => Some(init_tui_subscriber(file_level)),
     }
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -30,7 +30,7 @@ mod user_stats;
 pub use backend_stats::BackendStats;
 pub use collector::MetricsCollector;
 pub use connection_stats::ConnectionStatsAggregator;
-pub use snapshot::MetricsSnapshot;
+pub use snapshot::{DiskCacheStats, MetricsSnapshot};
 pub use store::{BackendStore, MetricsStore, UserMetrics};
 pub use types::*;
 pub use user_stats::UserStats;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -6,7 +6,7 @@
 //! - Shutdown signal handling
 
 use crate::types::ThreadCount;
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 /// Runtime configuration
 #[derive(Debug, Clone)]
@@ -214,7 +214,9 @@ pub async fn bind_listener(
     use tracing::info;
 
     let listen_addr = format!("{}:{}", host, port.get());
-    let listener = tokio::net::TcpListener::bind(&listen_addr).await?;
+    let listener = tokio::net::TcpListener::bind(&listen_addr)
+        .await
+        .with_context(|| format!("Failed to bind NNTP proxy listener at {listen_addr}"))?;
 
     info!("NNTP proxy listening on {} ({})", listen_addr, routing_mode);
 
@@ -728,6 +730,7 @@ pub fn spawn_idle_connection_clearer(proxy: &std::sync::Arc<crate::NntpProxy>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::Port;
 
     #[test]
     fn test_runtime_config_from_args_default() {
@@ -827,6 +830,23 @@ mod tests {
         assert!(debug_str.contains("RuntimeConfig"));
         assert!(debug_str.contains("worker_threads"));
         assert!(debug_str.contains("enable_cpu_pinning"));
+    }
+
+    #[tokio::test]
+    async fn test_bind_listener_context_mentions_proxy_listener() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let err = bind_listener(
+            "127.0.0.1",
+            Port::try_new(addr.port()).unwrap(),
+            crate::RoutingMode::PerCommand,
+        )
+        .await
+        .unwrap_err();
+
+        let err = format!("{err:#}");
+        assert!(err.contains("Failed to bind NNTP proxy listener"));
     }
 
     // Builder pattern tests

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -840,7 +840,7 @@ impl ClientSession {
                 Ok(BackendAttemptResult::BackendUnavailable) => {}
                 Err(e @ SessionError::ClientDisconnect(_)) => {
                     debug!(
-                        "Client {} no eligible backends remain for {:?}",
+                        "Client {} disconnected during article retry for {:?}",
                         self.client_addr,
                         request.message_id_value()
                     );

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -103,7 +103,17 @@ impl ClientSession {
         // One pending count for one connection — don't inflate pending by N,
         // as that skews load_ratio and can cause other sessions to over-allocate
         // connections on other backends, hitting provider connection limits.
-        let backend_id = router.route_with_availability(self.client_id, Some(&availability))?;
+        let backend_id = match router.route_with_availability(self.client_id, Some(&availability)) {
+            Ok(backend_id) => backend_id,
+            Err(err) => {
+                debug!(
+                    client = %self.client_addr,
+                    error = %err,
+                    "No eligible backend available for pipelined article batch"
+                );
+                return Err(super::no_backends_available_disconnect());
+            }
+        };
         let guard = CommandGuard::new(router.clone(), backend_id);
 
         let Some(provider) = router.backend_provider(backend_id) else {
@@ -828,8 +838,9 @@ impl ClientSession {
                 Ok(BackendAttemptResult::BackendUnavailable) => {}
                 Err(e @ SessionError::ClientDisconnect(_)) => {
                     debug!(
-                        "Client {} disconnected, stopping retry loop",
-                        self.client_addr
+                        "Client {} no eligible backends remain for {:?}",
+                        self.client_addr,
+                        request.message_id_value()
                     );
                     return Err(e);
                 }

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -111,7 +111,9 @@ impl ClientSession {
                     error = %err,
                     "No eligible backend available for pipelined article batch"
                 );
-                return Err(super::no_backends_available_disconnect());
+                return Err(SessionError::Backend(anyhow::anyhow!(
+                    "no eligible backend available for pipelined article batch"
+                )));
             }
         };
         let guard = CommandGuard::new(router.clone(), backend_id);

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -117,7 +117,7 @@ impl ClientSession {
                         error = %err,
                         "No eligible backend available for article retry"
                     );
-                    return Err(super::no_backends_available_disconnect());
+                    return Ok(BackendAttemptResult::BackendUnavailable);
                 }
             };
         let guard = CommandGuard::new(router.clone(), backend_id);

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -109,7 +109,17 @@ impl ClientSession {
         state: &mut ArticleAttemptState<'_>,
     ) -> Result<BackendAttemptResult, SessionError> {
         let backend_id =
-            router.route_with_availability(self.client_id, Some(state.availability))?;
+            match router.route_with_availability(self.client_id, Some(state.availability)) {
+                Ok(backend_id) => backend_id,
+                Err(err) => {
+                    debug!(
+                        client = %self.client_addr,
+                        error = %err,
+                        "No eligible backend available for article retry"
+                    );
+                    return Err(super::no_backends_available_disconnect());
+                }
+            };
         let guard = CommandGuard::new(router.clone(), backend_id);
         let Some(provider) = router.backend_provider(backend_id) else {
             state.availability.record_missing(backend_id);

--- a/src/session/handlers/mod.rs
+++ b/src/session/handlers/mod.rs
@@ -12,6 +12,13 @@
 
 mod article_retry;
 
+fn no_backends_available_disconnect() -> crate::session::SessionError {
+    crate::session::SessionError::ClientDisconnect(std::io::Error::new(
+        std::io::ErrorKind::BrokenPipe,
+        "No backends available for routing",
+    ))
+}
+
 /// Split a single-line pipelined response at its `\n` boundary in-place.
 ///
 /// In a pipelined batch, a single TCP read may contain the single-line response
@@ -44,3 +51,16 @@ mod per_command;
 mod pipeline;
 pub(crate) mod pipeline_worker;
 mod stateful;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_backends_available_disconnect_is_classified_as_client_disconnect() {
+        assert!(matches!(
+            no_backends_available_disconnect(),
+            crate::session::SessionError::ClientDisconnect(_)
+        ));
+    }
+}

--- a/src/session/handlers/mod.rs
+++ b/src/session/handlers/mod.rs
@@ -12,13 +12,6 @@
 
 mod article_retry;
 
-fn no_backends_available_disconnect() -> crate::session::SessionError {
-    crate::session::SessionError::ClientDisconnect(std::io::Error::new(
-        std::io::ErrorKind::BrokenPipe,
-        "No backends available for routing",
-    ))
-}
-
 /// Split a single-line pipelined response at its `\n` boundary in-place.
 ///
 /// In a pipelined batch, a single TCP read may contain the single-line response
@@ -51,16 +44,3 @@ mod per_command;
 mod pipeline;
 pub(crate) mod pipeline_worker;
 mod stateful;
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn no_backends_available_disconnect_is_classified_as_client_disconnect() {
-        assert!(matches!(
-            no_backends_available_disconnect(),
-            crate::session::SessionError::ClientDisconnect(_)
-        ));
-    }
-}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -20,6 +20,7 @@ pub enum ViewMode {
 }
 
 /// Historical throughput data point (generic over traffic direction)
+#[allow(clippy::struct_field_names)]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ThroughputPoint {
     /// Bytes sent per second
@@ -512,6 +513,9 @@ impl TuiApp {
 
     /// Get throughput history for a backend
     #[must_use]
+    ///
+    /// # Panics
+    /// Panics if `backend_idx` is out of range for the configured backend history.
     pub fn throughput_history(&self, backend_idx: usize) -> &VecDeque<ThroughputPoint> {
         self.backend_history(backend_idx)
             .expect("backend history index should be valid")
@@ -1190,32 +1194,32 @@ mod tests {
         let snapshot = app.snapshot_state();
 
         assert_eq!(snapshot.client_history.len(), 1);
-        assert_eq!(
+        assert_f64_eq(
             snapshot.client_history[0].sent_per_sec().get(),
-            client_point.sent_per_sec().get()
+            client_point.sent_per_sec().get(),
         );
-        assert_eq!(
+        assert_f64_eq(
             snapshot.client_history[0].received_per_sec().get(),
-            client_point.received_per_sec().get()
+            client_point.received_per_sec().get(),
         );
         assert_eq!(snapshot.backend_views.len(), 1);
         assert_eq!(snapshot.backend_views[0].history.len(), 1);
-        assert_eq!(
+        assert_f64_eq(
             snapshot.backend_views[0].history[0].sent_per_sec().get(),
-            backend_point.sent_per_sec().get()
+            backend_point.sent_per_sec().get(),
         );
-        assert_eq!(
+        assert_f64_eq(
             snapshot.backend_views[0].history[0]
                 .received_per_sec()
                 .get(),
-            backend_point.received_per_sec().get()
+            backend_point.received_per_sec().get(),
         );
-        assert_eq!(
+        assert_f64_eq(
             snapshot.backend_views[0].history[0]
                 .commands_per_sec()
                 .unwrap()
                 .get(),
-            backend_point.commands_per_sec().unwrap().get()
+            backend_point.commands_per_sec().unwrap().get(),
         );
         assert_eq!(
             snapshot.buffer_pool.as_ref().map(|pool| pool.total),

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -513,15 +513,16 @@ impl TuiApp {
     /// Get throughput history for a backend
     #[must_use]
     pub fn throughput_history(&self, backend_idx: usize) -> &VecDeque<ThroughputPoint> {
-        self.backend_history[backend_idx].points()
+        self.backend_history(backend_idx)
+            .expect("backend history index should be valid")
+            .points()
     }
 
     /// Get latest backend throughput for a backend
     #[must_use]
     pub fn latest_backend_throughput(&self, backend_idx: usize) -> Option<&ThroughputPoint> {
-        self.backend_history
-            .get(backend_idx)
-            .and_then(|h| h.latest())
+        self.backend_history(backend_idx)
+            .and_then(ThroughputHistory::latest)
     }
 
     /// Get log buffer for displaying recent log messages
@@ -534,6 +535,11 @@ impl TuiApp {
     #[must_use]
     pub const fn view_mode(&self) -> ViewMode {
         self.view_mode
+    }
+
+    #[must_use]
+    fn backend_history(&self, backend_idx: usize) -> Option<&ThroughputHistory> {
+        self.backend_history.get(backend_idx)
     }
 
     /// Toggle between normal and log fullscreen view

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3,7 +3,7 @@
 use crate::config::Server;
 use crate::metrics::{MetricsCollector, MetricsSnapshot};
 use crate::router::BackendSelector;
-use crate::tui::dashboard::{BackendView, BufferPoolStats, DashboardState};
+use crate::tui::dashboard::{BackendDisplay, BackendView, BufferPoolStats, DashboardState};
 use crate::tui::log_capture::LogBuffer;
 use crate::types::tui::{CommandsPerSecond, HistorySize, Throughput, Timestamp};
 use std::collections::VecDeque;
@@ -620,7 +620,12 @@ impl TuiApp {
         stats: &crate::metrics::BackendStats,
     ) -> BackendView {
         BackendView {
-            server: server.clone(),
+            server: BackendDisplay {
+                host: server.host.clone(),
+                port: server.port,
+                name: server.name.clone(),
+                max_connections: server.max_connections,
+            },
             stats: stats.clone(),
             active_connections: stats.active_connections.get(),
             health_status: stats.health_status,
@@ -1089,7 +1094,14 @@ mod tests {
 
         let metrics = MetricsCollector::new(1);
         let router = Arc::new(BackendSelector::new());
-        let servers = create_test_servers(1);
+        let servers = Arc::from(vec![
+            Server::builder("backend.example.com", Port::try_new(119).unwrap())
+                .name("Backend")
+                .username("backend-user")
+                .password("backend-pass")
+                .build()
+                .unwrap(),
+        ]);
 
         let app = TuiAppBuilder::new(metrics, router, servers)
             .with_log_buffer(log_buffer)
@@ -1103,6 +1115,8 @@ mod tests {
         assert!(!snapshot.show_details);
 
         let json = serde_json::to_string(&snapshot).expect("snapshot should serialize");
+        assert!(!json.contains("backend-user"));
+        assert!(!json.contains("backend-pass"));
         let decoded: DashboardState =
             serde_json::from_str(&json).expect("snapshot should deserialize");
 
@@ -1111,6 +1125,7 @@ mod tests {
         assert_eq!(decoded.view_mode, ViewMode::Normal);
         assert!(!decoded.show_details);
         assert!(decoded.buffer_pool.is_none());
+        assert_eq!(decoded.backend_views[0].server.name.as_str(), "Backend");
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -922,15 +922,19 @@ mod tests {
         use crate::metrics::{BackendStats, CommandCount};
         use crate::types::{BytesReceived, BytesSent};
 
-        let mut prev = BackendStats::default();
-        prev.bytes_sent = BytesSent::new(100);
-        prev.bytes_received = BytesReceived::new(200);
-        prev.total_commands = CommandCount::new(10);
+        let prev = BackendStats {
+            bytes_sent: BytesSent::new(100),
+            bytes_received: BytesReceived::new(200),
+            total_commands: CommandCount::new(10),
+            ..Default::default()
+        };
 
-        let mut next = prev.clone();
-        next.bytes_sent = BytesSent::new(250);
-        next.bytes_received = BytesReceived::new(500);
-        next.total_commands = CommandCount::new(40);
+        let next = BackendStats {
+            bytes_sent: BytesSent::new(250),
+            bytes_received: BytesReceived::new(500),
+            total_commands: CommandCount::new(40),
+            ..prev.clone()
+        };
 
         let point = TuiApp::build_backend_throughput_point(Timestamp::now(), 0.5, &next, &prev);
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -576,6 +576,12 @@ impl TuiApp {
     /// Build a serializable snapshot of the current dashboard state.
     #[must_use]
     pub fn snapshot_state(&self) -> DashboardState {
+        self.snapshot_state_with_log_limit(None)
+    }
+
+    /// Build a serializable snapshot of the current dashboard state with a bounded log tail.
+    #[must_use]
+    pub fn snapshot_state_with_log_limit(&self, log_limit: Option<usize>) -> DashboardState {
         let buffer_pool = self.buffer_pool.as_ref().map(Self::snapshot_buffer_pool);
 
         DashboardState {
@@ -585,8 +591,15 @@ impl TuiApp {
             system_stats: self.system_stats.clone(),
             view_mode: self.view_mode,
             show_details: self.show_details,
-            log_lines: self.log_buffer.all_lines(),
+            log_lines: self.snapshot_log_lines(log_limit),
             buffer_pool,
+        }
+    }
+
+    fn snapshot_log_lines(&self, log_limit: Option<usize>) -> Vec<String> {
+        match log_limit {
+            Some(limit) => self.log_buffer.recent_lines(limit),
+            None => self.log_buffer.all_lines(),
         }
     }
 
@@ -1098,6 +1111,33 @@ mod tests {
         assert_eq!(decoded.view_mode, ViewMode::Normal);
         assert!(!decoded.show_details);
         assert!(decoded.buffer_pool.is_none());
+    }
+
+    #[test]
+    fn test_snapshot_state_with_log_limit_keeps_recent_tail() {
+        use crate::tui::log_capture::LogBuffer;
+
+        let log_buffer = LogBuffer::new();
+        for i in 0..5 {
+            log_buffer.push(format!("Dashboard log line {i}"));
+        }
+
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+
+        let app = TuiAppBuilder::new(metrics, router, servers)
+            .with_log_buffer(log_buffer)
+            .build();
+
+        let snapshot = app.snapshot_state_with_log_limit(Some(2));
+        assert_eq!(
+            snapshot.log_lines,
+            vec![
+                "Dashboard log line 3".to_string(),
+                "Dashboard log line 4".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3,13 +3,14 @@
 use crate::config::Server;
 use crate::metrics::{MetricsCollector, MetricsSnapshot};
 use crate::router::BackendSelector;
+use crate::tui::dashboard::{BackendView, BufferPoolStats, DashboardState};
 use crate::tui::log_capture::LogBuffer;
 use crate::types::tui::{CommandsPerSecond, HistorySize, Throughput, Timestamp};
 use std::collections::VecDeque;
 use std::sync::Arc;
 
 /// TUI view mode - controls what is displayed
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub enum ViewMode {
     /// Normal view - shows all panels
     #[default]
@@ -19,10 +20,8 @@ pub enum ViewMode {
 }
 
 /// Historical throughput data point (generic over traffic direction)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ThroughputPoint {
-    /// Timestamp of this measurement
-    timestamp: Timestamp,
     /// Bytes sent per second
     sent_per_sec: Throughput,
     /// Bytes received per second
@@ -35,13 +34,12 @@ impl ThroughputPoint {
     /// Create a new backend throughput point
     #[must_use]
     pub const fn new_backend(
-        timestamp: Timestamp,
+        _timestamp: Timestamp,
         sent_per_sec: Throughput,
         received_per_sec: Throughput,
         commands_per_sec: CommandsPerSecond,
     ) -> Self {
         Self {
-            timestamp,
             sent_per_sec,
             received_per_sec,
             commands_per_sec: Some(commands_per_sec),
@@ -51,23 +49,15 @@ impl ThroughputPoint {
     /// Create a new client throughput point
     #[must_use]
     pub const fn new_client(
-        timestamp: Timestamp,
+        _timestamp: Timestamp,
         sent_per_sec: Throughput,
         received_per_sec: Throughput,
     ) -> Self {
         Self {
-            timestamp,
             sent_per_sec,
             received_per_sec,
             commands_per_sec: None,
         }
-    }
-
-    /// Get timestamp
-    #[must_use]
-    #[inline]
-    pub const fn timestamp(&self) -> Timestamp {
-        self.timestamp
     }
 
     /// Get sent bytes per second
@@ -326,6 +316,29 @@ impl TuiApp {
         }
     }
 
+    #[must_use]
+    fn build_backend_throughput_point(
+        now: Timestamp,
+        time_delta: f64,
+        new_stats: &crate::metrics::BackendStats,
+        prev_stats: &crate::metrics::BackendStats,
+    ) -> ThroughputPoint {
+        let sent_delta = new_stats.bytes_sent.saturating_sub(prev_stats.bytes_sent);
+        let recv_delta = new_stats
+            .bytes_received
+            .saturating_sub(prev_stats.bytes_received);
+        let cmd_delta = new_stats
+            .total_commands
+            .saturating_sub(prev_stats.total_commands);
+
+        ThroughputPoint::new_backend(
+            now,
+            Self::calculate_rate(sent_delta.into(), time_delta),
+            Self::calculate_rate(recv_delta.into(), time_delta),
+            Self::calculate_command_rate(cmd_delta.get(), time_delta),
+        )
+    }
+
     /// Calculate per-user rates from deltas
     #[inline]
     fn calculate_user_rates(
@@ -400,28 +413,19 @@ impl TuiApp {
             let client_point = ThroughputPoint::new_client(now, client_sent_rate, client_recv_rate);
             self.client_history.push(client_point);
 
-            // Calculate per-backend throughput
-            for (i, (new_stats, prev_stats)) in new_snapshot
-                .backend_stats
-                .iter()
-                .zip(prev.backend_stats.iter())
-                .enumerate()
-            {
-                let sent_delta = new_stats.bytes_sent.saturating_sub(prev_stats.bytes_sent);
-                let recv_delta = new_stats
-                    .bytes_received
-                    .saturating_sub(prev_stats.bytes_received);
-                let cmd_delta = new_stats
-                    .total_commands
-                    .saturating_sub(prev_stats.total_commands);
-
-                let sent_rate = Self::calculate_rate(sent_delta.into(), time_delta);
-                let recv_rate = Self::calculate_rate(recv_delta.into(), time_delta);
-                let cmd_rate = Self::calculate_command_rate(cmd_delta.get(), time_delta);
-
-                let point = ThroughputPoint::new_backend(now, sent_rate, recv_rate, cmd_rate);
-                self.backend_history[i].push(point);
-            }
+            self.backend_history
+                .iter_mut()
+                .zip(
+                    new_snapshot
+                        .backend_stats
+                        .iter()
+                        .zip(prev.backend_stats.iter()),
+                )
+                .for_each(|(history, (new_stats, prev_stats))| {
+                    history.push(Self::build_backend_throughput_point(
+                        now, time_delta, new_stats, prev_stats,
+                    ));
+                });
 
             // Enrich user stats with calculated rates
             let user_stats = new_snapshot
@@ -561,6 +565,62 @@ impl TuiApp {
     #[must_use]
     pub const fn buffer_pool(&self) -> Option<&crate::pool::BufferPool> {
         self.buffer_pool.as_ref()
+    }
+
+    /// Build a serializable snapshot of the current dashboard state.
+    #[must_use]
+    pub fn snapshot_state(&self) -> DashboardState {
+        let backend_views = self
+            .snapshot
+            .backend_stats
+            .iter()
+            .zip(self.servers.iter())
+            .enumerate()
+            .map(|(i, (stats, server))| {
+                let pending_count = self.backend_pending_count(i);
+                let load_ratio = self.backend_load_ratio(i);
+                let stateful_count = self.backend_stateful_count(i);
+                let traffic_share = self.backend_traffic_share(i);
+                let history = self
+                    .backend_history
+                    .get(i)
+                    .map_or_else(Vec::new, |history| {
+                        history.points().iter().cloned().collect()
+                    });
+
+                BackendView {
+                    server: server.clone(),
+                    stats: stats.clone(),
+                    active_connections: stats.active_connections.get(),
+                    health_status: stats.health_status,
+                    pending_count,
+                    load_ratio,
+                    stateful_count,
+                    traffic_share,
+                    history,
+                }
+            })
+            .collect();
+
+        let buffer_pool = self.buffer_pool.as_ref().map(|pool| {
+            let (available, in_use, total) = pool.stats();
+            BufferPoolStats {
+                available,
+                in_use,
+                total,
+            }
+        });
+
+        DashboardState {
+            snapshot: self.snapshot.as_ref().clone(),
+            backend_views,
+            client_history: self.client_history.points().iter().cloned().collect(),
+            system_stats: self.system_stats.clone(),
+            view_mode: self.view_mode,
+            show_details: self.show_details,
+            log_lines: self.log_buffer.all_lines(),
+            buffer_pool,
+        }
     }
 }
 
@@ -847,6 +907,28 @@ mod tests {
     }
 
     #[test]
+    fn test_build_backend_throughput_point() {
+        use crate::metrics::{BackendStats, CommandCount};
+        use crate::types::{BytesReceived, BytesSent};
+
+        let mut prev = BackendStats::default();
+        prev.bytes_sent = BytesSent::new(100);
+        prev.bytes_received = BytesReceived::new(200);
+        prev.total_commands = CommandCount::new(10);
+
+        let mut next = prev.clone();
+        next.bytes_sent = BytesSent::new(250);
+        next.bytes_received = BytesReceived::new(500);
+        next.total_commands = CommandCount::new(40);
+
+        let point = TuiApp::build_backend_throughput_point(Timestamp::now(), 0.5, &next, &prev);
+
+        assert_f64_eq(point.sent_per_sec().get(), 300.0);
+        assert_f64_eq(point.received_per_sec().get(), 600.0);
+        assert_f64_eq(point.commands_per_sec().unwrap().get(), 60.0);
+    }
+
+    #[test]
     fn test_with_log_buffer() {
         use crate::tui::log_capture::LogBuffer;
 
@@ -968,5 +1050,38 @@ mod tests {
             .build();
 
         assert_eq!(app.backend_history.len(), 3);
+    }
+
+    #[test]
+    fn test_snapshot_state_serialization_round_trip() {
+        use crate::tui::log_capture::LogBuffer;
+
+        let log_buffer = LogBuffer::new();
+        log_buffer.push("Dashboard log line".to_string());
+
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+
+        let app = TuiAppBuilder::new(metrics, router, servers)
+            .with_log_buffer(log_buffer)
+            .build();
+
+        let snapshot = app.snapshot_state();
+        assert_eq!(snapshot.backend_views.len(), 1);
+        assert_eq!(snapshot.client_history.len(), 0);
+        assert_eq!(snapshot.log_lines, vec!["Dashboard log line".to_string()]);
+        assert_eq!(snapshot.view_mode, ViewMode::Normal);
+        assert!(!snapshot.show_details);
+
+        let json = serde_json::to_string(&snapshot).expect("snapshot should serialize");
+        let decoded: DashboardState =
+            serde_json::from_str(&json).expect("snapshot should deserialize");
+
+        assert_eq!(decoded.backend_views.len(), 1);
+        assert_eq!(decoded.log_lines, vec!["Dashboard log line".to_string()]);
+        assert_eq!(decoded.view_mode, ViewMode::Normal);
+        assert!(!decoded.show_details);
+        assert!(decoded.buffer_pool.is_none());
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3,7 +3,10 @@
 use crate::config::Server;
 use crate::metrics::{MetricsCollector, MetricsSnapshot};
 use crate::router::BackendSelector;
-use crate::tui::dashboard::{BackendDisplay, BackendView, BufferPoolStats, DashboardState};
+use crate::tui::dashboard::{
+    BackendDisplay, BackendView, BufferPoolStats, DashboardMetrics, DashboardState,
+    DashboardUserStats,
+};
 use crate::tui::log_capture::LogBuffer;
 use crate::types::tui::{CommandsPerSecond, HistorySize, Throughput, Timestamp};
 use std::collections::VecDeque;
@@ -589,8 +592,9 @@ impl TuiApp {
         let buffer_pool = self.buffer_pool.as_ref().map(Self::snapshot_buffer_pool);
 
         DashboardState {
-            snapshot: self.snapshot.as_ref().clone(),
+            metrics: DashboardMetrics::from_snapshot(self.snapshot.as_ref()),
             backend_views: self.snapshot_backend_views(),
+            top_users: self.snapshot_top_users(),
             client_history: self.client_history.points().iter().cloned().collect(),
             system_stats: self.system_stats.clone(),
             view_mode: self.view_mode,
@@ -654,6 +658,18 @@ impl TuiApp {
             in_use,
             total,
         }
+    }
+
+    fn snapshot_top_users(&self) -> Vec<DashboardUserStats> {
+        let mut top_users = self
+            .snapshot
+            .user_stats
+            .iter()
+            .map(DashboardUserStats::from_user_stats)
+            .collect::<Vec<_>>();
+        top_users.sort_by_key(|user| std::cmp::Reverse(user.total_bytes()));
+        top_users.truncate(10);
+        top_users
     }
 }
 
@@ -1113,6 +1129,7 @@ mod tests {
 
         let snapshot = app.snapshot_state();
         assert_eq!(snapshot.backend_views.len(), 1);
+        assert_eq!(snapshot.top_users.len(), 0);
         assert_eq!(snapshot.client_history.len(), 0);
         assert_eq!(snapshot.log_lines, vec!["Dashboard log line".to_string()]);
         assert_eq!(snapshot.view_mode, ViewMode::Normal);
@@ -1125,6 +1142,7 @@ mod tests {
             serde_json::from_str(&json).expect("snapshot should deserialize");
 
         assert_eq!(decoded.backend_views.len(), 1);
+        assert_eq!(decoded.top_users.len(), 0);
         assert_eq!(decoded.log_lines, vec!["Dashboard log line".to_string()]);
         assert_eq!(decoded.view_mode, ViewMode::Normal);
         assert!(!decoded.show_details);
@@ -1204,6 +1222,7 @@ mod tests {
         );
         assert_eq!(snapshot.backend_views.len(), 1);
         assert_eq!(snapshot.backend_views[0].history.len(), 1);
+        assert_eq!(snapshot.top_users.len(), 0);
         assert_f64_eq(
             snapshot.backend_views[0].history[0].sent_per_sec().get(),
             backend_point.sent_per_sec().get(),
@@ -1225,5 +1244,71 @@ mod tests {
             snapshot.buffer_pool.as_ref().map(|pool| pool.total),
             Some(4)
         );
+    }
+
+    #[test]
+    fn test_snapshot_state_serializes_dashboard_metrics_and_top_users() {
+        use crate::metrics::{CommandCount, DiskCacheStats, ErrorCount};
+
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            total_connections: 42,
+            active_connections: 3,
+            stateful_sessions: 2,
+            client_to_backend_bytes: crate::types::ClientToBackendBytes::new(100),
+            backend_to_client_bytes: crate::types::BackendToClientBytes::new(250),
+            uptime: Duration::from_secs(61),
+            user_stats: vec![crate::metrics::UserStats {
+                username: "alice".to_string(),
+                active_connections: 2,
+                total_connections: crate::types::TotalConnections::new(9),
+                bytes_sent: crate::types::BytesSent::new(500),
+                bytes_received: crate::types::BytesReceived::new(700),
+                bytes_sent_per_sec: crate::types::BytesPerSecondRate::new(11),
+                bytes_received_per_sec: crate::types::BytesPerSecondRate::new(13),
+                total_commands: CommandCount::new(17),
+                errors: ErrorCount::new(1),
+            }],
+            cache_entries: 7,
+            cache_size_bytes: 8192,
+            cache_hit_rate: 12.5,
+            disk_cache: Some(DiskCacheStats {
+                disk_hits: 3,
+                disk_hit_rate: 50.0,
+                disk_capacity: 1024,
+                bytes_written: 2048,
+                bytes_read: 1024,
+                write_ios: 4,
+                read_ios: 5,
+            }),
+            pipeline_batches: 6,
+            pipeline_commands: 12,
+            pipeline_requests_queued: 8,
+            pipeline_requests_completed: 7,
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+        let json = serde_json::to_string(&snapshot).expect("snapshot should serialize");
+        let decoded: DashboardState =
+            serde_json::from_str(&json).expect("snapshot should deserialize");
+
+        assert_eq!(decoded.metrics.total_connections, 42);
+        assert_eq!(decoded.metrics.active_connections, 3);
+        assert_eq!(decoded.metrics.stateful_sessions, 2);
+        assert_eq!(decoded.metrics.cache_entries, 7);
+        assert_eq!(decoded.metrics.cache_size_bytes, 8192);
+        assert_eq!(decoded.metrics.cache_hit_rate, 12.5);
+        assert_eq!(decoded.metrics.pipeline_batches, 6);
+        assert_eq!(decoded.metrics.pipeline_commands, 12);
+        assert_eq!(decoded.top_users.len(), 1);
+        assert_eq!(decoded.top_users[0].username, "alice");
+        assert_eq!(decoded.top_users[0].active_connections, 2);
+        assert_eq!(decoded.top_users[0].bytes_sent_per_sec.get(), 11);
+        assert_eq!(decoded.top_users[0].bytes_received_per_sec.get(), 13);
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -576,56 +576,61 @@ impl TuiApp {
     /// Build a serializable snapshot of the current dashboard state.
     #[must_use]
     pub fn snapshot_state(&self) -> DashboardState {
-        let backend_views = self
-            .snapshot
-            .backend_stats
-            .iter()
-            .zip(self.servers.iter())
-            .enumerate()
-            .map(|(i, (stats, server))| {
-                let pending_count = self.backend_pending_count(i);
-                let load_ratio = self.backend_load_ratio(i);
-                let stateful_count = self.backend_stateful_count(i);
-                let traffic_share = self.backend_traffic_share(i);
-                let history = self
-                    .backend_history
-                    .get(i)
-                    .map_or_else(Vec::new, |history| {
-                        history.points().iter().cloned().collect()
-                    });
-
-                BackendView {
-                    server: server.clone(),
-                    stats: stats.clone(),
-                    active_connections: stats.active_connections.get(),
-                    health_status: stats.health_status,
-                    pending_count,
-                    load_ratio,
-                    stateful_count,
-                    traffic_share,
-                    history,
-                }
-            })
-            .collect();
-
-        let buffer_pool = self.buffer_pool.as_ref().map(|pool| {
-            let (available, in_use, total) = pool.stats();
-            BufferPoolStats {
-                available,
-                in_use,
-                total,
-            }
-        });
+        let buffer_pool = self.buffer_pool.as_ref().map(Self::snapshot_buffer_pool);
 
         DashboardState {
             snapshot: self.snapshot.as_ref().clone(),
-            backend_views,
+            backend_views: self.snapshot_backend_views(),
             client_history: self.client_history.points().iter().cloned().collect(),
             system_stats: self.system_stats.clone(),
             view_mode: self.view_mode,
             show_details: self.show_details,
             log_lines: self.log_buffer.all_lines(),
             buffer_pool,
+        }
+    }
+
+    fn snapshot_backend_views(&self) -> Vec<BackendView> {
+        self.snapshot
+            .backend_stats
+            .iter()
+            .zip(self.servers.iter())
+            .enumerate()
+            .map(|(i, (stats, server))| self.snapshot_backend_view(i, server, stats))
+            .collect()
+    }
+
+    fn snapshot_backend_view(
+        &self,
+        backend_idx: usize,
+        server: &Server,
+        stats: &crate::metrics::BackendStats,
+    ) -> BackendView {
+        BackendView {
+            server: server.clone(),
+            stats: stats.clone(),
+            active_connections: stats.active_connections.get(),
+            health_status: stats.health_status,
+            pending_count: self.backend_pending_count(backend_idx),
+            load_ratio: self.backend_load_ratio(backend_idx),
+            stateful_count: self.backend_stateful_count(backend_idx),
+            traffic_share: self.backend_traffic_share(backend_idx),
+            history: Self::snapshot_throughput_history(self.backend_history(backend_idx)),
+        }
+    }
+
+    fn snapshot_throughput_history(history: Option<&ThroughputHistory>) -> Vec<ThroughputPoint> {
+        history
+            .map(|history| history.points().iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    fn snapshot_buffer_pool(pool: &crate::pool::BufferPool) -> BufferPoolStats {
+        let (available, in_use, total) = pool.stats();
+        BufferPoolStats {
+            available,
+            in_use,
+            total,
         }
     }
 }
@@ -1089,5 +1094,73 @@ mod tests {
         assert_eq!(decoded.view_mode, ViewMode::Normal);
         assert!(!decoded.show_details);
         assert!(decoded.buffer_pool.is_none());
+    }
+
+    #[test]
+    fn test_snapshot_state_collects_history_and_buffer_pool() {
+        use crate::pool::BufferPool;
+        use crate::tui::log_capture::LogBuffer;
+        use crate::types::BufferSize;
+
+        let log_buffer = LogBuffer::new();
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let buffer_pool = BufferPool::new(BufferSize::try_new(8192).unwrap(), 4);
+
+        let mut app = TuiAppBuilder::new(metrics, router, servers)
+            .with_log_buffer(log_buffer)
+            .with_buffer_pool(buffer_pool)
+            .build();
+
+        let client_point = ThroughputPoint::new_client(
+            Timestamp::now(),
+            Throughput::new(10.0),
+            Throughput::new(20.0),
+        );
+        let backend_point = ThroughputPoint::new_backend(
+            Timestamp::now(),
+            Throughput::new(30.0),
+            Throughput::new(40.0),
+            CommandsPerSecond::new(5.0),
+        );
+
+        app.client_history.push(client_point.clone());
+        app.backend_history[0].push(backend_point.clone());
+
+        let snapshot = app.snapshot_state();
+
+        assert_eq!(snapshot.client_history.len(), 1);
+        assert_eq!(
+            snapshot.client_history[0].sent_per_sec().get(),
+            client_point.sent_per_sec().get()
+        );
+        assert_eq!(
+            snapshot.client_history[0].received_per_sec().get(),
+            client_point.received_per_sec().get()
+        );
+        assert_eq!(snapshot.backend_views.len(), 1);
+        assert_eq!(snapshot.backend_views[0].history.len(), 1);
+        assert_eq!(
+            snapshot.backend_views[0].history[0].sent_per_sec().get(),
+            backend_point.sent_per_sec().get()
+        );
+        assert_eq!(
+            snapshot.backend_views[0].history[0]
+                .received_per_sec()
+                .get(),
+            backend_point.received_per_sec().get()
+        );
+        assert_eq!(
+            snapshot.backend_views[0].history[0]
+                .commands_per_sec()
+                .unwrap()
+                .get(),
+            backend_point.commands_per_sec().unwrap().get()
+        );
+        assert_eq!(
+            snapshot.buffer_pool.as_ref().map(|pool| pool.total),
+            Some(4)
+        );
     }
 }

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -1,0 +1,102 @@
+//! Serializable dashboard state shared between local and attached TUI modes.
+
+use crate::config::Server;
+use crate::metrics::{BackendHealthStatus, BackendStats, MetricsSnapshot};
+use crate::tui::app::{ThroughputPoint, ViewMode};
+use crate::tui::system_stats::SystemStats;
+
+/// Snapshot of the I/O buffer pool used by the summary panel.
+#[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
+pub struct BufferPoolStats {
+    pub available: usize,
+    pub in_use: usize,
+    pub total: usize,
+}
+
+/// A backend entry rendered in the backend list and chart panels.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BackendView {
+    pub server: Server,
+    pub stats: BackendStats,
+    pub active_connections: usize,
+    pub health_status: BackendHealthStatus,
+    pub pending_count: usize,
+    pub load_ratio: Option<f64>,
+    pub stateful_count: usize,
+    pub traffic_share: Option<f64>,
+    pub history: Vec<ThroughputPoint>,
+}
+
+impl BackendView {
+    #[must_use]
+    pub fn latest_throughput(&self) -> Option<&ThroughputPoint> {
+        self.history.last()
+    }
+}
+
+/// Full dashboard state, suitable for rendering locally or over websocket.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DashboardState {
+    pub snapshot: MetricsSnapshot,
+    pub backend_views: Vec<BackendView>,
+    pub client_history: Vec<ThroughputPoint>,
+    pub system_stats: SystemStats,
+    pub view_mode: ViewMode,
+    pub show_details: bool,
+    pub log_lines: Vec<String>,
+    pub buffer_pool: Option<BufferPoolStats>,
+}
+
+impl DashboardState {
+    #[must_use]
+    pub fn latest_client_throughput(&self) -> Option<&ThroughputPoint> {
+        self.client_history.last()
+    }
+
+    #[must_use]
+    pub fn latest_backend_throughput(&self, backend_idx: usize) -> Option<&ThroughputPoint> {
+        self.backend_views
+            .get(backend_idx)
+            .and_then(BackendView::latest_throughput)
+    }
+
+    #[must_use]
+    pub fn throughput_history(&self, backend_idx: usize) -> Option<&[ThroughputPoint]> {
+        self.backend_views
+            .get(backend_idx)
+            .map(|view| view.history.as_slice())
+    }
+
+    #[must_use]
+    pub fn backend_pending_count(&self, backend_idx: usize) -> usize {
+        self.backend_views
+            .get(backend_idx)
+            .map_or(0, |view| view.pending_count)
+    }
+
+    #[must_use]
+    pub fn backend_load_ratio(&self, backend_idx: usize) -> Option<f64> {
+        self.backend_views
+            .get(backend_idx)
+            .and_then(|view| view.load_ratio)
+    }
+
+    #[must_use]
+    pub fn backend_stateful_count(&self, backend_idx: usize) -> usize {
+        self.backend_views
+            .get(backend_idx)
+            .map_or(0, |view| view.stateful_count)
+    }
+
+    #[must_use]
+    pub fn backend_traffic_share(&self, backend_idx: usize) -> Option<f64> {
+        self.backend_views
+            .get(backend_idx)
+            .and_then(|view| view.traffic_share)
+    }
+
+    #[must_use]
+    pub fn buffer_pool(&self) -> Option<&BufferPoolStats> {
+        self.buffer_pool.as_ref()
+    }
+}

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -1,9 +1,16 @@
 //! Serializable dashboard state shared between local and attached TUI modes.
 
-use crate::metrics::{BackendHealthStatus, BackendStats, MetricsSnapshot};
+use crate::metrics::{
+    BackendHealthStatus, BackendStats, CommandCount, DiskCacheStats, ErrorCount, MetricsSnapshot,
+    UserStats,
+};
 use crate::tui::app::{ThroughputPoint, ViewMode};
 use crate::tui::system_stats::SystemStats;
-use crate::types::{HostName, MaxConnections, Port, ServerName};
+use crate::types::{
+    BackendToClientBytes, BytesPerSecondRate, BytesReceived, BytesSent, ClientToBackendBytes,
+    HostName, MaxConnections, Port, ServerName, TotalConnections,
+};
+use std::time::Duration;
 
 /// Snapshot of the I/O buffer pool used by the summary panel.
 #[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
@@ -43,11 +50,112 @@ impl BackendView {
     }
 }
 
+/// Serialized user stats used by the dashboard payload.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct DashboardUserStats {
+    pub username: String,
+    pub active_connections: usize,
+    pub total_connections: TotalConnections,
+    pub bytes_sent: BytesSent,
+    pub bytes_received: BytesReceived,
+    pub bytes_sent_per_sec: BytesPerSecondRate,
+    pub bytes_received_per_sec: BytesPerSecondRate,
+    pub total_commands: CommandCount,
+    pub errors: ErrorCount,
+}
+
+impl DashboardUserStats {
+    #[must_use]
+    pub fn from_user_stats(user: &UserStats) -> Self {
+        Self {
+            username: user.username.clone(),
+            active_connections: user.active_connections,
+            total_connections: user.total_connections,
+            bytes_sent: user.bytes_sent,
+            bytes_received: user.bytes_received,
+            bytes_sent_per_sec: user.bytes_sent_per_sec,
+            bytes_received_per_sec: user.bytes_received_per_sec,
+            total_commands: user.total_commands,
+            errors: user.errors,
+        }
+    }
+
+    #[must_use]
+    pub const fn total_bytes(&self) -> u64 {
+        self.bytes_sent
+            .as_u64()
+            .saturating_add(self.bytes_received.as_u64())
+    }
+}
+
+/// Serialized metrics used by the dashboard payload.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct DashboardMetrics {
+    pub total_connections: u64,
+    pub active_connections: usize,
+    pub stateful_sessions: usize,
+    pub client_to_backend_bytes: ClientToBackendBytes,
+    pub backend_to_client_bytes: BackendToClientBytes,
+    pub uptime: Duration,
+    pub cache_entries: u64,
+    pub cache_size_bytes: u64,
+    pub cache_hit_rate: f64,
+    pub disk_cache: Option<DiskCacheStats>,
+    pub pipeline_batches: u64,
+    pub pipeline_commands: u64,
+    pub pipeline_requests_queued: u64,
+    pub pipeline_requests_completed: u64,
+}
+
+impl DashboardMetrics {
+    #[must_use]
+    pub fn from_snapshot(snapshot: &MetricsSnapshot) -> Self {
+        Self {
+            total_connections: snapshot.total_connections,
+            active_connections: snapshot.active_connections,
+            stateful_sessions: snapshot.stateful_sessions,
+            client_to_backend_bytes: snapshot.client_to_backend_bytes,
+            backend_to_client_bytes: snapshot.backend_to_client_bytes,
+            uptime: snapshot.uptime,
+            cache_entries: snapshot.cache_entries,
+            cache_size_bytes: snapshot.cache_size_bytes,
+            cache_hit_rate: snapshot.cache_hit_rate,
+            disk_cache: snapshot.disk_cache,
+            pipeline_batches: snapshot.pipeline_batches,
+            pipeline_commands: snapshot.pipeline_commands,
+            pipeline_requests_queued: snapshot.pipeline_requests_queued,
+            pipeline_requests_completed: snapshot.pipeline_requests_completed,
+        }
+    }
+
+    #[must_use]
+    pub fn format_uptime(&self) -> String {
+        let secs = self.uptime.as_secs();
+        let hours = secs / 3600;
+        let minutes = (secs % 3600) / 60;
+        let seconds = secs % 60;
+
+        if hours > 0 {
+            format!("{hours}h {minutes}m {seconds}s")
+        } else if minutes > 0 {
+            format!("{minutes}m {seconds}s")
+        } else {
+            format!("{seconds}s")
+        }
+    }
+
+    #[must_use]
+    pub const fn total_bytes(&self) -> u64 {
+        self.client_to_backend_bytes.as_u64() + self.backend_to_client_bytes.as_u64()
+    }
+}
+
 /// Full dashboard state, suitable for rendering locally or over websocket.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DashboardState {
-    pub snapshot: MetricsSnapshot,
+    pub metrics: DashboardMetrics,
     pub backend_views: Vec<BackendView>,
+    pub top_users: Vec<DashboardUserStats>,
     pub client_history: Vec<ThroughputPoint>,
     pub system_stats: SystemStats,
     pub view_mode: ViewMode,
@@ -112,7 +220,7 @@ impl DashboardState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metrics::{BackendHealthStatus, BackendStats, MetricsSnapshot};
+    use crate::metrics::{BackendHealthStatus, BackendStats};
     use crate::tui::app::{ThroughputPoint, ViewMode};
     use crate::types::Port;
     use crate::types::tui::{Throughput, Timestamp};
@@ -144,8 +252,9 @@ mod tests {
     #[test]
     fn backend_accessors_handle_out_of_range_indices() {
         let state = DashboardState {
-            snapshot: MetricsSnapshot::default(),
+            metrics: DashboardMetrics::default(),
             backend_views: vec![sample_backend_view()],
+            top_users: Vec::new(),
             client_history: Vec::new(),
             system_stats: SystemStats::default(),
             view_mode: ViewMode::Normal,

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -147,7 +147,7 @@ mod tests {
             snapshot: MetricsSnapshot::default(),
             backend_views: vec![sample_backend_view()],
             client_history: Vec::new(),
-            system_stats: Default::default(),
+            system_stats: SystemStats::default(),
             view_mode: ViewMode::Normal,
             show_details: false,
             log_lines: Vec::new(),

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -1,9 +1,9 @@
 //! Serializable dashboard state shared between local and attached TUI modes.
 
-use crate::config::Server;
 use crate::metrics::{BackendHealthStatus, BackendStats, MetricsSnapshot};
 use crate::tui::app::{ThroughputPoint, ViewMode};
 use crate::tui::system_stats::SystemStats;
+use crate::types::{HostName, MaxConnections, Port, ServerName};
 
 /// Snapshot of the I/O buffer pool used by the summary panel.
 #[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
@@ -15,8 +15,17 @@ pub struct BufferPoolStats {
 
 /// A backend entry rendered in the backend list and chart panels.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BackendDisplay {
+    pub host: HostName,
+    pub port: Port,
+    pub name: ServerName,
+    pub max_connections: MaxConnections,
+}
+
+/// A backend entry rendered in the backend list and chart panels.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BackendView {
-    pub server: Server,
+    pub server: BackendDisplay,
     pub stats: BackendStats,
     pub active_connections: usize,
     pub health_status: BackendHealthStatus,
@@ -110,10 +119,12 @@ mod tests {
 
     fn sample_backend_view() -> BackendView {
         BackendView {
-            server: Server::builder("backend.example.com", Port::try_new(119).unwrap())
-                .name("Backend")
-                .build()
-                .unwrap(),
+            server: BackendDisplay {
+                host: HostName::try_new("backend.example.com".to_string()).unwrap(),
+                port: Port::try_new(119).unwrap(),
+                name: ServerName::try_new("Backend".to_string()).unwrap(),
+                max_connections: MaxConnections::try_new(10).unwrap(),
+            },
             stats: BackendStats::default(),
             active_connections: 1,
             health_status: BackendHealthStatus::Healthy,

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -49,54 +49,105 @@ pub struct DashboardState {
 
 impl DashboardState {
     #[must_use]
+    fn backend_view(&self, backend_idx: usize) -> Option<&BackendView> {
+        self.backend_views.get(backend_idx)
+    }
+
+    #[must_use]
     pub fn latest_client_throughput(&self) -> Option<&ThroughputPoint> {
         self.client_history.last()
     }
 
     #[must_use]
     pub fn latest_backend_throughput(&self, backend_idx: usize) -> Option<&ThroughputPoint> {
-        self.backend_views
-            .get(backend_idx)
+        self.backend_view(backend_idx)
             .and_then(BackendView::latest_throughput)
     }
 
     #[must_use]
     pub fn throughput_history(&self, backend_idx: usize) -> Option<&[ThroughputPoint]> {
-        self.backend_views
-            .get(backend_idx)
+        self.backend_view(backend_idx)
             .map(|view| view.history.as_slice())
     }
 
     #[must_use]
     pub fn backend_pending_count(&self, backend_idx: usize) -> usize {
-        self.backend_views
-            .get(backend_idx)
+        self.backend_view(backend_idx)
             .map_or(0, |view| view.pending_count)
     }
 
     #[must_use]
     pub fn backend_load_ratio(&self, backend_idx: usize) -> Option<f64> {
-        self.backend_views
-            .get(backend_idx)
+        self.backend_view(backend_idx)
             .and_then(|view| view.load_ratio)
     }
 
     #[must_use]
     pub fn backend_stateful_count(&self, backend_idx: usize) -> usize {
-        self.backend_views
-            .get(backend_idx)
+        self.backend_view(backend_idx)
             .map_or(0, |view| view.stateful_count)
     }
 
     #[must_use]
     pub fn backend_traffic_share(&self, backend_idx: usize) -> Option<f64> {
-        self.backend_views
-            .get(backend_idx)
+        self.backend_view(backend_idx)
             .and_then(|view| view.traffic_share)
     }
 
     #[must_use]
     pub fn buffer_pool(&self) -> Option<&BufferPoolStats> {
         self.buffer_pool.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metrics::{BackendHealthStatus, BackendStats, MetricsSnapshot};
+    use crate::tui::app::{ThroughputPoint, ViewMode};
+    use crate::types::Port;
+    use crate::types::tui::{Throughput, Timestamp};
+
+    fn sample_backend_view() -> BackendView {
+        BackendView {
+            server: Server::builder("backend.example.com", Port::try_new(119).unwrap())
+                .name("Backend")
+                .build()
+                .unwrap(),
+            stats: BackendStats::default(),
+            active_connections: 1,
+            health_status: BackendHealthStatus::Healthy,
+            pending_count: 2,
+            load_ratio: Some(0.5),
+            stateful_count: 3,
+            traffic_share: Some(42.0),
+            history: vec![ThroughputPoint::new_backend(
+                Timestamp::now(),
+                Throughput::new(1.0),
+                Throughput::new(2.0),
+                crate::types::tui::CommandsPerSecond::new(3.0),
+            )],
+        }
+    }
+
+    #[test]
+    fn backend_accessors_handle_out_of_range_indices() {
+        let state = DashboardState {
+            snapshot: MetricsSnapshot::default(),
+            backend_views: vec![sample_backend_view()],
+            client_history: Vec::new(),
+            system_stats: Default::default(),
+            view_mode: ViewMode::Normal,
+            show_details: false,
+            log_lines: Vec::new(),
+            buffer_pool: None,
+        };
+
+        assert!(state.latest_backend_throughput(1).is_none());
+        assert!(state.throughput_history(1).is_none());
+        assert_eq!(state.backend_pending_count(1), 0);
+        assert!(state.backend_load_ratio(1).is_none());
+        assert_eq!(state.backend_stateful_count(1), 0);
+        assert!(state.backend_traffic_share(1).is_none());
     }
 }

--- a/src/tui/helpers.rs
+++ b/src/tui/helpers.rs
@@ -3,9 +3,8 @@
 use ratatui::style::Color;
 
 use super::constants::{BACKEND_COLORS, throughput};
+use super::dashboard::BackendView;
 use super::types::{BackendChartData, ChartDataVec, ChartPoint, ChartX, ChartY, PointVec};
-use crate::config::Server;
-use crate::tui::TuiApp;
 use crate::tui::app::ThroughputPoint;
 
 // ============================================================================
@@ -57,7 +56,7 @@ pub fn create_sparkline(value: u64, max_value: u64) -> String {
 /// 3. Accumulates results with global max tracking
 ///
 /// Returns (`chart_data`, `global_max_throughput`)
-pub fn build_chart_data(servers: &[Server], app: &TuiApp) -> (ChartDataVec, f64) {
+pub fn build_chart_data(backend_views: &[BackendView]) -> (ChartDataVec, f64) {
     /// Extract data from a single throughput point
     #[inline]
     fn extract_point_data(idx: usize, point: &ThroughputPoint) -> (ChartPoint, ChartPoint, ChartY) {
@@ -82,39 +81,30 @@ pub fn build_chart_data(servers: &[Server], app: &TuiApp) -> (ChartDataVec, f64)
         ((sent_vec, recv_vec), max.max(point_max))
     }
 
-    /// Build chart data for a single backend (pure function)
-    fn build_backend_data(
-        index: usize,
-        server: &Server,
-        history: &std::collections::VecDeque<ThroughputPoint>,
-    ) -> (BackendChartData, f64) {
-        let ((sent_points, recv_points), backend_max) = history
-            .iter()
-            .enumerate()
-            .map(|(idx, point)| extract_point_data(idx, point))
-            .fold(
-                ((PointVec::new(), PointVec::new()), ChartY::from(0.0)),
-                accumulate_points,
-            );
-
-        (
-            BackendChartData::new(
-                server.name.as_str().to_string(),
-                backend_color(index),
-                &sent_points,
-                &recv_points,
-            ),
-            backend_max.get(),
-        )
-    }
-
     // Functional pipeline: enumerate → map → fold
-    servers
+    backend_views
         .iter()
         .enumerate()
-        .map(|(index, server)| {
-            let history = app.throughput_history(index);
-            build_backend_data(index, server, history)
+        .map(|(index, backend)| {
+            let ((sent_points, recv_points), backend_max) = backend
+                .history
+                .iter()
+                .enumerate()
+                .map(|(idx, point)| extract_point_data(idx, point))
+                .fold(
+                    ((PointVec::new(), PointVec::new()), ChartY::from(0.0)),
+                    accumulate_points,
+                );
+
+            (
+                BackendChartData::new(
+                    backend.server.name.as_str().to_string(),
+                    backend_color(index),
+                    &sent_points,
+                    &recv_points,
+                ),
+                backend_max.get(),
+            )
         })
         .fold(
             (ChartDataVec::new(), 0.0_f64),
@@ -248,18 +238,33 @@ pub const fn load_percentage_color(percent: f64) -> Color {
     }
 }
 
-/// Color for byte sizes and large counters based on magnitude.
+/// Color for pending count
 #[must_use]
-pub const fn magnitude_color(value: u64) -> Color {
-    use super::constants::styles;
-    if value >= 1_000_000_000_000 {
-        Color::Red
-    } else if value >= 1_000_000_000 {
+pub const fn pending_count_color(pending: usize) -> Color {
+    if pending > 0 {
         Color::Yellow
-    } else if value >= 1_000_000 {
-        styles::VALUE_PRIMARY
-    } else if value >= 1_000 {
-        styles::VALUE_INFO
+    } else {
+        super::constants::styles::VALUE_NEUTRAL
+    }
+}
+
+/// Color for error count
+#[must_use]
+pub const fn error_count_color(has_errors: bool) -> Color {
+    use super::constants::styles;
+    if has_errors {
+        Color::Yellow
+    } else {
+        styles::VALUE_NEUTRAL
+    }
+}
+
+/// Color for connection failures
+#[must_use]
+pub const fn connection_failure_color(failures: u64) -> Color {
+    use super::constants::styles;
+    if failures > 0 {
+        Color::Red
     } else {
         styles::VALUE_NEUTRAL
     }
@@ -338,18 +343,6 @@ mod tests {
         assert_eq!(format_throughput_label(1_048_576.0), "1 MiB/s");
         assert_eq!(format_throughput_label(1_024.0), "1 KiB/s");
         assert_eq!(format_throughput_label(0.0), "0 B/s");
-    }
-
-    #[test]
-    fn test_magnitude_color_boundaries() {
-        use super::super::constants::styles;
-
-        assert_eq!(magnitude_color(0), styles::VALUE_NEUTRAL);
-        assert_eq!(magnitude_color(999), styles::VALUE_NEUTRAL);
-        assert_eq!(magnitude_color(1_000), styles::VALUE_INFO);
-        assert_eq!(magnitude_color(1_000_000), styles::VALUE_PRIMARY);
-        assert_eq!(magnitude_color(1_000_000_000), Color::Yellow);
-        assert_eq!(magnitude_color(1_000_000_000_000), Color::Red);
     }
 
     #[test]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -18,8 +18,10 @@ use crate::tui::constants::styles;
 pub use app::{TuiApp, TuiAppBuilder, ViewMode};
 pub use dashboard::{BackendView, BufferPoolStats, DashboardState};
 pub use log_capture::{LogBuffer, LogMakeWriter};
-pub use remote::run_dashboard_publisher;
 pub(crate) use remote::spawn_dashboard_reader;
+pub use remote::{
+    bind_dashboard_listener, run_dashboard_publisher, run_dashboard_publisher_on_listener,
+};
 pub use system_stats::{SystemMonitor, SystemStats};
 
 use anyhow::Result;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -194,8 +194,7 @@ where
 
     let state = state_rx.borrow().clone();
     let local_system_stats = local_system_monitor.update();
-    terminal
-        .draw(|f| draw_attached_dashboard(f, state.as_ref(), local_system_stats.memory_bytes))?;
+    terminal.draw(|f| draw_attached_dashboard(f, state.as_ref(), &local_system_stats))?;
 
     loop {
         tokio::select! {
@@ -210,9 +209,7 @@ where
 
                 let state = state_rx.borrow().clone();
                 let local_system_stats = local_system_monitor.update();
-                terminal.draw(|f| {
-                    draw_attached_dashboard(f, state.as_ref(), local_system_stats.memory_bytes)
-                })?;
+                terminal.draw(|f| draw_attached_dashboard(f, state.as_ref(), &local_system_stats))?;
             }
         }
     }
@@ -223,10 +220,10 @@ where
 fn draw_attached_dashboard(
     f: &mut ratatui::Frame,
     state: Option<&DashboardState>,
-    local_memory_bytes: u64,
+    local_system_stats: &SystemStats,
 ) {
     if let Some(state) = state {
-        ui::render_ui(f, state, Some(local_memory_bytes));
+        ui::render_ui(f, state, Some(local_system_stats));
         return;
     }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -128,9 +128,12 @@ pub async fn run_tui(
 pub async fn run_attached_tui(connect_addr: SocketAddr) -> Result<()> {
     let (state_tx, mut state_rx) = tokio::sync::watch::channel(None::<DashboardState>);
     let _reader = spawn_dashboard_reader(connect_addr, state_tx);
+    let mut local_system_monitor = SystemMonitor::new();
 
     with_terminal_session(move |terminal| {
-        Box::pin(async move { run_attached_app(terminal, &mut state_rx).await })
+        Box::pin(async move {
+            run_attached_app(terminal, &mut state_rx, &mut local_system_monitor).await
+        })
     })
     .await
 }
@@ -148,7 +151,7 @@ where
     let mut update_interval = tokio::time::interval(Duration::from_millis(250));
 
     // Initial render
-    terminal.draw(|f| ui::render_ui(f, &app.snapshot_state()))?;
+    terminal.draw(|f| ui::render_ui(f, &app.snapshot_state(), None))?;
 
     let mut should_quit = false;
 
@@ -162,18 +165,15 @@ where
             _ = update_interval.tick() => {
                 app.update();
 
-                match poll_tui_input(true).await? {
-                    TuiInputAction::Quit => should_quit = true,
-                    TuiInputAction::ToggleLogFullscreen => app.toggle_log_fullscreen(),
-                    TuiInputAction::ToggleDetails => app.toggle_details(),
-                    TuiInputAction::None => {}
+                if apply_tui_input(true, Some(app)).await? {
+                    should_quit = true;
                 }
 
                 if should_quit {
                     break;
                 }
 
-                terminal.draw(|f| ui::render_ui(f, &app.snapshot_state()))?;
+                terminal.draw(|f| ui::render_ui(f, &app.snapshot_state(), None))?;
             }
         }
     }
@@ -184,6 +184,7 @@ where
 async fn run_attached_app<B: ratatui::backend::Backend>(
     terminal: &mut Terminal<B>,
     state_rx: &mut tokio::sync::watch::Receiver<Option<DashboardState>>,
+    local_system_monitor: &mut SystemMonitor,
 ) -> Result<()>
 where
     B::Error: Send + Sync + 'static,
@@ -192,12 +193,14 @@ where
     let mut should_quit = false;
 
     let state = state_rx.borrow().clone();
-    terminal.draw(|f| draw_attached_dashboard(f, state.as_ref()))?;
+    let local_system_stats = local_system_monitor.update();
+    terminal
+        .draw(|f| draw_attached_dashboard(f, state.as_ref(), local_system_stats.memory_bytes))?;
 
     loop {
         tokio::select! {
             _ = update_interval.tick() => {
-                if matches!(poll_tui_input(false).await?, TuiInputAction::Quit) {
+                if apply_tui_input(false, None).await? {
                     should_quit = true;
                 }
 
@@ -206,7 +209,10 @@ where
                 }
 
                 let state = state_rx.borrow().clone();
-                terminal.draw(|f| draw_attached_dashboard(f, state.as_ref()))?;
+                let local_system_stats = local_system_monitor.update();
+                terminal.draw(|f| {
+                    draw_attached_dashboard(f, state.as_ref(), local_system_stats.memory_bytes)
+                })?;
             }
         }
     }
@@ -214,9 +220,13 @@ where
     Ok(())
 }
 
-fn draw_attached_dashboard(f: &mut ratatui::Frame, state: Option<&DashboardState>) {
+fn draw_attached_dashboard(
+    f: &mut ratatui::Frame,
+    state: Option<&DashboardState>,
+    local_memory_bytes: u64,
+) {
     if let Some(state) = state {
-        ui::render_ui(f, state);
+        ui::render_ui(f, state, Some(local_memory_bytes));
         return;
     }
 
@@ -287,6 +297,25 @@ async fn poll_tui_input(allow_dashboard_actions: bool) -> Result<TuiInputAction>
         Event::Key(key) => key_event_action(key, allow_dashboard_actions),
         _ => TuiInputAction::None,
     })
+}
+
+async fn apply_tui_input(allow_dashboard_actions: bool, app: Option<&mut TuiApp>) -> Result<bool> {
+    match poll_tui_input(allow_dashboard_actions).await? {
+        TuiInputAction::Quit => Ok(true),
+        TuiInputAction::ToggleLogFullscreen => {
+            if let Some(app) = app {
+                app.toggle_log_fullscreen();
+            }
+            Ok(false)
+        }
+        TuiInputAction::ToggleDetails => {
+            if let Some(app) = app {
+                app.toggle_details();
+            }
+            Ok(false)
+        }
+        TuiInputAction::None => Ok(false),
+    }
 }
 
 #[cfg(test)]

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -39,6 +39,14 @@ use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::sync::mpsc;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TuiInputAction {
+    None,
+    Quit,
+    ToggleLogFullscreen,
+    ToggleDetails,
+}
+
 /// Setup the terminal for TUI rendering
 fn setup_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
     enable_raw_mode()?;
@@ -154,29 +162,11 @@ where
             _ = update_interval.tick() => {
                 app.update();
 
-                // Check events on blocking thread pool to not block async runtime
-                let has_events = tokio::task::spawn_blocking(|| {
-                    event::poll(Duration::from_millis(0))
-                }).await??;
-
-                if has_events {
-                    let key_event = tokio::task::spawn_blocking(|| {
-                        event::read()
-                    }).await??;
-
-                    if let Event::Key(key) = key_event
-                        && key.kind == KeyEventKind::Press
-                    {
-                        match key.code {
-                            KeyCode::Char('q') | KeyCode::Esc => should_quit = true,
-                            KeyCode::Char('c') if key.modifiers.contains(event::KeyModifiers::CONTROL) => {
-                                should_quit = true;
-                            }
-                            KeyCode::Char('l') => app.toggle_log_fullscreen(),
-                            KeyCode::Char('d') => app.toggle_details(),
-                            _ => {}
-                        }
-                    }
+                match poll_tui_input(true).await? {
+                    TuiInputAction::Quit => should_quit = true,
+                    TuiInputAction::ToggleLogFullscreen => app.toggle_log_fullscreen(),
+                    TuiInputAction::ToggleDetails => app.toggle_details(),
+                    TuiInputAction::None => {}
                 }
 
                 if should_quit {
@@ -207,26 +197,8 @@ where
     loop {
         tokio::select! {
             _ = update_interval.tick() => {
-                let has_events = tokio::task::spawn_blocking(|| {
-                    event::poll(Duration::from_millis(0))
-                }).await??;
-
-                if has_events {
-                    let key_event = tokio::task::spawn_blocking(|| {
-                        event::read()
-                    }).await??;
-
-                    if let Event::Key(key) = key_event
-                        && key.kind == KeyEventKind::Press
-                    {
-                        match key.code {
-                            KeyCode::Char('q') | KeyCode::Esc => should_quit = true,
-                            KeyCode::Char('c') if key.modifiers.contains(event::KeyModifiers::CONTROL) => {
-                                should_quit = true;
-                            }
-                            _ => {}
-                        }
-                    }
+                if matches!(poll_tui_input(false).await?, TuiInputAction::Quit) {
+                    should_quit = true;
                 }
 
                 if should_quit {
@@ -281,4 +253,88 @@ fn draw_attached_dashboard(f: &mut ratatui::Frame, state: Option<&DashboardState
     f.render_widget(title, chunks[0]);
     f.render_widget(body, chunks[1]);
     f.render_widget(footer, chunks[2]);
+}
+
+fn key_event_action(
+    key: crossterm::event::KeyEvent,
+    allow_dashboard_actions: bool,
+) -> TuiInputAction {
+    if key.kind != KeyEventKind::Press {
+        return TuiInputAction::None;
+    }
+
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => TuiInputAction::Quit,
+        KeyCode::Char('c') if key.modifiers.contains(event::KeyModifiers::CONTROL) => {
+            TuiInputAction::Quit
+        }
+        KeyCode::Char('l') if allow_dashboard_actions => TuiInputAction::ToggleLogFullscreen,
+        KeyCode::Char('d') if allow_dashboard_actions => TuiInputAction::ToggleDetails,
+        _ => TuiInputAction::None,
+    }
+}
+
+async fn poll_tui_input(allow_dashboard_actions: bool) -> Result<TuiInputAction> {
+    let has_events =
+        tokio::task::spawn_blocking(|| event::poll(Duration::from_millis(0))).await??;
+
+    if !has_events {
+        return Ok(TuiInputAction::None);
+    }
+
+    let key_event = tokio::task::spawn_blocking(event::read).await??;
+    Ok(match key_event {
+        Event::Key(key) => key_event_action(key, allow_dashboard_actions),
+        _ => TuiInputAction::None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn key_event_action_quits_on_q_and_escape() {
+        let q = crossterm::event::KeyEvent::new(KeyCode::Char('q'), event::KeyModifiers::NONE);
+        let esc = crossterm::event::KeyEvent::new(KeyCode::Esc, event::KeyModifiers::NONE);
+
+        assert_eq!(key_event_action(q, true), TuiInputAction::Quit);
+        assert_eq!(key_event_action(esc, true), TuiInputAction::Quit);
+    }
+
+    #[test]
+    fn key_event_action_supports_dashboard_toggles_only_when_enabled() {
+        let log_toggle =
+            crossterm::event::KeyEvent::new(KeyCode::Char('l'), event::KeyModifiers::NONE);
+        let details_toggle =
+            crossterm::event::KeyEvent::new(KeyCode::Char('d'), event::KeyModifiers::NONE);
+
+        assert_eq!(
+            key_event_action(log_toggle, true),
+            TuiInputAction::ToggleLogFullscreen
+        );
+        assert_eq!(
+            key_event_action(details_toggle, true),
+            TuiInputAction::ToggleDetails
+        );
+        assert_eq!(key_event_action(log_toggle, false), TuiInputAction::None);
+        assert_eq!(
+            key_event_action(details_toggle, false),
+            TuiInputAction::None
+        );
+    }
+
+    #[test]
+    fn key_event_action_ignores_key_releases_and_other_input() {
+        let released = crossterm::event::KeyEvent {
+            code: KeyCode::Char('q'),
+            modifiers: event::KeyModifiers::NONE,
+            kind: KeyEventKind::Release,
+            state: event::KeyEventState::NONE,
+        };
+        let other = crossterm::event::KeyEvent::new(KeyCode::Char('x'), event::KeyModifiers::NONE);
+
+        assert_eq!(key_event_action(released, true), TuiInputAction::None);
+        assert_eq!(key_event_action(other, true), TuiInputAction::None);
+    }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -44,6 +44,7 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 
 type TuiTerminal = Terminal<CrosstermBackend<io::Stdout>>;
+const LOCAL_TUI_LOG_LINE_LIMIT: usize = 256;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RemoteDashboardStatus {
@@ -216,7 +217,7 @@ where
     let mut update_interval = tokio::time::interval(Duration::from_millis(250));
 
     // Initial render
-    terminal.draw(|f| ui::render_ui(f, &app.snapshot_state(), None, None))?;
+    terminal.draw(|f| ui::render_ui(f, &renderable_dashboard_state(app), None, None))?;
 
     let mut should_quit = false;
 
@@ -238,12 +239,16 @@ where
                     break;
                 }
 
-                terminal.draw(|f| ui::render_ui(f, &app.snapshot_state(), None, None))?;
+                terminal.draw(|f| ui::render_ui(f, &renderable_dashboard_state(app), None, None))?;
             }
         }
     }
 
     Ok(())
+}
+
+fn renderable_dashboard_state(app: &TuiApp) -> DashboardState {
+    app.snapshot_state_with_log_limit(Some(LOCAL_TUI_LOG_LINE_LIMIT))
 }
 
 async fn run_attached_app<B: ratatui::backend::Backend>(
@@ -418,6 +423,11 @@ async fn apply_tui_input(allow_dashboard_actions: bool, app: Option<&mut TuiApp>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::Server;
+    use crate::metrics::MetricsCollector;
+    use crate::router::BackendSelector;
+    use crate::types::Port;
+    use std::sync::Arc;
 
     #[test]
     fn key_event_action_quits_on_q_and_escape() {
@@ -505,5 +515,32 @@ mod tests {
             .expect_err("non-loopback attach should fail");
 
         assert!(format!("{err:#}").contains("must connect to a loopback address"));
+    }
+
+    #[test]
+    fn renderable_dashboard_state_limits_local_log_tail() {
+        let log_buffer = LogBuffer::new();
+        for i in 0..(LOCAL_TUI_LOG_LINE_LIMIT + 10) {
+            log_buffer.push(format!("line {i}"));
+        }
+
+        let app = TuiAppBuilder::new(
+            MetricsCollector::new(1),
+            Arc::new(BackendSelector::new()),
+            Arc::from(vec![
+                Server::builder("backend.example.com", Port::try_new(119).unwrap())
+                    .name("Backend")
+                    .build()
+                    .unwrap(),
+            ]),
+        )
+        .with_log_buffer(log_buffer)
+        .build();
+
+        let state = renderable_dashboard_state(&app);
+
+        assert_eq!(state.log_lines.len(), LOCAL_TUI_LOG_LINE_LIMIT);
+        assert_eq!(state.log_lines.first().map(String::as_str), Some("line 10"));
+        assert_eq!(state.log_lines.last().map(String::as_str), Some("line 265"));
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -27,6 +27,7 @@ use crossterm::{
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
+use futures::future::BoxFuture;
 use ratatui::{Terminal, backend::CrosstermBackend};
 use ratatui::{
     layout::{Alignment, Constraint, Direction, Layout},
@@ -39,6 +40,8 @@ use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::sync::mpsc;
 
+type TuiTerminal = Terminal<CrosstermBackend<io::Stdout>>;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TuiInputAction {
     None,
@@ -48,7 +51,7 @@ enum TuiInputAction {
 }
 
 /// Setup the terminal for TUI rendering
-fn setup_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
+fn setup_terminal() -> Result<TuiTerminal> {
     enable_raw_mode()?;
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen)?;
@@ -59,7 +62,7 @@ fn setup_terminal() -> Result<Terminal<CrosstermBackend<io::Stdout>>> {
 }
 
 /// Restore the terminal to its original state
-fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Result<()> {
+fn restore_terminal(terminal: &mut TuiTerminal) -> Result<()> {
     // Clear the terminal first to prevent escape sequences leaking to shell
     terminal.clear()?;
 
@@ -68,6 +71,24 @@ fn restore_terminal(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>) -> Re
     terminal.show_cursor()?;
 
     Ok(())
+}
+
+async fn with_terminal_session<T>(
+    run: impl for<'a> FnOnce(&'a mut TuiTerminal) -> BoxFuture<'a, Result<T>>,
+) -> Result<T> {
+    let mut terminal = setup_terminal()?;
+
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+        original_hook(panic_info);
+    }));
+
+    let result = run(&mut terminal).await;
+
+    restore_terminal(&mut terminal)?;
+    result
 }
 
 /// Run the TUI event loop
@@ -92,22 +113,10 @@ pub async fn run_tui(
     shutdown_tx: mpsc::Sender<()>,
     mut shutdown_rx: mpsc::Receiver<()>,
 ) -> Result<()> {
-    // Setup terminal
-    let mut terminal = setup_terminal()?;
-
-    // Setup panic hook to ensure terminal cleanup
-    let original_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |panic_info| {
-        let _ = disable_raw_mode();
-        let _ = execute!(io::stdout(), LeaveAlternateScreen);
-        original_hook(panic_info);
-    }));
-
-    // Run the app
-    let result = run_app(&mut terminal, &mut app, &mut shutdown_rx).await;
-
-    // Restore terminal
-    restore_terminal(&mut terminal)?;
+    let result = with_terminal_session(move |terminal| {
+        Box::pin(async move { run_app(terminal, &mut app, &mut shutdown_rx).await })
+    })
+    .await;
 
     // Signal shutdown when TUI exits
     let _ = shutdown_tx.send(()).await;
@@ -117,22 +126,13 @@ pub async fn run_tui(
 
 /// Run the TUI as a remote dashboard client connected to a headless publisher.
 pub async fn run_attached_tui(connect_addr: SocketAddr) -> Result<()> {
-    let mut terminal = setup_terminal()?;
-
-    let original_hook = std::panic::take_hook();
-    std::panic::set_hook(Box::new(move |panic_info| {
-        let _ = disable_raw_mode();
-        let _ = execute!(io::stdout(), LeaveAlternateScreen);
-        original_hook(panic_info);
-    }));
-
     let (state_tx, mut state_rx) = tokio::sync::watch::channel(None::<DashboardState>);
     let _reader = spawn_dashboard_reader(connect_addr, state_tx);
 
-    let result = run_attached_app(&mut terminal, &mut state_rx).await;
-
-    restore_terminal(&mut terminal)?;
-    result
+    with_terminal_session(move |terminal| {
+        Box::pin(async move { run_attached_app(terminal, &mut state_rx).await })
+    })
+    .await
 }
 
 /// Main TUI event loop

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -181,6 +181,10 @@ pub async fn run_tui(
 }
 
 /// Run the TUI as a remote dashboard client connected to a headless publisher.
+///
+/// # Errors
+/// Returns an error when the target is non-loopback or when terminal setup,
+/// drawing, input, or restore operations fail.
 pub async fn run_attached_tui(connect_addr: SocketAddr) -> Result<()> {
     anyhow::ensure!(
         connect_addr.ip().is_loopback(),

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -14,12 +14,13 @@ mod ui;
 #[cfg(test)]
 mod ui_tests;
 
+use crate::tui::constants::styles;
 pub use app::{TuiApp, TuiAppBuilder, ViewMode};
 pub use dashboard::{BackendView, BufferPoolStats, DashboardState};
 pub use log_capture::{LogBuffer, LogMakeWriter};
-pub use remote::{run_dashboard_publisher, spawn_dashboard_reader};
+pub use remote::run_dashboard_publisher;
+pub(crate) use remote::spawn_dashboard_reader;
 pub use system_stats::{SystemMonitor, SystemStats};
-pub use ui::render_ui;
 
 use anyhow::Result;
 use crossterm::{
@@ -41,6 +42,59 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 
 type TuiTerminal = Terminal<CrosstermBackend<io::Stdout>>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RemoteDashboardStatus {
+    Connecting {
+        target: SocketAddr,
+    },
+    Connected {
+        target: SocketAddr,
+    },
+    Reconnecting {
+        target: SocketAddr,
+        retry_delay: Duration,
+        last_error: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct AttachedDashboard {
+    pub latest_state: Option<DashboardState>,
+    pub status: RemoteDashboardStatus,
+}
+
+impl AttachedDashboard {
+    fn connecting(target: SocketAddr) -> Self {
+        Self {
+            latest_state: None,
+            status: RemoteDashboardStatus::Connecting { target },
+        }
+    }
+
+    fn connected(target: SocketAddr, latest_state: Option<DashboardState>) -> Self {
+        Self {
+            latest_state,
+            status: RemoteDashboardStatus::Connected { target },
+        }
+    }
+
+    fn reconnecting(
+        target: SocketAddr,
+        retry_delay: Duration,
+        latest_state: Option<DashboardState>,
+        last_error: impl Into<String>,
+    ) -> Self {
+        Self {
+            latest_state,
+            status: RemoteDashboardStatus::Reconnecting {
+                target,
+                retry_delay,
+                last_error: last_error.into(),
+            },
+        }
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TuiInputAction {
@@ -126,7 +180,8 @@ pub async fn run_tui(
 
 /// Run the TUI as a remote dashboard client connected to a headless publisher.
 pub async fn run_attached_tui(connect_addr: SocketAddr) -> Result<()> {
-    let (state_tx, mut state_rx) = tokio::sync::watch::channel(None::<DashboardState>);
+    let (state_tx, mut state_rx) =
+        tokio::sync::watch::channel(AttachedDashboard::connecting(connect_addr));
     let _reader = spawn_dashboard_reader(connect_addr, state_tx);
     let mut local_system_monitor = SystemMonitor::new();
 
@@ -151,7 +206,7 @@ where
     let mut update_interval = tokio::time::interval(Duration::from_millis(250));
 
     // Initial render
-    terminal.draw(|f| ui::render_ui(f, &app.snapshot_state(), None))?;
+    terminal.draw(|f| ui::render_ui(f, &app.snapshot_state(), None, None))?;
 
     let mut should_quit = false;
 
@@ -173,7 +228,7 @@ where
                     break;
                 }
 
-                terminal.draw(|f| ui::render_ui(f, &app.snapshot_state(), None))?;
+                terminal.draw(|f| ui::render_ui(f, &app.snapshot_state(), None, None))?;
             }
         }
     }
@@ -183,7 +238,7 @@ where
 
 async fn run_attached_app<B: ratatui::backend::Backend>(
     terminal: &mut Terminal<B>,
-    state_rx: &mut tokio::sync::watch::Receiver<Option<DashboardState>>,
+    state_rx: &mut tokio::sync::watch::Receiver<AttachedDashboard>,
     local_system_monitor: &mut SystemMonitor,
 ) -> Result<()>
 where
@@ -194,7 +249,7 @@ where
 
     let state = state_rx.borrow().clone();
     let local_system_stats = local_system_monitor.update();
-    terminal.draw(|f| draw_attached_dashboard(f, state.as_ref(), &local_system_stats))?;
+    terminal.draw(|f| draw_attached_dashboard(f, &state, &local_system_stats))?;
 
     loop {
         tokio::select! {
@@ -209,7 +264,7 @@ where
 
                 let state = state_rx.borrow().clone();
                 let local_system_stats = local_system_monitor.update();
-                terminal.draw(|f| draw_attached_dashboard(f, state.as_ref(), &local_system_stats))?;
+                terminal.draw(|f| draw_attached_dashboard(f, &state, &local_system_stats))?;
             }
         }
     }
@@ -219,11 +274,11 @@ where
 
 fn draw_attached_dashboard(
     f: &mut ratatui::Frame,
-    state: Option<&DashboardState>,
+    attached: &AttachedDashboard,
     local_system_stats: &SystemStats,
 ) {
-    if let Some(state) = state {
-        ui::render_ui(f, state, Some(local_system_stats));
+    if let Some(state) = attached.latest_state.as_ref() {
+        ui::render_ui(f, state, Some(local_system_stats), Some(&attached.status));
         return;
     }
 
@@ -241,12 +296,12 @@ fn draw_attached_dashboard(
         "NNTP Proxy "
             .fg(crate::tui::constants::styles::BORDER_ACTIVE)
             .bold(),
-        "- Remote Dashboard".fg(Color::White),
+        "- Attached Dashboard".fg(Color::White),
     ]))
     .alignment(Alignment::Center);
 
-    let body =
-        Paragraph::new(Line::from("Connecting to dashboard...")).alignment(Alignment::Center);
+    let body = Paragraph::new(build_attached_placeholder_lines(&attached.status))
+        .alignment(Alignment::Center);
 
     let footer = Paragraph::new(Line::from(vec![
         "Press ".fg(crate::tui::constants::styles::LABEL),
@@ -260,6 +315,41 @@ fn draw_attached_dashboard(
     f.render_widget(title, chunks[0]);
     f.render_widget(body, chunks[1]);
     f.render_widget(footer, chunks[2]);
+}
+
+fn build_attached_placeholder_lines(status: &RemoteDashboardStatus) -> Vec<Line<'static>> {
+    match status {
+        RemoteDashboardStatus::Connecting { target } => vec![
+            Line::from(vec![
+                "Connecting to ".fg(styles::LABEL),
+                target.to_string().fg(styles::VALUE_INFO).bold(),
+                "...".fg(styles::LABEL),
+            ]),
+            Line::from("Waiting for the first dashboard snapshot."),
+        ],
+        RemoteDashboardStatus::Connected { target } => vec![
+            Line::from(vec![
+                "Connected to ".fg(styles::LABEL),
+                target.to_string().fg(styles::VALUE_PRIMARY).bold(),
+            ]),
+            Line::from("Waiting for the first dashboard snapshot."),
+        ],
+        RemoteDashboardStatus::Reconnecting {
+            target,
+            retry_delay,
+            last_error,
+        } => vec![
+            Line::from(vec![
+                "Reconnecting to ".fg(styles::LABEL),
+                target.to_string().fg(Color::Yellow).bold(),
+                format!(" in {:.1}s", retry_delay.as_secs_f32()).fg(styles::LABEL),
+            ]),
+            Line::from(vec![
+                "Last error: ".fg(styles::LABEL),
+                last_error.clone().fg(Color::Yellow),
+            ]),
+        ],
+    }
 }
 
 fn key_event_action(
@@ -362,5 +452,39 @@ mod tests {
 
         assert_eq!(key_event_action(released, true), TuiInputAction::None);
         assert_eq!(key_event_action(other, true), TuiInputAction::None);
+    }
+
+    #[test]
+    fn attached_placeholder_lines_reflect_connection_state() {
+        let connecting = build_attached_placeholder_lines(&RemoteDashboardStatus::Connecting {
+            target: "127.0.0.1:8120".parse().unwrap(),
+        })
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+        let reconnecting = build_attached_placeholder_lines(&RemoteDashboardStatus::Reconnecting {
+            target: "127.0.0.1:8120".parse().unwrap(),
+            retry_delay: Duration::from_secs(1),
+            last_error: "connection refused".to_string(),
+        })
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+
+        assert!(
+            connecting
+                .iter()
+                .any(|line| line.contains("Connecting to 127.0.0.1:8120"))
+        );
+        assert!(
+            reconnecting
+                .iter()
+                .any(|line| line.contains("Reconnecting to 127.0.0.1:8120 in 1.0s"))
+        );
+        assert!(
+            reconnecting
+                .iter()
+                .any(|line| line.contains("Last error: connection refused"))
+        );
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4,8 +4,10 @@
 
 mod app;
 mod constants;
+mod dashboard;
 mod helpers;
 pub mod log_capture;
+mod remote;
 mod system_stats;
 mod types;
 mod ui;
@@ -13,7 +15,9 @@ mod ui;
 mod ui_tests;
 
 pub use app::{TuiApp, TuiAppBuilder, ViewMode};
+pub use dashboard::{BackendView, BufferPoolStats, DashboardState};
 pub use log_capture::{LogBuffer, LogMakeWriter};
+pub use remote::{run_dashboard_publisher, spawn_dashboard_reader};
 pub use system_stats::{SystemMonitor, SystemStats};
 pub use ui::render_ui;
 
@@ -24,7 +28,14 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
+use ratatui::{
+    layout::{Alignment, Constraint, Direction, Layout},
+    style::{Color, Stylize},
+    text::Line,
+    widgets::Paragraph,
+};
 use std::io;
+use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -96,6 +107,26 @@ pub async fn run_tui(
     result
 }
 
+/// Run the TUI as a remote dashboard client connected to a headless publisher.
+pub async fn run_attached_tui(connect_addr: SocketAddr) -> Result<()> {
+    let mut terminal = setup_terminal()?;
+
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+        original_hook(panic_info);
+    }));
+
+    let (state_tx, mut state_rx) = tokio::sync::watch::channel(None::<DashboardState>);
+    let _reader = spawn_dashboard_reader(connect_addr, state_tx);
+
+    let result = run_attached_app(&mut terminal, &mut state_rx).await;
+
+    restore_terminal(&mut terminal)?;
+    result
+}
+
 /// Main TUI event loop
 async fn run_app<B: ratatui::backend::Backend>(
     terminal: &mut Terminal<B>,
@@ -109,7 +140,7 @@ where
     let mut update_interval = tokio::time::interval(Duration::from_millis(250));
 
     // Initial render
-    terminal.draw(|f| ui::render_ui(f, app))?;
+    terminal.draw(|f| ui::render_ui(f, &app.snapshot_state()))?;
 
     let mut should_quit = false;
 
@@ -152,10 +183,102 @@ where
                     break;
                 }
 
-                terminal.draw(|f| ui::render_ui(f, app))?;
+                terminal.draw(|f| ui::render_ui(f, &app.snapshot_state()))?;
             }
         }
     }
 
     Ok(())
+}
+
+async fn run_attached_app<B: ratatui::backend::Backend>(
+    terminal: &mut Terminal<B>,
+    state_rx: &mut tokio::sync::watch::Receiver<Option<DashboardState>>,
+) -> Result<()>
+where
+    B::Error: Send + Sync + 'static,
+{
+    let mut update_interval = tokio::time::interval(Duration::from_millis(250));
+    let mut should_quit = false;
+
+    let state = state_rx.borrow().clone();
+    terminal.draw(|f| draw_attached_dashboard(f, state.as_ref()))?;
+
+    loop {
+        tokio::select! {
+            _ = update_interval.tick() => {
+                let has_events = tokio::task::spawn_blocking(|| {
+                    event::poll(Duration::from_millis(0))
+                }).await??;
+
+                if has_events {
+                    let key_event = tokio::task::spawn_blocking(|| {
+                        event::read()
+                    }).await??;
+
+                    if let Event::Key(key) = key_event
+                        && key.kind == KeyEventKind::Press
+                    {
+                        match key.code {
+                            KeyCode::Char('q') | KeyCode::Esc => should_quit = true,
+                            KeyCode::Char('c') if key.modifiers.contains(event::KeyModifiers::CONTROL) => {
+                                should_quit = true;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+
+                if should_quit {
+                    break;
+                }
+
+                let state = state_rx.borrow().clone();
+                terminal.draw(|f| draw_attached_dashboard(f, state.as_ref()))?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn draw_attached_dashboard(f: &mut ratatui::Frame, state: Option<&DashboardState>) {
+    if let Some(state) = state {
+        ui::render_ui(f, state);
+        return;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(3),
+        ])
+        .split(f.area());
+
+    let title = Paragraph::new(Line::from(vec![
+        "NNTP Proxy "
+            .fg(crate::tui::constants::styles::BORDER_ACTIVE)
+            .bold(),
+        "- Remote Dashboard".fg(Color::White),
+    ]))
+    .alignment(Alignment::Center);
+
+    let body =
+        Paragraph::new(Line::from("Connecting to dashboard...")).alignment(Alignment::Center);
+
+    let footer = Paragraph::new(Line::from(vec![
+        "Press ".fg(crate::tui::constants::styles::LABEL),
+        "q".fg(crate::tui::constants::styles::VALUE_INFO).bold(),
+        " or ".fg(crate::tui::constants::styles::LABEL),
+        "Esc".fg(crate::tui::constants::styles::VALUE_INFO).bold(),
+        " to exit".fg(crate::tui::constants::styles::LABEL),
+    ]))
+    .alignment(Alignment::Center);
+
+    f.render_widget(title, chunks[0]);
+    f.render_widget(body, chunks[1]);
+    f.render_widget(footer, chunks[2]);
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -182,6 +182,10 @@ pub async fn run_tui(
 
 /// Run the TUI as a remote dashboard client connected to a headless publisher.
 pub async fn run_attached_tui(connect_addr: SocketAddr) -> Result<()> {
+    anyhow::ensure!(
+        connect_addr.ip().is_loopback(),
+        "Attached dashboard client must connect to a loopback address: {connect_addr}"
+    );
     let (state_tx, mut state_rx) =
         tokio::sync::watch::channel(AttachedDashboard::connecting(connect_addr));
     let _reader = spawn_dashboard_reader(connect_addr, state_tx);
@@ -488,5 +492,14 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("Last error: connection refused"))
         );
+    }
+
+    #[tokio::test]
+    async fn run_attached_tui_rejects_non_loopback_target() {
+        let err = run_attached_tui("10.0.0.5:8120".parse().unwrap())
+            .await
+            .expect_err("non-loopback attach should fail");
+
+        assert!(format!("{err:#}").contains("must connect to a loopback address"));
     }
 }

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -2,6 +2,7 @@
 
 use crate::tui::TuiApp;
 use crate::tui::dashboard::DashboardState;
+use anyhow::Context;
 use futures::{Sink, SinkExt, Stream, StreamExt, TryStreamExt, future, stream};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -98,7 +99,9 @@ pub async fn run_dashboard_publisher(
     listen_addr: SocketAddr,
     mut shutdown_rx: tokio::sync::mpsc::Receiver<()>,
 ) -> anyhow::Result<()> {
-    let listener = TcpListener::bind(listen_addr).await?;
+    let listener = TcpListener::bind(listen_addr)
+        .await
+        .with_context(|| format!("Failed to bind dashboard websocket listener at {listen_addr}"))?;
     let (state_tx, _state_rx) = watch::channel(Arc::new(app.snapshot_state()));
     let mut update_interval = tokio::time::interval(Duration::from_millis(250));
     update_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -249,6 +252,22 @@ mod tests {
             .is_none()
         );
         assert!(dashboard_state_from_message(Ok(Message::Text("{not-json}".into()))).is_none());
+    }
+
+    #[tokio::test]
+    async fn dashboard_publisher_bind_error_mentions_dashboard_listener() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test port");
+        let addr = listener.local_addr().expect("local addr");
+        let (_shutdown_tx, shutdown_rx) = mpsc::channel::<()>(1);
+
+        let err = run_dashboard_publisher(build_test_app(), addr, shutdown_rx)
+            .await
+            .expect_err("bind should fail");
+
+        let err = format!("{err:#}");
+        assert!(err.contains("Failed to bind dashboard websocket listener"));
     }
 
     #[tokio::test]

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -2,6 +2,7 @@
 
 use crate::tui::TuiApp;
 use crate::tui::dashboard::DashboardState;
+use crate::tui::{AttachedDashboard, RemoteDashboardStatus};
 use anyhow::Context;
 use futures::{Sink, SinkExt, Stream, StreamExt, TryStreamExt, future, stream};
 use std::net::SocketAddr;
@@ -131,9 +132,11 @@ pub async fn run_dashboard_publisher(
     listen_addr: SocketAddr,
     mut shutdown_rx: tokio::sync::mpsc::Receiver<()>,
 ) -> anyhow::Result<()> {
-    let listener = TcpListener::bind(listen_addr)
-        .await
-        .with_context(|| format!("Failed to bind dashboard websocket listener at {listen_addr}"))?;
+    let listener = TcpListener::bind(listen_addr).await.with_context(|| {
+        format!(
+            "Failed to bind dashboard websocket listener at {listen_addr}; ensure that socket is free and distinct from the proxy listener"
+        )
+    })?;
     let (state_tx, _state_rx) = watch::channel(Arc::new(app.snapshot_state()));
     let mut update_interval = tokio::time::interval(Duration::from_millis(250));
     update_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -158,16 +161,16 @@ pub async fn run_dashboard_publisher(
 }
 
 /// Spawn a background task that keeps the attached TUI synced to a websocket dashboard.
-pub fn spawn_dashboard_reader(
+pub(crate) fn spawn_dashboard_reader(
     connect_addr: SocketAddr,
-    state_tx: watch::Sender<Option<DashboardState>>,
+    state_tx: watch::Sender<AttachedDashboard>,
 ) -> tokio::task::JoinHandle<()> {
     spawn_dashboard_reader_with_retry_delay(connect_addr, state_tx, Duration::from_secs(1))
 }
 
 fn spawn_dashboard_reader_with_retry_delay(
     connect_addr: SocketAddr,
-    state_tx: watch::Sender<Option<DashboardState>>,
+    state_tx: watch::Sender<AttachedDashboard>,
     retry_delay: Duration,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
@@ -184,8 +187,16 @@ fn spawn_dashboard_reader_with_retry_delay(
                 break;
             }
 
+            let last_error = retry_reason(&session_result);
+            let last_snapshot = state_tx.borrow().latest_state.clone();
+            let _ = state_tx.send(AttachedDashboard::reconnecting(
+                connect_addr,
+                retry_delay,
+                last_snapshot,
+                last_error.clone(),
+            ));
             warn!(
-                "Attached dashboard websocket disconnected or unavailable; retrying in {retry_delay:?}"
+                "Attached dashboard websocket disconnected or unavailable; retrying in {retry_delay:?}: {last_error}"
             );
             tokio::time::sleep(retry_delay).await;
             info!("Reconnecting attached dashboard client to {ws_url}");
@@ -199,14 +210,20 @@ fn dashboard_reader_should_retry(outcome: &anyhow::Result<ReaderSessionOutcome>)
 
 async fn dashboard_reader_session(
     ws_url: &str,
-    state_tx: watch::Sender<Option<DashboardState>>,
+    state_tx: watch::Sender<AttachedDashboard>,
 ) -> anyhow::Result<ReaderSessionOutcome> {
-    let Ok((ws_stream, _)) = connect_async(ws_url).await else {
-        warn!("Failed to connect attached dashboard client to {ws_url}");
-        return Ok(ReaderSessionOutcome::RetryAfterDelay);
+    let connect_addr = dashboard_target_from_ws_url(ws_url)?;
+    let (ws_stream, _) = match connect_async(ws_url).await {
+        Ok(connection) => connection,
+        Err(err) => {
+            warn!("Failed to connect attached dashboard client to {ws_url}: {err}");
+            return Ok(ReaderSessionOutcome::RetryAfterDelay);
+        }
     };
 
     info!("Attached dashboard websocket connected to {ws_url}");
+    let last_snapshot = state_tx.borrow().latest_state.clone();
+    let _ = state_tx.send(AttachedDashboard::connected(connect_addr, last_snapshot));
     let (_, source) = ws_stream.split();
     forward_dashboard_states(source, state_tx).await.map(|_| {
         warn!("Attached dashboard websocket stream ended for {ws_url}");
@@ -216,7 +233,7 @@ async fn dashboard_reader_session(
 
 async fn forward_dashboard_states<S>(
     source: S,
-    state_tx: watch::Sender<Option<DashboardState>>,
+    state_tx: watch::Sender<AttachedDashboard>,
 ) -> anyhow::Result<()>
 where
     S: Stream<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
@@ -224,13 +241,35 @@ where
     dashboard_source_stream(source)
         .map(Ok::<DashboardState, anyhow::Error>)
         .try_fold(state_tx, |state_tx, state| async move {
+            let connect_addr = match &state_tx.borrow().status {
+                RemoteDashboardStatus::Connecting { target }
+                | RemoteDashboardStatus::Connected { target }
+                | RemoteDashboardStatus::Reconnecting { target, .. } => *target,
+            };
             state_tx
-                .send(Some(state))
+                .send(AttachedDashboard::connected(connect_addr, Some(state)))
                 .map_err(|_| anyhow::anyhow!("attached dashboard state receiver dropped"))?;
             Ok::<_, anyhow::Error>(state_tx)
         })
         .await
         .map(|_| ())
+}
+
+fn retry_reason(outcome: &anyhow::Result<ReaderSessionOutcome>) -> String {
+    outcome
+        .as_ref()
+        .map(|_| "connection dropped".to_string())
+        .unwrap_or_else(|err| err.to_string())
+}
+
+fn dashboard_target_from_ws_url(ws_url: &str) -> anyhow::Result<SocketAddr> {
+    ws_url
+        .strip_prefix("ws://")
+        .context("dashboard websocket URL must start with ws://")?
+        .parse()
+        .with_context(|| {
+            format!("dashboard websocket URL contains an invalid socket address: {ws_url}")
+        })
 }
 
 #[cfg(test)]
@@ -319,6 +358,25 @@ mod tests {
         ))));
     }
 
+    #[test]
+    fn retry_reason_prefers_source_error_text() {
+        assert_eq!(
+            retry_reason(&Ok(ReaderSessionOutcome::RetryAfterDelay)),
+            "connection dropped"
+        );
+        assert_eq!(
+            retry_reason(&Err(anyhow::anyhow!("connection refused"))),
+            "connection refused"
+        );
+    }
+
+    #[test]
+    fn dashboard_target_from_ws_url_parses_socket_addresses() {
+        let addr = dashboard_target_from_ws_url("ws://127.0.0.1:8120").expect("target addr");
+        assert_eq!(addr, "127.0.0.1:8120".parse().unwrap());
+        assert!(dashboard_target_from_ws_url("http://127.0.0.1:8120").is_err());
+    }
+
     #[tokio::test]
     async fn publish_dashboard_snapshot_updates_watch_channel() {
         let mut app = build_test_app();
@@ -346,6 +404,7 @@ mod tests {
 
         let err = format!("{err:#}");
         assert!(err.contains("Failed to bind dashboard websocket listener"));
+        assert!(err.contains("ensure that socket is free"));
     }
 
     #[tokio::test]
@@ -356,7 +415,7 @@ mod tests {
         let addr = listener.local_addr().expect("local addr");
         drop(listener);
 
-        let (state_tx, _state_rx) = watch::channel(None::<DashboardState>);
+        let (state_tx, _state_rx) = watch::channel(AttachedDashboard::connecting(addr));
         let outcome = dashboard_reader_session(&format!("ws://{addr}"), state_tx)
             .await
             .expect("reader session");
@@ -365,13 +424,13 @@ mod tests {
     }
 
     async fn wait_for_log_lines(
-        state_rx: &mut watch::Receiver<Option<DashboardState>>,
+        state_rx: &mut watch::Receiver<AttachedDashboard>,
         expected: &[&str],
         timeout: Duration,
     ) -> DashboardState {
         tokio::time::timeout(timeout, async {
             loop {
-                if let Some(state) = state_rx.borrow().clone()
+                if let Some(state) = state_rx.borrow().latest_state.clone()
                     && state
                         .log_lines
                         .iter()
@@ -438,7 +497,8 @@ mod tests {
 
     #[tokio::test]
     async fn reader_applies_latest_state() {
-        let (state_tx, mut state_rx) = watch::channel(None::<DashboardState>);
+        let connect_addr: SocketAddr = "127.0.0.1:8120".parse().unwrap();
+        let (state_tx, mut state_rx) = watch::channel(AttachedDashboard::connecting(connect_addr));
 
         let first = DashboardState {
             snapshot: MetricsSnapshot::default(),
@@ -483,6 +543,12 @@ mod tests {
 
         assert_eq!(observed.log_lines, vec!["second".to_string()]);
         assert!(observed.show_details);
+        assert_eq!(
+            state_rx.borrow().status,
+            RemoteDashboardStatus::Connected {
+                target: connect_addr
+            }
+        );
     }
 
     #[tokio::test]
@@ -492,7 +558,7 @@ mod tests {
             .expect("bind test port");
         let addr = listener.local_addr().expect("local addr");
 
-        let (state_tx, mut state_rx) = watch::channel(None::<DashboardState>);
+        let (state_tx, mut state_rx) = watch::channel(AttachedDashboard::connecting(addr));
         let reader =
             spawn_dashboard_reader_with_retry_delay(addr, state_tx, Duration::from_millis(25));
 
@@ -532,6 +598,7 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(100)).await;
         let latest = state_rx
             .borrow()
+            .latest_state
             .clone()
             .expect("state should remain present");
         assert_eq!(latest.log_lines, vec!["good".to_string()]);
@@ -548,7 +615,7 @@ mod tests {
             .expect("bind test port");
         let addr = listener.local_addr().expect("local addr");
 
-        let (state_tx, mut state_rx) = watch::channel(None::<DashboardState>);
+        let (state_tx, mut state_rx) = watch::channel(AttachedDashboard::connecting(addr));
         let reader =
             spawn_dashboard_reader_with_retry_delay(addr, state_tx, Duration::from_millis(25));
 
@@ -582,8 +649,26 @@ mod tests {
         let first_observed =
             wait_for_log_lines(&mut state_rx, &["first"], Duration::from_secs(3)).await;
         assert_eq!(first_observed.log_lines, vec!["first".to_string()]);
+        assert_eq!(
+            state_rx.borrow().status,
+            RemoteDashboardStatus::Connected { target: addr }
+        );
 
         drop(first_ws);
+
+        tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                if matches!(
+                    &state_rx.borrow().status,
+                    RemoteDashboardStatus::Reconnecting { target, .. } if *target == addr
+                ) {
+                    break;
+                }
+                state_rx.changed().await.expect("reader still alive");
+            }
+        })
+        .await
+        .expect("reader should enter reconnecting state");
 
         let second_conn = tokio::time::timeout(Duration::from_secs(5), listener.accept())
             .await
@@ -625,6 +710,10 @@ mod tests {
         assert_eq!(
             second_observed.buffer_pool.as_ref().map(|pool| pool.total),
             Some(3)
+        );
+        assert_eq!(
+            state_rx.borrow().status,
+            RemoteDashboardStatus::Connected { target: addr }
         );
 
         drop(second_ws);

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -385,20 +385,7 @@ mod tests {
 
     #[tokio::test]
     async fn reader_applies_latest_state() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("bind test port");
-        let addr = listener.local_addr().expect("local addr");
-
         let (state_tx, mut state_rx) = watch::channel(None::<DashboardState>);
-        let reader =
-            spawn_dashboard_reader_with_retry_delay(addr, state_tx, Duration::from_millis(25));
-
-        let (stream, _) = tokio::time::timeout(Duration::from_secs(3), listener.accept())
-            .await
-            .expect("reader should connect")
-            .expect("accept reader connection");
-        let mut ws = accept_async(stream).await.expect("accept websocket");
 
         let first = DashboardState {
             snapshot: MetricsSnapshot::default(),
@@ -422,29 +409,27 @@ mod tests {
         second.log_lines = vec!["second".to_string()];
         second.show_details = true;
 
-        ws.send(Message::Text(
-            serde_json::to_string(&first)
-                .expect("serialize first")
-                .into(),
-        ))
-        .await
-        .expect("send first state");
-        ws.send(Message::Text(
-            serde_json::to_string(&second)
-                .expect("serialize second")
-                .into(),
-        ))
-        .await
-        .expect("send second state");
+        let source = stream::iter(vec![
+            Ok(Message::Text(
+                serde_json::to_string(&first)
+                    .expect("serialize first")
+                    .into(),
+            )),
+            Ok(Message::Text(
+                serde_json::to_string(&second)
+                    .expect("serialize second")
+                    .into(),
+            )),
+        ]);
+
+        forward_dashboard_states(source, state_tx)
+            .await
+            .expect("forward dashboard states");
 
         let observed = wait_for_log_lines(&mut state_rx, &["second"], Duration::from_secs(3)).await;
 
         assert_eq!(observed.log_lines, vec!["second".to_string()]);
         assert!(observed.show_details);
-
-        let _ = ws.close(None).await;
-        reader.abort();
-        let _ = reader.await;
     }
 
     #[tokio::test]

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -175,10 +175,15 @@ fn spawn_dashboard_reader_with_retry_delay(
 
         info!("Connecting attached dashboard client to {ws_url}");
 
-        while matches!(
-            dashboard_reader_session(&ws_url, state_tx.clone()).await,
-            Ok(ReaderSessionOutcome::RetryAfterDelay)
-        ) {
+        loop {
+            let session_result = dashboard_reader_session(&ws_url, state_tx.clone()).await;
+            if !dashboard_reader_should_retry(&session_result) {
+                if let Err(err) = session_result {
+                    warn!("Attached dashboard websocket reader stopped for {ws_url}: {err}");
+                }
+                break;
+            }
+
             warn!(
                 "Attached dashboard websocket disconnected or unavailable; retrying in {retry_delay:?}"
             );
@@ -186,6 +191,10 @@ fn spawn_dashboard_reader_with_retry_delay(
             info!("Reconnecting attached dashboard client to {ws_url}");
         }
     })
+}
+
+fn dashboard_reader_should_retry(outcome: &anyhow::Result<ReaderSessionOutcome>) -> bool {
+    matches!(outcome, Ok(ReaderSessionOutcome::RetryAfterDelay))
 }
 
 async fn dashboard_reader_session(
@@ -298,6 +307,16 @@ mod tests {
             dashboard_peer_label(Some("127.0.0.1:1234".parse().unwrap())),
             " from 127.0.0.1:1234"
         );
+    }
+
+    #[test]
+    fn dashboard_reader_should_retry_only_for_retry_outcomes() {
+        assert!(dashboard_reader_should_retry(&Ok(
+            ReaderSessionOutcome::RetryAfterDelay
+        )));
+        assert!(!dashboard_reader_should_retry(&Err(anyhow::anyhow!(
+            "boom"
+        ))));
     }
 
     #[tokio::test]

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -111,6 +111,20 @@ async fn handle_dashboard_client(
     Ok(())
 }
 
+fn spawn_dashboard_client_task(stream: TcpStream, state_rx: watch::Receiver<Arc<DashboardState>>) {
+    tokio::spawn(async move {
+        if let Err(err) = handle_dashboard_client(stream, state_rx).await {
+            warn!("Dashboard websocket client error: {err}");
+        }
+    });
+}
+
+fn publish_dashboard_snapshot(app: &mut TuiApp, state_tx: &watch::Sender<Arc<DashboardState>>) {
+    app.update();
+    let state = Arc::new(app.snapshot_state());
+    let _ = state_tx.send(state);
+}
+
 /// Run the headless dashboard websocket publisher.
 pub async fn run_dashboard_publisher(
     mut app: TuiApp,
@@ -130,18 +144,12 @@ pub async fn run_dashboard_publisher(
                 break;
             }
             _ = update_interval.tick() => {
-                app.update();
-                let state = Arc::new(app.snapshot_state());
-                let _ = state_tx.send(state);
+                publish_dashboard_snapshot(&mut app, &state_tx);
             }
             accept_result = listener.accept() => {
                 let (stream, _) = accept_result?;
                 let rx = state_tx.subscribe();
-                tokio::spawn(async move {
-                    if let Err(err) = handle_dashboard_client(stream, rx).await {
-                        warn!("Dashboard websocket client error: {err}");
-                    }
-                });
+                spawn_dashboard_client_task(stream, rx);
             }
         }
     }
@@ -290,6 +298,19 @@ mod tests {
             dashboard_peer_label(Some("127.0.0.1:1234".parse().unwrap())),
             " from 127.0.0.1:1234"
         );
+    }
+
+    #[tokio::test]
+    async fn publish_dashboard_snapshot_updates_watch_channel() {
+        let mut app = build_test_app();
+        let (state_tx, mut state_rx) = watch::channel(Arc::new(app.snapshot_state()));
+
+        publish_dashboard_snapshot(&mut app, &state_tx);
+
+        state_rx.changed().await.expect("snapshot should update");
+        let snapshot = state_rx.borrow().clone();
+        assert_eq!(snapshot.backend_views.len(), 1);
+        assert_eq!(snapshot.view_mode, ViewMode::Normal);
     }
 
     #[tokio::test]

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -322,10 +322,10 @@ fn dashboard_target_from_ws_url(ws_url: &str) -> anyhow::Result<SocketAddr> {
 mod tests {
     use super::*;
     use crate::config::Server;
-    use crate::metrics::{MetricsCollector, MetricsSnapshot};
+    use crate::metrics::MetricsCollector;
     use crate::router::BackendSelector;
     use crate::tui::app::{ThroughputPoint, ViewMode};
-    use crate::tui::dashboard::BufferPoolStats;
+    use crate::tui::dashboard::{BufferPoolStats, DashboardMetrics};
     use crate::types::Port;
     use crate::types::tui::{Throughput, Timestamp};
     use std::sync::Arc;
@@ -354,17 +354,25 @@ mod tests {
         TuiApp::new(metrics, router, servers)
     }
 
-    #[test]
-    fn dashboard_state_from_message_parses_text_frames() {
-        let state = DashboardState {
-            snapshot: MetricsSnapshot::default(),
+    fn empty_dashboard_state() -> DashboardState {
+        DashboardState {
+            metrics: DashboardMetrics::default(),
             backend_views: Vec::new(),
+            top_users: Vec::new(),
             client_history: Vec::new(),
             system_stats: crate::tui::SystemStats::default(),
             view_mode: ViewMode::Normal,
             show_details: false,
-            log_lines: vec!["hello".to_string()],
+            log_lines: Vec::new(),
             buffer_pool: None,
+        }
+    }
+
+    #[test]
+    fn dashboard_state_from_message_parses_text_frames() {
+        let state = DashboardState {
+            log_lines: vec!["hello".to_string()],
+            ..empty_dashboard_state()
         };
         let message = Message::Text(serde_json::to_string(&state).unwrap().into());
 
@@ -572,13 +580,14 @@ mod tests {
         let (state_tx, mut state_rx) = watch::channel(AttachedDashboard::connecting(connect_addr));
 
         let first = DashboardState {
-            snapshot: MetricsSnapshot::default(),
             backend_views: Vec::new(),
+            top_users: Vec::new(),
             client_history: vec![ThroughputPoint::new_client(
                 Timestamp::now(),
                 Throughput::new(1.0),
                 Throughput::new(2.0),
             )],
+            metrics: DashboardMetrics::default(),
             system_stats: crate::tui::SystemStats::default(),
             view_mode: ViewMode::Normal,
             show_details: false,
@@ -640,14 +649,8 @@ mod tests {
         let mut ws = accept_async(stream).await.expect("accept websocket");
 
         let good = DashboardState {
-            snapshot: MetricsSnapshot::default(),
-            backend_views: Vec::new(),
-            client_history: Vec::new(),
-            system_stats: crate::tui::SystemStats::default(),
-            view_mode: ViewMode::Normal,
-            show_details: false,
             log_lines: vec!["good".to_string()],
-            buffer_pool: None,
+            ..empty_dashboard_state()
         };
 
         ws.send(Message::Text(
@@ -699,14 +702,8 @@ mod tests {
             .expect("accept initial websocket");
 
         let first = DashboardState {
-            snapshot: MetricsSnapshot::default(),
-            backend_views: Vec::new(),
-            client_history: Vec::new(),
-            system_stats: crate::tui::SystemStats::default(),
-            view_mode: ViewMode::Normal,
-            show_details: false,
             log_lines: vec!["first".to_string()],
-            buffer_pool: None,
+            ..empty_dashboard_state()
         };
         first_ws
             .send(Message::Text(
@@ -750,10 +747,6 @@ mod tests {
             .expect("accept reconnect websocket");
 
         let second = DashboardState {
-            snapshot: MetricsSnapshot::default(),
-            backend_views: Vec::new(),
-            client_history: Vec::new(),
-            system_stats: crate::tui::SystemStats::default(),
             view_mode: ViewMode::LogFullscreen,
             show_details: true,
             log_lines: vec!["second".to_string()],
@@ -762,6 +755,7 @@ mod tests {
                 in_use: 1,
                 total: 3,
             }),
+            ..empty_dashboard_state()
         };
         second_ws
             .send(Message::Text(

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::watch;
 use tokio_tungstenite::{accept_async, connect_async, tungstenite::Message};
+use tracing::{info, warn};
 
 #[allow(clippy::cast_precision_loss)]
 fn dashboard_message(state: &DashboardState) -> anyhow::Result<Message> {
@@ -83,6 +84,13 @@ async fn handle_dashboard_client(
     stream: TcpStream,
     state_rx: watch::Receiver<Arc<DashboardState>>,
 ) -> anyhow::Result<()> {
+    let peer_addr = stream.peer_addr().ok();
+    if let Some(peer_addr) = peer_addr {
+        info!("Dashboard websocket client connected from {peer_addr}");
+    } else {
+        info!("Dashboard websocket client connected");
+    }
+
     let ws_stream = accept_async(stream).await?;
     let (sink, source) = ws_stream.split();
 
@@ -90,6 +98,12 @@ async fn handle_dashboard_client(
         send_dashboard_state_stream(sink, state_rx),
         drain_dashboard_source(source)
     )?;
+
+    if let Some(peer_addr) = peer_addr {
+        info!("Dashboard websocket client disconnected from {peer_addr}");
+    } else {
+        info!("Dashboard websocket client disconnected");
+    }
     Ok(())
 }
 
@@ -120,7 +134,9 @@ pub async fn run_dashboard_publisher(
                 let (stream, _) = accept_result?;
                 let rx = state_tx.subscribe();
                 tokio::spawn(async move {
-                    let _ = handle_dashboard_client(stream, rx).await;
+                    if let Err(err) = handle_dashboard_client(stream, rx).await {
+                        warn!("Dashboard websocket client error: {err}");
+                    }
                 });
             }
         }
@@ -145,11 +161,17 @@ fn spawn_dashboard_reader_with_retry_delay(
     tokio::spawn(async move {
         let ws_url = format!("ws://{connect_addr}");
 
+        info!("Connecting attached dashboard client to {ws_url}");
+
         while matches!(
             dashboard_reader_session(&ws_url, state_tx.clone()).await,
             Ok(ReaderSessionOutcome::RetryAfterDelay)
         ) {
+            warn!(
+                "Attached dashboard websocket disconnected or unavailable; retrying in {retry_delay:?}"
+            );
             tokio::time::sleep(retry_delay).await;
+            info!("Reconnecting attached dashboard client to {ws_url}");
         }
     })
 }
@@ -159,13 +181,16 @@ async fn dashboard_reader_session(
     state_tx: watch::Sender<Option<DashboardState>>,
 ) -> anyhow::Result<ReaderSessionOutcome> {
     let Ok((ws_stream, _)) = connect_async(ws_url).await else {
+        warn!("Failed to connect attached dashboard client to {ws_url}");
         return Ok(ReaderSessionOutcome::RetryAfterDelay);
     };
 
+    info!("Attached dashboard websocket connected to {ws_url}");
     let (_, source) = ws_stream.split();
-    forward_dashboard_states(source, state_tx)
-        .await
-        .map(|_| ReaderSessionOutcome::RetryAfterDelay)
+    forward_dashboard_states(source, state_tx).await.map(|_| {
+        warn!("Attached dashboard websocket stream ended for {ws_url}");
+        ReaderSessionOutcome::RetryAfterDelay
+    })
 }
 
 async fn forward_dashboard_states<S>(

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -1,0 +1,552 @@
+//! WebSocket transport for attached and headless dashboard modes.
+
+use crate::tui::TuiApp;
+use crate::tui::dashboard::DashboardState;
+use futures::{Sink, SinkExt, Stream, StreamExt, TryStreamExt, future, stream};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::watch;
+use tokio_tungstenite::{accept_async, connect_async, tungstenite::Message};
+
+#[allow(clippy::cast_precision_loss)]
+fn dashboard_message(state: &DashboardState) -> anyhow::Result<Message> {
+    Ok(Message::Text(serde_json::to_string(state)?.into()))
+}
+
+fn dashboard_state_from_message(
+    message: Result<Message, tokio_tungstenite::tungstenite::Error>,
+) -> Option<DashboardState> {
+    match message {
+        Ok(Message::Text(text)) => serde_json::from_str::<DashboardState>(text.as_str()).ok(),
+        _ => None,
+    }
+}
+
+fn dashboard_state_stream(
+    state_rx: watch::Receiver<Arc<DashboardState>>,
+) -> impl Stream<Item = Arc<DashboardState>> {
+    let initial_state = state_rx.borrow().clone();
+    let updates = stream::unfold(state_rx, |mut state_rx| async move {
+        if state_rx.changed().await.is_ok() {
+            let state = state_rx.borrow().clone();
+            Some((state, state_rx))
+        } else {
+            None
+        }
+    });
+
+    stream::once(async move { initial_state }).chain(updates)
+}
+
+fn dashboard_source_stream(
+    source: impl Stream<Item = Result<Message, tokio_tungstenite::tungstenite::Error>>,
+) -> impl Stream<Item = DashboardState> {
+    source.filter_map(|message| async move { dashboard_state_from_message(message) })
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReaderSessionOutcome {
+    RetryAfterDelay,
+}
+
+async fn send_dashboard_state_stream<S>(
+    sink: S,
+    state_rx: watch::Receiver<Arc<DashboardState>>,
+) -> anyhow::Result<()>
+where
+    S: Sink<Message, Error = tokio_tungstenite::tungstenite::Error> + Unpin,
+{
+    dashboard_state_stream(state_rx)
+        .map(|state| dashboard_message(state.as_ref()))
+        .try_fold(sink, |mut sink, message| async move {
+            sink.send(message).await?;
+            Ok::<_, anyhow::Error>(sink)
+        })
+        .await
+        .map(|_| ())
+}
+
+async fn drain_dashboard_source<S>(source: S) -> anyhow::Result<()>
+where
+    S: Stream<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
+{
+    dashboard_source_stream(source)
+        .for_each(|_| future::ready(()))
+        .await;
+    Ok(())
+}
+
+async fn handle_dashboard_client(
+    stream: TcpStream,
+    state_rx: watch::Receiver<Arc<DashboardState>>,
+) -> anyhow::Result<()> {
+    let ws_stream = accept_async(stream).await?;
+    let (sink, source) = ws_stream.split();
+
+    futures::try_join!(
+        send_dashboard_state_stream(sink, state_rx),
+        drain_dashboard_source(source)
+    )?;
+    Ok(())
+}
+
+/// Run the headless dashboard websocket publisher.
+pub async fn run_dashboard_publisher(
+    mut app: TuiApp,
+    listen_addr: SocketAddr,
+    mut shutdown_rx: tokio::sync::mpsc::Receiver<()>,
+) -> anyhow::Result<()> {
+    let listener = TcpListener::bind(listen_addr).await?;
+    let (state_tx, _state_rx) = watch::channel(Arc::new(app.snapshot_state()));
+    let mut update_interval = tokio::time::interval(Duration::from_millis(250));
+    update_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = shutdown_rx.recv() => {
+                break;
+            }
+            _ = update_interval.tick() => {
+                app.update();
+                let state = Arc::new(app.snapshot_state());
+                let _ = state_tx.send(state);
+            }
+            accept_result = listener.accept() => {
+                let (stream, _) = accept_result?;
+                let rx = state_tx.subscribe();
+                tokio::spawn(async move {
+                    let _ = handle_dashboard_client(stream, rx).await;
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Spawn a background task that keeps the attached TUI synced to a websocket dashboard.
+pub fn spawn_dashboard_reader(
+    connect_addr: SocketAddr,
+    state_tx: watch::Sender<Option<DashboardState>>,
+) -> tokio::task::JoinHandle<()> {
+    spawn_dashboard_reader_with_retry_delay(connect_addr, state_tx, Duration::from_secs(1))
+}
+
+fn spawn_dashboard_reader_with_retry_delay(
+    connect_addr: SocketAddr,
+    state_tx: watch::Sender<Option<DashboardState>>,
+    retry_delay: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let ws_url = format!("ws://{connect_addr}");
+
+        while matches!(
+            dashboard_reader_session(&ws_url, state_tx.clone()).await,
+            Ok(ReaderSessionOutcome::RetryAfterDelay)
+        ) {
+            tokio::time::sleep(retry_delay).await;
+        }
+    })
+}
+
+async fn dashboard_reader_session(
+    ws_url: &str,
+    state_tx: watch::Sender<Option<DashboardState>>,
+) -> anyhow::Result<ReaderSessionOutcome> {
+    let Ok((ws_stream, _)) = connect_async(ws_url).await else {
+        return Ok(ReaderSessionOutcome::RetryAfterDelay);
+    };
+
+    let (_, source) = ws_stream.split();
+    forward_dashboard_states(source, state_tx)
+        .await
+        .map(|_| ReaderSessionOutcome::RetryAfterDelay)
+}
+
+async fn forward_dashboard_states<S>(
+    source: S,
+    state_tx: watch::Sender<Option<DashboardState>>,
+) -> anyhow::Result<()>
+where
+    S: Stream<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin,
+{
+    dashboard_source_stream(source)
+        .map(Ok::<DashboardState, anyhow::Error>)
+        .try_fold(state_tx, |state_tx, state| async move {
+            state_tx
+                .send(Some(state))
+                .map_err(|_| anyhow::anyhow!("attached dashboard state receiver dropped"))?;
+            Ok::<_, anyhow::Error>(state_tx)
+        })
+        .await
+        .map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Server;
+    use crate::metrics::{MetricsCollector, MetricsSnapshot};
+    use crate::router::BackendSelector;
+    use crate::tui::app::{ThroughputPoint, ViewMode};
+    use crate::tui::dashboard::BufferPoolStats;
+    use crate::types::Port;
+    use crate::types::tui::{Throughput, Timestamp};
+    use std::sync::Arc;
+    use tokio::sync::mpsc;
+
+    fn create_test_servers(count: usize) -> Arc<[Server]> {
+        (0..count)
+            .map(|i| {
+                Server::builder(
+                    format!("backend{i}.example.com"),
+                    Port::try_new(119).unwrap(),
+                )
+                .name(format!("Backend {i}"))
+                .build()
+                .unwrap()
+            })
+            .collect::<Vec<_>>()
+            .into()
+    }
+
+    fn build_test_app() -> TuiApp {
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+
+        TuiApp::new(metrics, router, servers)
+    }
+
+    #[test]
+    fn dashboard_state_from_message_parses_text_frames() {
+        let state = DashboardState {
+            snapshot: MetricsSnapshot::default(),
+            backend_views: Vec::new(),
+            client_history: Vec::new(),
+            system_stats: crate::tui::SystemStats::default(),
+            view_mode: ViewMode::Normal,
+            show_details: false,
+            log_lines: vec!["hello".to_string()],
+            buffer_pool: None,
+        };
+        let message = Message::Text(serde_json::to_string(&state).unwrap().into());
+
+        let parsed = dashboard_state_from_message(Ok(message)).expect("state should parse");
+        assert_eq!(parsed.log_lines, vec!["hello".to_string()]);
+    }
+
+    #[test]
+    fn dashboard_state_from_message_ignores_non_text_and_invalid_json() {
+        assert!(dashboard_state_from_message(Ok(Message::Binary(vec![1, 2, 3].into()))).is_none());
+        assert!(dashboard_state_from_message(Ok(Message::Ping(vec![1, 2].into()))).is_none());
+        assert!(
+            dashboard_state_from_message(Err(
+                tokio_tungstenite::tungstenite::Error::ConnectionClosed
+            ))
+            .is_none()
+        );
+        assert!(dashboard_state_from_message(Ok(Message::Text("{not-json}".into()))).is_none());
+    }
+
+    #[tokio::test]
+    async fn reader_session_reports_retry_for_disconnected_listener() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test port");
+        let addr = listener.local_addr().expect("local addr");
+        drop(listener);
+
+        let (state_tx, _state_rx) = watch::channel(None::<DashboardState>);
+        let outcome = dashboard_reader_session(&format!("ws://{addr}"), state_tx)
+            .await
+            .expect("reader session");
+
+        assert_eq!(outcome, ReaderSessionOutcome::RetryAfterDelay);
+    }
+
+    async fn wait_for_log_lines(
+        state_rx: &mut watch::Receiver<Option<DashboardState>>,
+        expected: &[&str],
+        timeout: Duration,
+    ) -> DashboardState {
+        tokio::time::timeout(timeout, async {
+            loop {
+                if let Some(state) = state_rx.borrow().clone()
+                    && state
+                        .log_lines
+                        .iter()
+                        .map(String::as_str)
+                        .eq(expected.iter().copied())
+                {
+                    return state;
+                }
+                state_rx.changed().await.expect("reader still alive");
+            }
+        })
+        .await
+        .expect("observe expected dashboard state")
+    }
+
+    #[tokio::test]
+    async fn publisher_serves_initial_snapshot() {
+        let app = build_test_app();
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test port");
+        let addr = listener.local_addr().expect("local addr");
+        drop(listener);
+
+        let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
+        let publisher = tokio::spawn(run_dashboard_publisher(app, addr, shutdown_rx));
+
+        let (ws_stream, _) = tokio::time::timeout(Duration::from_secs(3), async {
+            loop {
+                match tokio_tungstenite::connect_async(format!("ws://{addr}")).await {
+                    Ok(result) => break result,
+                    Err(_) => tokio::time::sleep(Duration::from_millis(50)).await,
+                }
+            }
+        })
+        .await
+        .expect("publisher should accept connections");
+        let (mut sink, mut source) = ws_stream.split();
+
+        let message = tokio::time::timeout(Duration::from_secs(3), source.next())
+            .await
+            .expect("receive snapshot")
+            .expect("ws message")
+            .expect("valid ws frame");
+
+        let Message::Text(text) = message else {
+            panic!("expected text frame");
+        };
+        let state = serde_json::from_str::<DashboardState>(text.as_str())
+            .expect("deserialize dashboard state");
+
+        assert_eq!(state.backend_views.len(), 1);
+        assert_eq!(state.view_mode, ViewMode::Normal);
+        assert!(state.buffer_pool.is_none());
+
+        sink.close().await.expect("close websocket");
+        let _ = shutdown_tx.send(()).await;
+        tokio::time::timeout(Duration::from_secs(3), publisher)
+            .await
+            .expect("publisher task should exit")
+            .expect("publisher join")
+            .expect("publisher should exit cleanly");
+    }
+
+    #[tokio::test]
+    async fn reader_applies_latest_state() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test port");
+        let addr = listener.local_addr().expect("local addr");
+
+        let (state_tx, mut state_rx) = watch::channel(None::<DashboardState>);
+        let reader =
+            spawn_dashboard_reader_with_retry_delay(addr, state_tx, Duration::from_millis(25));
+
+        let (stream, _) = tokio::time::timeout(Duration::from_secs(3), listener.accept())
+            .await
+            .expect("reader should connect")
+            .expect("accept reader connection");
+        let mut ws = accept_async(stream).await.expect("accept websocket");
+
+        let first = DashboardState {
+            snapshot: MetricsSnapshot::default(),
+            backend_views: Vec::new(),
+            client_history: vec![ThroughputPoint::new_client(
+                Timestamp::now(),
+                Throughput::new(1.0),
+                Throughput::new(2.0),
+            )],
+            system_stats: crate::tui::SystemStats::default(),
+            view_mode: ViewMode::Normal,
+            show_details: false,
+            log_lines: vec!["first".to_string()],
+            buffer_pool: Some(BufferPoolStats {
+                available: 1,
+                in_use: 0,
+                total: 1,
+            }),
+        };
+        let mut second = first.clone();
+        second.log_lines = vec!["second".to_string()];
+        second.show_details = true;
+
+        ws.send(Message::Text(
+            serde_json::to_string(&first)
+                .expect("serialize first")
+                .into(),
+        ))
+        .await
+        .expect("send first state");
+        ws.send(Message::Text(
+            serde_json::to_string(&second)
+                .expect("serialize second")
+                .into(),
+        ))
+        .await
+        .expect("send second state");
+
+        let observed = wait_for_log_lines(&mut state_rx, &["second"], Duration::from_secs(3)).await;
+
+        assert_eq!(observed.log_lines, vec!["second".to_string()]);
+        assert!(observed.show_details);
+
+        let _ = ws.close(None).await;
+        reader.abort();
+        let _ = reader.await;
+    }
+
+    #[tokio::test]
+    async fn reader_ignores_malformed_frames() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test port");
+        let addr = listener.local_addr().expect("local addr");
+
+        let (state_tx, mut state_rx) = watch::channel(None::<DashboardState>);
+        let reader =
+            spawn_dashboard_reader_with_retry_delay(addr, state_tx, Duration::from_millis(25));
+
+        let (stream, _) = tokio::time::timeout(Duration::from_secs(3), listener.accept())
+            .await
+            .expect("reader should connect")
+            .expect("accept reader connection");
+        let mut ws = accept_async(stream).await.expect("accept websocket");
+
+        let good = DashboardState {
+            snapshot: MetricsSnapshot::default(),
+            backend_views: Vec::new(),
+            client_history: Vec::new(),
+            system_stats: crate::tui::SystemStats::default(),
+            view_mode: ViewMode::Normal,
+            show_details: false,
+            log_lines: vec!["good".to_string()],
+            buffer_pool: None,
+        };
+
+        ws.send(Message::Text(
+            serde_json::to_string(&good).expect("serialize good").into(),
+        ))
+        .await
+        .expect("send good state");
+
+        let observed = wait_for_log_lines(&mut state_rx, &["good"], Duration::from_secs(3)).await;
+        assert_eq!(observed.log_lines, vec!["good".to_string()]);
+
+        ws.send(Message::Binary(vec![1, 2, 3].into()))
+            .await
+            .expect("send binary frame");
+        ws.send(Message::Text("{not-json}".into()))
+            .await
+            .expect("send invalid json");
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let latest = state_rx
+            .borrow()
+            .clone()
+            .expect("state should remain present");
+        assert_eq!(latest.log_lines, vec!["good".to_string()]);
+
+        drop(ws);
+        reader.abort();
+        let _ = reader.await;
+    }
+
+    #[tokio::test]
+    async fn reader_recovers_after_disconnect() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test port");
+        let addr = listener.local_addr().expect("local addr");
+
+        let (state_tx, mut state_rx) = watch::channel(None::<DashboardState>);
+        let reader =
+            spawn_dashboard_reader_with_retry_delay(addr, state_tx, Duration::from_millis(25));
+
+        let first_conn = tokio::time::timeout(Duration::from_secs(3), listener.accept())
+            .await
+            .expect("reader should connect initially")
+            .expect("accept initial connection");
+        let mut first_ws = accept_async(first_conn.0)
+            .await
+            .expect("accept initial websocket");
+
+        let first = DashboardState {
+            snapshot: MetricsSnapshot::default(),
+            backend_views: Vec::new(),
+            client_history: Vec::new(),
+            system_stats: crate::tui::SystemStats::default(),
+            view_mode: ViewMode::Normal,
+            show_details: false,
+            log_lines: vec!["first".to_string()],
+            buffer_pool: None,
+        };
+        first_ws
+            .send(Message::Text(
+                serde_json::to_string(&first)
+                    .expect("serialize first")
+                    .into(),
+            ))
+            .await
+            .expect("send first state");
+
+        let first_observed =
+            wait_for_log_lines(&mut state_rx, &["first"], Duration::from_secs(3)).await;
+        assert_eq!(first_observed.log_lines, vec!["first".to_string()]);
+
+        drop(first_ws);
+
+        let second_conn = tokio::time::timeout(Duration::from_secs(5), listener.accept())
+            .await
+            .expect("reader should reconnect")
+            .expect("accept reconnect connection");
+        let mut second_ws = accept_async(second_conn.0)
+            .await
+            .expect("accept reconnect websocket");
+
+        let second = DashboardState {
+            snapshot: MetricsSnapshot::default(),
+            backend_views: Vec::new(),
+            client_history: Vec::new(),
+            system_stats: crate::tui::SystemStats::default(),
+            view_mode: ViewMode::LogFullscreen,
+            show_details: true,
+            log_lines: vec!["second".to_string()],
+            buffer_pool: Some(BufferPoolStats {
+                available: 2,
+                in_use: 1,
+                total: 3,
+            }),
+        };
+        second_ws
+            .send(Message::Text(
+                serde_json::to_string(&second)
+                    .expect("serialize second")
+                    .into(),
+            ))
+            .await
+            .expect("send second state");
+
+        let second_observed =
+            wait_for_log_lines(&mut state_rx, &["second"], Duration::from_secs(5)).await;
+
+        assert_eq!(second_observed.log_lines, vec!["second".to_string()]);
+        assert_eq!(second_observed.view_mode, ViewMode::LogFullscreen);
+        assert!(second_observed.show_details);
+        assert_eq!(
+            second_observed.buffer_pool.as_ref().map(|pool| pool.total),
+            Some(3)
+        );
+
+        drop(second_ws);
+        reader.abort();
+        let _ = reader.await;
+    }
+}

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -143,6 +143,10 @@ fn handle_dashboard_accept_result(
     }
 }
 
+/// Bind the dashboard websocket listener.
+///
+/// # Errors
+/// Returns an error when the address is not loopback or the socket cannot be bound.
 pub async fn bind_dashboard_listener(listen_addr: SocketAddr) -> anyhow::Result<TcpListener> {
     anyhow::ensure!(
         listen_addr.ip().is_loopback(),
@@ -155,6 +159,10 @@ pub async fn bind_dashboard_listener(listen_addr: SocketAddr) -> anyhow::Result<
     })
 }
 
+/// Run the headless dashboard publisher on an already-bound listener.
+///
+/// # Errors
+/// Returns an error if websocket publishing fails after startup.
 pub async fn run_dashboard_publisher_on_listener(
     mut app: TuiApp,
     listener: TcpListener,
@@ -184,6 +192,10 @@ pub async fn run_dashboard_publisher_on_listener(
 }
 
 /// Run the headless dashboard websocket publisher.
+///
+/// # Errors
+/// Returns an error if the listener cannot be bound or the publisher exits with
+/// an unrecoverable websocket error.
 pub async fn run_dashboard_publisher(
     app: TuiApp,
     listen_addr: SocketAddr,
@@ -258,7 +270,7 @@ async fn dashboard_reader_session(
     let last_snapshot = state_tx.borrow().latest_state.clone();
     let _ = state_tx.send(AttachedDashboard::connected(connect_addr, last_snapshot));
     let (_, source) = ws_stream.split();
-    forward_dashboard_states(source, state_tx).await.map(|_| {
+    forward_dashboard_states(source, state_tx).await.map(|()| {
         warn!("Attached dashboard websocket stream ended for {ws_url}");
         ReaderSessionOutcome::RetryAfterDelay
     })
@@ -291,8 +303,9 @@ where
 fn retry_reason(outcome: &anyhow::Result<ReaderSessionOutcome>) -> String {
     outcome
         .as_ref()
-        .map(|_| "connection dropped".to_string())
-        .unwrap_or_else(|err| err.to_string())
+        .map_or_else(std::string::ToString::to_string, |_| {
+            "connection dropped".to_string()
+        })
 }
 
 fn dashboard_target_from_ws_url(ws_url: &str) -> anyhow::Result<SocketAddr> {

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -48,6 +48,12 @@ fn dashboard_source_stream(
     source.filter_map(|message| async move { dashboard_state_from_message(message) })
 }
 
+fn dashboard_peer_label(peer_addr: Option<SocketAddr>) -> String {
+    peer_addr
+        .map(|addr| format!(" from {addr}"))
+        .unwrap_or_default()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ReaderSessionOutcome {
     RetryAfterDelay,
@@ -85,11 +91,10 @@ async fn handle_dashboard_client(
     state_rx: watch::Receiver<Arc<DashboardState>>,
 ) -> anyhow::Result<()> {
     let peer_addr = stream.peer_addr().ok();
-    if let Some(peer_addr) = peer_addr {
-        info!("Dashboard websocket client connected from {peer_addr}");
-    } else {
-        info!("Dashboard websocket client connected");
-    }
+    info!(
+        "Dashboard websocket client connected{}",
+        dashboard_peer_label(peer_addr)
+    );
 
     let ws_stream = accept_async(stream).await?;
     let (sink, source) = ws_stream.split();
@@ -99,11 +104,10 @@ async fn handle_dashboard_client(
         drain_dashboard_source(source)
     )?;
 
-    if let Some(peer_addr) = peer_addr {
-        info!("Dashboard websocket client disconnected from {peer_addr}");
-    } else {
-        info!("Dashboard websocket client disconnected");
-    }
+    info!(
+        "Dashboard websocket client disconnected{}",
+        dashboard_peer_label(peer_addr)
+    );
     Ok(())
 }
 
@@ -277,6 +281,15 @@ mod tests {
             .is_none()
         );
         assert!(dashboard_state_from_message(Ok(Message::Text("{not-json}".into()))).is_none());
+    }
+
+    #[test]
+    fn dashboard_peer_label_formats_optional_peer_addresses() {
+        assert_eq!(dashboard_peer_label(None), "");
+        assert_eq!(
+            dashboard_peer_label(Some("127.0.0.1:1234".parse().unwrap())),
+            " from 127.0.0.1:1234"
+        );
     }
 
     #[tokio::test]

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -129,6 +129,10 @@ fn publish_dashboard_snapshot(app: &mut TuiApp, state_tx: &watch::Sender<Arc<Das
 }
 
 pub async fn bind_dashboard_listener(listen_addr: SocketAddr) -> anyhow::Result<TcpListener> {
+    anyhow::ensure!(
+        listen_addr.ip().is_loopback(),
+        "Dashboard websocket listener must bind to a loopback address; got {listen_addr}"
+    );
     TcpListener::bind(listen_addr).await.with_context(|| {
         format!(
             "Failed to bind dashboard websocket listener at {listen_addr}; ensure that socket is free and distinct from the proxy listener"
@@ -421,6 +425,15 @@ mod tests {
         let err = format!("{err:#}");
         assert!(err.contains("Failed to bind dashboard websocket listener"));
         assert!(err.contains("ensure that socket is free"));
+    }
+
+    #[tokio::test]
+    async fn dashboard_publisher_rejects_non_loopback_listener() {
+        let err = bind_dashboard_listener("0.0.0.0:8120".parse().unwrap())
+            .await
+            .expect_err("non-loopback bind should fail");
+
+        assert!(format!("{err:#}").contains("must bind to a loopback address"));
     }
 
     #[tokio::test]

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -128,6 +128,21 @@ fn publish_dashboard_snapshot(app: &mut TuiApp, state_tx: &watch::Sender<Arc<Das
     let _ = state_tx.send(state);
 }
 
+fn handle_dashboard_accept_result(
+    accept_result: std::io::Result<(TcpStream, SocketAddr)>,
+    state_tx: &watch::Sender<Arc<DashboardState>>,
+) {
+    match accept_result {
+        Ok((stream, _)) => {
+            let rx = state_tx.subscribe();
+            spawn_dashboard_client_task(stream, rx);
+        }
+        Err(err) => {
+            warn!(error = %err, "Dashboard websocket accept failed; continuing");
+        }
+    }
+}
+
 pub async fn bind_dashboard_listener(listen_addr: SocketAddr) -> anyhow::Result<TcpListener> {
     anyhow::ensure!(
         listen_addr.ip().is_loopback(),
@@ -160,9 +175,7 @@ pub async fn run_dashboard_publisher_on_listener(
                 publish_dashboard_snapshot(&mut app, &state_tx);
             }
             accept_result = listener.accept() => {
-                let (stream, _) = accept_result?;
-                let rx = state_tx.subscribe();
-                spawn_dashboard_client_task(stream, rx);
+                handle_dashboard_accept_result(accept_result, &state_tx);
             }
         }
     }
@@ -427,6 +440,19 @@ mod tests {
         assert!(err.contains("ensure that socket is free"));
     }
 
+    #[test]
+    fn dashboard_accept_errors_are_nonfatal() {
+        let app = build_test_app();
+        let (state_tx, _state_rx) = watch::channel(Arc::new(
+            app.snapshot_state_with_log_limit(Some(DASHBOARD_LOG_LINE_LIMIT)),
+        ));
+
+        handle_dashboard_accept_result(
+            Err(std::io::Error::other("synthetic accept error")),
+            &state_tx,
+        );
+    }
+
     #[tokio::test]
     async fn dashboard_publisher_rejects_non_loopback_listener() {
         let err = bind_dashboard_listener("0.0.0.0:8120".parse().unwrap())
@@ -482,10 +508,13 @@ mod tests {
             .await
             .expect("bind test port");
         let addr = listener.local_addr().expect("local addr");
-        drop(listener);
 
         let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
-        let publisher = tokio::spawn(run_dashboard_publisher(app, addr, shutdown_rx));
+        let publisher = tokio::spawn(run_dashboard_publisher_on_listener(
+            app,
+            listener,
+            shutdown_rx,
+        ));
 
         let (ws_stream, _) = tokio::time::timeout(Duration::from_secs(3), async {
             loop {

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -13,6 +13,8 @@ use tokio::sync::watch;
 use tokio_tungstenite::{accept_async, connect_async, tungstenite::Message};
 use tracing::{info, warn};
 
+const DASHBOARD_LOG_LINE_LIMIT: usize = 256;
+
 #[allow(clippy::cast_precision_loss)]
 fn dashboard_message(state: &DashboardState) -> anyhow::Result<Message> {
     Ok(Message::Text(serde_json::to_string(state)?.into()))
@@ -122,22 +124,26 @@ fn spawn_dashboard_client_task(stream: TcpStream, state_rx: watch::Receiver<Arc<
 
 fn publish_dashboard_snapshot(app: &mut TuiApp, state_tx: &watch::Sender<Arc<DashboardState>>) {
     app.update();
-    let state = Arc::new(app.snapshot_state());
+    let state = Arc::new(app.snapshot_state_with_log_limit(Some(DASHBOARD_LOG_LINE_LIMIT)));
     let _ = state_tx.send(state);
 }
 
-/// Run the headless dashboard websocket publisher.
-pub async fn run_dashboard_publisher(
-    mut app: TuiApp,
-    listen_addr: SocketAddr,
-    mut shutdown_rx: tokio::sync::mpsc::Receiver<()>,
-) -> anyhow::Result<()> {
-    let listener = TcpListener::bind(listen_addr).await.with_context(|| {
+pub async fn bind_dashboard_listener(listen_addr: SocketAddr) -> anyhow::Result<TcpListener> {
+    TcpListener::bind(listen_addr).await.with_context(|| {
         format!(
             "Failed to bind dashboard websocket listener at {listen_addr}; ensure that socket is free and distinct from the proxy listener"
         )
-    })?;
-    let (state_tx, _state_rx) = watch::channel(Arc::new(app.snapshot_state()));
+    })
+}
+
+pub async fn run_dashboard_publisher_on_listener(
+    mut app: TuiApp,
+    listener: TcpListener,
+    mut shutdown_rx: tokio::sync::mpsc::Receiver<()>,
+) -> anyhow::Result<()> {
+    let (state_tx, _state_rx) = watch::channel(Arc::new(
+        app.snapshot_state_with_log_limit(Some(DASHBOARD_LOG_LINE_LIMIT)),
+    ));
     let mut update_interval = tokio::time::interval(Duration::from_millis(250));
     update_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
@@ -158,6 +164,16 @@ pub async fn run_dashboard_publisher(
     }
 
     Ok(())
+}
+
+/// Run the headless dashboard websocket publisher.
+pub async fn run_dashboard_publisher(
+    app: TuiApp,
+    listen_addr: SocketAddr,
+    shutdown_rx: tokio::sync::mpsc::Receiver<()>,
+) -> anyhow::Result<()> {
+    let listener = bind_dashboard_listener(listen_addr).await?;
+    run_dashboard_publisher_on_listener(app, listener, shutdown_rx).await
 }
 
 /// Spawn a background task that keeps the attached TUI synced to a websocket dashboard.

--- a/src/tui/system_stats.rs
+++ b/src/tui/system_stats.rs
@@ -5,7 +5,7 @@
 use sysinfo::{ProcessRefreshKind, ProcessesToUpdate, RefreshKind, System};
 
 /// System resource statistics for the current process
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct SystemStats {
     /// CPU usage percentage (0.0 - 100.0 per core, can exceed 100.0 on multi-core)
     pub cpu_usage: f32,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -47,7 +47,7 @@ fn bordered_block(title: &'static str, border_color: Color) -> Block<'static> {
 // ============================================================================
 
 /// Render the main UI
-pub fn render_ui(f: &mut Frame, state: &DashboardState) {
+pub fn render_ui(f: &mut Frame, state: &DashboardState, attached_ui_memory_bytes: Option<u64>) {
     use crate::tui::app::ViewMode;
 
     // Check if we're in log fullscreen mode
@@ -97,7 +97,7 @@ pub fn render_ui(f: &mut Frame, state: &DashboardState) {
 
     // Render each section
     render_title(f, chunks[0], &state.snapshot);
-    render_summary(f, chunks[1], state);
+    render_summary(f, chunks[1], state, attached_ui_memory_bytes);
 
     // Backends area now contains 3 columns: backends, chart, and user stats
     render_backends(f, chunks[2], state);
@@ -134,7 +134,12 @@ fn render_title(f: &mut Frame, area: Rect, snapshot: &crate::metrics::MetricsSna
 }
 
 /// Render summary statistics
-fn render_summary(f: &mut Frame, area: Rect, state: &DashboardState) {
+fn render_summary(
+    f: &mut Frame,
+    area: Rect,
+    state: &DashboardState,
+    attached_ui_memory_bytes: Option<u64>,
+) {
     let snapshot = &state.snapshot;
     let system_stats = &state.system_stats;
 
@@ -158,6 +163,7 @@ fn render_summary(f: &mut Frame, area: Rect, state: &DashboardState) {
         system_stats,
         state.buffer_pool(),
         state.show_details,
+        attached_ui_memory_bytes,
     );
 
     // Middle: Cache summary
@@ -195,6 +201,7 @@ fn create_app_summary(
     system_stats: &crate::tui::SystemStats,
     buffer_pool: Option<&BufferPoolStats>,
     show_details: bool,
+    attached_ui_memory_bytes: Option<u64>,
 ) -> Paragraph<'static> {
     /// Color for CPU usage based on threshold
     const fn cpu_color(usage: f32) -> Color {
@@ -231,6 +238,14 @@ fn create_app_summary(
         }
     }
 
+    let is_attached = attached_ui_memory_bytes.is_some();
+    let cpu_label = if is_attached { "Proxy CPU: " } else { "CPU: " };
+    let memory_label = if is_attached {
+        "Proxy Memory: "
+    } else {
+        "Memory: "
+    };
+
     let mut lines = vec![
         Line::from(vec![
             "Uptime: ".fg(styles::LABEL),
@@ -241,14 +256,21 @@ fn create_app_summary(
             format!("{}", snapshot.stateful_sessions).fg(session_color(snapshot.stateful_sessions)),
         ]),
         Line::from(vec![
-            "CPU: ".fg(styles::LABEL),
+            cpu_label.fg(styles::LABEL),
             format!("{:.1}%", system_stats.cpu_usage).fg(cpu_color(system_stats.cpu_usage)),
         ]),
         Line::from(vec![
-            "Memory: ".fg(styles::LABEL),
+            memory_label.fg(styles::LABEL),
             format_bytes(system_stats.memory_bytes).fg(styles::VALUE_INFO),
         ]),
     ];
+
+    if let Some(ui_memory_bytes) = attached_ui_memory_bytes {
+        lines.push(Line::from(vec![
+            "UI Memory: ".fg(styles::LABEL),
+            format_bytes(ui_memory_bytes).fg(styles::VALUE_INFO),
+        ]));
+    }
 
     // Show pipeline stats if any batches have been processed
     if snapshot.pipeline_batches > 0 {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -746,11 +746,7 @@ fn render_user_stats(f: &mut Frame, area: Rect, snapshot: &crate::metrics::Metri
         ]
     }
 
-    // Functional pipeline: sort → take top 10 → find max → build items
-    let mut sorted_users = snapshot.user_stats.iter().collect::<Vec<_>>();
-    sorted_users.sort_by_key(|u| std::cmp::Reverse(u.total_bytes()));
-
-    let top_users: Vec<_> = sorted_users.into_iter().take(10).collect();
+    let top_users = top_users_by_bytes(&snapshot.user_stats);
     let max_total = top_users.iter().map(|u| u.total_bytes()).max().unwrap_or(1);
 
     // Header row
@@ -781,9 +777,24 @@ fn render_user_stats(f: &mut Frame, area: Rect, snapshot: &crate::metrics::Metri
     f.render_widget(list, area);
 }
 
+fn top_users_by_bytes(users: &[crate::metrics::UserStats]) -> Vec<&crate::metrics::UserStats> {
+    let mut sorted_users = users.iter().collect::<Vec<_>>();
+    sorted_users.sort_by_key(|user| std::cmp::Reverse(user.total_bytes()));
+    sorted_users.into_iter().take(10).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::metrics::UserStats;
+
+    fn user_stats(name: &str, total_bytes: u64) -> UserStats {
+        UserStats {
+            username: name.to_string(),
+            bytes_sent: crate::types::BytesSent::new(total_bytes),
+            ..Default::default()
+        }
+    }
 
     #[test]
     fn recent_log_lines_returns_full_slice_when_count_exceeds_length() {
@@ -815,5 +826,35 @@ mod tests {
         let recent = recent_log_lines(&lines, 0);
 
         assert!(recent.is_empty());
+    }
+
+    #[test]
+    fn top_users_by_bytes_sorts_descending() {
+        let users = vec![
+            user_stats("alice", 10),
+            user_stats("bob", 30),
+            user_stats("carol", 20),
+        ];
+
+        let top_users = top_users_by_bytes(&users);
+
+        let usernames = top_users
+            .iter()
+            .map(|user| user.username.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(usernames, vec!["bob", "carol", "alice"]);
+    }
+
+    #[test]
+    fn top_users_by_bytes_caps_results_at_ten() {
+        let users = (0..12)
+            .map(|i| user_stats(&format!("user{i}"), i))
+            .collect::<Vec<_>>();
+
+        let top_users = top_users_by_bytes(&users);
+
+        assert_eq!(top_users.len(), 10);
+        assert_eq!(top_users[0].username, "user11");
+        assert_eq!(top_users[9].username, "user2");
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -47,7 +47,11 @@ fn bordered_block(title: &'static str, border_color: Color) -> Block<'static> {
 // ============================================================================
 
 /// Render the main UI
-pub fn render_ui(f: &mut Frame, state: &DashboardState, attached_ui_memory_bytes: Option<u64>) {
+pub fn render_ui(
+    f: &mut Frame,
+    state: &DashboardState,
+    attached_ui_stats: Option<&crate::tui::SystemStats>,
+) {
     use crate::tui::app::ViewMode;
 
     // Check if we're in log fullscreen mode
@@ -97,7 +101,7 @@ pub fn render_ui(f: &mut Frame, state: &DashboardState, attached_ui_memory_bytes
 
     // Render each section
     render_title(f, chunks[0], &state.snapshot);
-    render_summary(f, chunks[1], state, attached_ui_memory_bytes);
+    render_summary(f, chunks[1], state, attached_ui_stats);
 
     // Backends area now contains 3 columns: backends, chart, and user stats
     render_backends(f, chunks[2], state);
@@ -138,7 +142,7 @@ fn render_summary(
     f: &mut Frame,
     area: Rect,
     state: &DashboardState,
-    attached_ui_memory_bytes: Option<u64>,
+    attached_ui_stats: Option<&crate::tui::SystemStats>,
 ) {
     let snapshot = &state.snapshot;
     let system_stats = &state.system_stats;
@@ -163,7 +167,7 @@ fn render_summary(
         system_stats,
         state.buffer_pool(),
         state.show_details,
-        attached_ui_memory_bytes,
+        attached_ui_stats,
     );
 
     // Middle: Cache summary
@@ -201,7 +205,7 @@ fn create_app_summary(
     system_stats: &crate::tui::SystemStats,
     buffer_pool: Option<&BufferPoolStats>,
     show_details: bool,
-    attached_ui_memory_bytes: Option<u64>,
+    attached_ui_stats: Option<&crate::tui::SystemStats>,
 ) -> Paragraph<'static> {
     /// Color for CPU usage based on threshold
     const fn cpu_color(usage: f32) -> Color {
@@ -238,13 +242,35 @@ fn create_app_summary(
         }
     }
 
-    let is_attached = attached_ui_memory_bytes.is_some();
-    let cpu_label = if is_attached { "Proxy CPU: " } else { "CPU: " };
-    let memory_label = if is_attached {
-        "Proxy Memory: "
-    } else {
-        "Memory: "
-    };
+    if let Some(ui_stats) = attached_ui_stats {
+        let lines = vec![
+            Line::from(vec![
+                "Uptime: ".fg(styles::LABEL),
+                snapshot.format_uptime().fg(styles::VALUE_PRIMARY),
+            ]),
+            Line::from(vec![
+                "Stateful Sessions: ".fg(styles::LABEL),
+                format!("{}", snapshot.stateful_sessions)
+                    .fg(session_color(snapshot.stateful_sessions)),
+            ]),
+            Line::from(vec![
+                "CPU (proxy, UI): ".fg(styles::LABEL),
+                format!("{:.1}%", system_stats.cpu_usage).fg(cpu_color(system_stats.cpu_usage)),
+                " / ".fg(styles::LABEL),
+                format!("{:.1}%", ui_stats.cpu_usage).fg(cpu_color(ui_stats.cpu_usage)),
+            ]),
+            Line::from(vec![
+                "Memory (proxy, UI): ".fg(styles::LABEL),
+                format_bytes(system_stats.memory_bytes).fg(styles::VALUE_INFO),
+                " / ".fg(styles::LABEL),
+                format_bytes(ui_stats.memory_bytes).fg(styles::VALUE_INFO),
+            ]),
+        ];
+
+        return Paragraph::new(lines)
+            .block(bordered_block("App", styles::BORDER_NORMAL))
+            .alignment(Alignment::Left);
+    }
 
     let mut lines = vec![
         Line::from(vec![
@@ -256,21 +282,14 @@ fn create_app_summary(
             format!("{}", snapshot.stateful_sessions).fg(session_color(snapshot.stateful_sessions)),
         ]),
         Line::from(vec![
-            cpu_label.fg(styles::LABEL),
+            "CPU: ".fg(styles::LABEL),
             format!("{:.1}%", system_stats.cpu_usage).fg(cpu_color(system_stats.cpu_usage)),
         ]),
         Line::from(vec![
-            memory_label.fg(styles::LABEL),
+            "Memory: ".fg(styles::LABEL),
             format_bytes(system_stats.memory_bytes).fg(styles::VALUE_INFO),
         ]),
     ];
-
-    if let Some(ui_memory_bytes) = attached_ui_memory_bytes {
-        lines.push(Line::from(vec![
-            "UI Memory: ".fg(styles::LABEL),
-            format_bytes(ui_memory_bytes).fg(styles::VALUE_INFO),
-        ]));
-    }
 
     // Show pipeline stats if any batches have been processed
     if snapshot.pipeline_batches > 0 {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -207,8 +207,26 @@ fn create_app_summary(
     show_details: bool,
     attached_ui_stats: Option<&crate::tui::SystemStats>,
 ) -> Paragraph<'static> {
-    /// Color for CPU usage based on threshold
-    const fn cpu_color(usage: f32) -> Color {
+    let lines = build_app_summary_lines(
+        snapshot,
+        system_stats,
+        buffer_pool,
+        show_details,
+        attached_ui_stats,
+    );
+    Paragraph::new(lines)
+        .block(bordered_block("App", styles::BORDER_NORMAL))
+        .alignment(Alignment::Left)
+}
+
+fn build_app_summary_lines(
+    snapshot: &crate::metrics::MetricsSnapshot,
+    system_stats: &crate::tui::SystemStats,
+    buffer_pool: Option<&BufferPoolStats>,
+    show_details: bool,
+    attached_ui_stats: Option<&crate::tui::SystemStats>,
+) -> Vec<Line<'static>> {
+    fn cpu_color(usage: f32) -> Color {
         if usage > 80.0 {
             Color::Red
         } else if usage > 50.0 {
@@ -218,8 +236,7 @@ fn create_app_summary(
         }
     }
 
-    /// Color for session count (highlight if active)
-    const fn session_color(count: usize) -> Color {
+    fn session_color(count: usize) -> Color {
         if count > 0 {
             styles::VALUE_PRIMARY
         } else {
@@ -227,12 +244,8 @@ fn create_app_summary(
         }
     }
 
-    /// Color for buffer pool utilization
-    const fn buffer_color(in_use: usize, total: usize) -> Color {
-        let percent = match (in_use * 100).checked_div(total) {
-            Some(v) => v,
-            None => 0,
-        };
+    fn buffer_color(in_use: usize, total: usize) -> Color {
+        let percent = (in_use * 100).checked_div(total).unwrap_or_default();
         if percent > 80 {
             Color::Red
         } else if percent > 60 {
@@ -242,17 +255,19 @@ fn create_app_summary(
         }
     }
 
+    let mut lines = vec![
+        Line::from(vec![
+            "Uptime: ".fg(styles::LABEL),
+            snapshot.format_uptime().fg(styles::VALUE_PRIMARY),
+        ]),
+        Line::from(vec![
+            "Stateful Sessions: ".fg(styles::LABEL),
+            format!("{}", snapshot.stateful_sessions).fg(session_color(snapshot.stateful_sessions)),
+        ]),
+    ];
+
     if let Some(ui_stats) = attached_ui_stats {
-        let lines = vec![
-            Line::from(vec![
-                "Uptime: ".fg(styles::LABEL),
-                snapshot.format_uptime().fg(styles::VALUE_PRIMARY),
-            ]),
-            Line::from(vec![
-                "Stateful Sessions: ".fg(styles::LABEL),
-                format!("{}", snapshot.stateful_sessions)
-                    .fg(session_color(snapshot.stateful_sessions)),
-            ]),
+        lines.extend([
             Line::from(vec![
                 "CPU (proxy, UI): ".fg(styles::LABEL),
                 format!("{:.1}%", system_stats.cpu_usage).fg(cpu_color(system_stats.cpu_usage)),
@@ -265,33 +280,20 @@ fn create_app_summary(
                 " / ".fg(styles::LABEL),
                 format_bytes(ui_stats.memory_bytes).fg(styles::VALUE_INFO),
             ]),
-        ];
-
-        return Paragraph::new(lines)
-            .block(bordered_block("App", styles::BORDER_NORMAL))
-            .alignment(Alignment::Left);
+        ]);
+    } else {
+        lines.extend([
+            Line::from(vec![
+                "CPU: ".fg(styles::LABEL),
+                format!("{:.1}%", system_stats.cpu_usage).fg(cpu_color(system_stats.cpu_usage)),
+            ]),
+            Line::from(vec![
+                "Memory: ".fg(styles::LABEL),
+                format_bytes(system_stats.memory_bytes).fg(styles::VALUE_INFO),
+            ]),
+        ]);
     }
 
-    let mut lines = vec![
-        Line::from(vec![
-            "Uptime: ".fg(styles::LABEL),
-            snapshot.format_uptime().fg(styles::VALUE_PRIMARY),
-        ]),
-        Line::from(vec![
-            "Stateful Sessions: ".fg(styles::LABEL),
-            format!("{}", snapshot.stateful_sessions).fg(session_color(snapshot.stateful_sessions)),
-        ]),
-        Line::from(vec![
-            "CPU: ".fg(styles::LABEL),
-            format!("{:.1}%", system_stats.cpu_usage).fg(cpu_color(system_stats.cpu_usage)),
-        ]),
-        Line::from(vec![
-            "Memory: ".fg(styles::LABEL),
-            format_bytes(system_stats.memory_bytes).fg(styles::VALUE_INFO),
-        ]),
-    ];
-
-    // Show pipeline stats if any batches have been processed
     if snapshot.pipeline_batches > 0 {
         let avg_batch =
             counter_as_f64(snapshot.pipeline_commands) / counter_as_f64(snapshot.pipeline_batches);
@@ -305,7 +307,6 @@ fn create_app_summary(
         ]));
     }
 
-    // Show backend pipeline multiplexing stats if any requests have been queued
     if snapshot.pipeline_requests_queued > 0 {
         lines.push(Line::from(vec![
             "Mux Queue: ".fg(styles::LABEL),
@@ -317,7 +318,6 @@ fn create_app_summary(
         ]));
     }
 
-    // Add buffer stats in details mode if available
     if show_details && let Some(pool) = buffer_pool {
         let usage_percent = if pool.total > 0 {
             size_as_f64(pool.in_use * 100) / size_as_f64(pool.total)
@@ -331,9 +331,7 @@ fn create_app_summary(
         ]));
     }
 
-    Paragraph::new(lines)
-        .block(bordered_block("App", styles::BORDER_NORMAL))
-        .alignment(Alignment::Left)
+    lines
 }
 
 /// Create cache summary panel
@@ -827,7 +825,9 @@ fn top_users_by_bytes(users: &[crate::metrics::UserStats]) -> Vec<&crate::metric
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::metrics::MetricsSnapshot;
     use crate::metrics::UserStats;
+    use crate::tui::dashboard::BufferPoolStats;
 
     fn user_stats(name: &str, total_bytes: u64) -> UserStats {
         UserStats {
@@ -897,5 +897,54 @@ mod tests {
         assert_eq!(top_users.len(), 10);
         assert_eq!(top_users[0].username, "user11");
         assert_eq!(top_users[9].username, "user2");
+    }
+
+    #[test]
+    fn app_summary_lines_switch_between_local_and_remote_stats() {
+        let snapshot = MetricsSnapshot::default();
+        let system_stats = crate::tui::SystemStats::default();
+        let buffer_pool = BufferPoolStats {
+            available: 3,
+            in_use: 2,
+            total: 5,
+        };
+
+        let local_lines =
+            build_app_summary_lines(&snapshot, &system_stats, Some(&buffer_pool), true, None)
+                .into_iter()
+                .map(|line| line.to_string())
+                .collect::<Vec<_>>();
+        let remote_lines = build_app_summary_lines(
+            &snapshot,
+            &system_stats,
+            Some(&buffer_pool),
+            true,
+            Some(&crate::tui::SystemStats {
+                cpu_usage: 12.5,
+                memory_bytes: 42,
+                ..Default::default()
+            }),
+        )
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+
+        assert!(local_lines.iter().any(|line| line.contains("CPU:")));
+        assert!(local_lines.iter().any(|line| line.contains("Memory:")));
+        assert!(
+            remote_lines
+                .iter()
+                .any(|line| line.contains("CPU (proxy, UI):"))
+        );
+        assert!(
+            remote_lines
+                .iter()
+                .any(|line| line.contains("Memory (proxy, UI):"))
+        );
+        assert!(
+            !remote_lines
+                .iter()
+                .any(|line| line.contains("CPU:") && !line.contains("proxy"))
+        );
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,12 +1,12 @@
 //! TUI rendering and layout
 
-use crate::formatting::{format_bytes, format_count};
-use crate::tui::app::TuiApp;
+use crate::formatting::format_bytes;
 use crate::tui::constants::{chart, layout, styles, text};
+use crate::tui::dashboard::{BufferPoolStats, DashboardState};
 use crate::tui::helpers::{
-    build_chart_data, calculate_chart_bounds, create_sparkline, error_rate_color,
-    format_error_rate, format_summary_throughput, format_throughput_label, health_indicator,
-    load_percentage_color, magnitude_color,
+    build_chart_data, calculate_chart_bounds, connection_failure_color, create_sparkline,
+    error_count_color, error_rate_color, format_error_rate, format_summary_throughput,
+    format_throughput_label, health_indicator, load_percentage_color, pending_count_color,
 };
 use ratatui::{
     Frame,
@@ -30,33 +30,6 @@ const fn size_as_f64(value: usize) -> f64 {
     value as f64
 }
 
-#[allow(clippy::cast_precision_loss)] // Utilization percentages are display-only values.
-fn buffer_utilization_percent(in_use: usize, total: usize) -> f64 {
-    if total == 0 {
-        0.0
-    } else {
-        size_as_f64(in_use * 100) / size_as_f64(total)
-    }
-}
-
-const fn backend_error_count_color(errors_4xx: u64, errors_5xx: u64) -> Color {
-    if errors_5xx > 0 {
-        Color::Red
-    } else if errors_4xx > 0 {
-        Color::Yellow
-    } else {
-        styles::VALUE_NEUTRAL
-    }
-}
-
-const fn connection_failures_color(failures: u64) -> Color {
-    if failures > 0 {
-        Color::Red
-    } else {
-        styles::VALUE_NEUTRAL
-    }
-}
-
 // ============================================================================
 // Widget Creation Helpers (Pure Functions)
 // ============================================================================
@@ -74,13 +47,11 @@ fn bordered_block(title: &'static str, border_color: Color) -> Block<'static> {
 // ============================================================================
 
 /// Render the main UI
-pub fn render_ui(f: &mut Frame, app: &TuiApp) {
+pub fn render_ui(f: &mut Frame, state: &DashboardState) {
     use crate::tui::app::ViewMode;
-    let snapshot = app.snapshot();
-    let servers = app.servers();
 
     // Check if we're in log fullscreen mode
-    if app.view_mode() == ViewMode::LogFullscreen {
+    if state.view_mode == ViewMode::LogFullscreen {
         // Fullscreen logs - show only title and logs
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -92,8 +63,8 @@ pub fn render_ui(f: &mut Frame, app: &TuiApp) {
             ])
             .split(f.area());
 
-        render_title(f, chunks[0], snapshot);
-        render_logs(f, chunks[1], app);
+        render_title(f, chunks[0], &state.snapshot);
+        render_logs(f, chunks[1], state);
         render_footer(f, chunks[2]);
         return;
     }
@@ -125,14 +96,14 @@ pub fn render_ui(f: &mut Frame, app: &TuiApp) {
     };
 
     // Render each section
-    render_title(f, chunks[0], snapshot);
-    render_summary(f, chunks[1], app);
+    render_title(f, chunks[0], &state.snapshot);
+    render_summary(f, chunks[1], state);
 
     // Backends area now contains 3 columns: backends, chart, and user stats
-    render_backends(f, chunks[2], snapshot, servers, app);
+    render_backends(f, chunks[2], state);
 
     if show_logs {
-        render_logs(f, chunks[3], app);
+        render_logs(f, chunks[3], state);
         render_footer(f, chunks[4]);
     } else {
         render_footer(f, chunks[3]);
@@ -150,14 +121,9 @@ fn render_title(f: &mut Frame, area: Rect, snapshot: &crate::metrics::MetricsSna
         "Uptime: ".fg(styles::LABEL),
         snapshot.format_uptime().fg(styles::VALUE_PRIMARY).bold(),
         "  |  Active: ".fg(styles::LABEL),
-        format!(
-            "{} connections",
-            format_count(snapshot.active_connections as u64)
-        )
-        .fg(magnitude_color(snapshot.active_connections as u64)),
+        format!("{} connections", snapshot.active_connections).fg(styles::VALUE_SECONDARY),
         "  |  Total: ".fg(styles::LABEL),
-        format!("{} connections", format_count(snapshot.total_connections))
-            .fg(magnitude_color(snapshot.total_connections)),
+        format!("{} connections", snapshot.total_connections).fg(styles::VALUE_NEUTRAL),
     ]);
 
     let title = Paragraph::new(vec![title_line, info_line])
@@ -168,13 +134,13 @@ fn render_title(f: &mut Frame, area: Rect, snapshot: &crate::metrics::MetricsSna
 }
 
 /// Render summary statistics
-fn render_summary(f: &mut Frame, area: Rect, app: &TuiApp) {
-    let snapshot = app.snapshot();
-    let system_stats = app.system_stats();
+fn render_summary(f: &mut Frame, area: Rect, state: &DashboardState) {
+    let snapshot = &state.snapshot;
+    let system_stats = &state.system_stats;
 
     // Get latest throughput from history (extracted for testing)
     let (client_to_backend_str, backend_to_client_str) =
-        format_summary_throughput(app.latest_client_throughput());
+        format_summary_throughput(state.latest_client_throughput());
 
     // Split summary box into three columns
     let summary_chunks = Layout::default()
@@ -190,8 +156,8 @@ fn render_summary(f: &mut Frame, area: Rect, app: &TuiApp) {
     let left_summary = create_app_summary(
         snapshot,
         system_stats,
-        app.buffer_pool(),
-        app.show_details(),
+        state.buffer_pool(),
+        state.show_details,
     );
 
     // Middle: Cache summary
@@ -207,22 +173,16 @@ fn render_summary(f: &mut Frame, area: Rect, app: &TuiApp) {
 }
 
 /// Render backend server visualization
-fn render_backends(
-    f: &mut Frame,
-    area: Rect,
-    snapshot: &crate::metrics::MetricsSnapshot,
-    servers: &[crate::config::Server],
-    app: &TuiApp,
-) {
+fn render_backends(f: &mut Frame, area: Rect, state: &DashboardState) {
     // Split into three columns: backend list, data flow chart, and top users
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints(layout::backend_columns())
         .split(area);
 
-    render_backend_list(f, chunks[0], snapshot, servers, app);
-    render_data_flow(f, chunks[1], servers, app);
-    render_user_stats(f, chunks[2], snapshot);
+    render_backend_list(f, chunks[0], state);
+    render_data_flow(f, chunks[1], state);
+    render_user_stats(f, chunks[2], &state.snapshot);
 }
 
 // ============================================================================
@@ -233,7 +193,7 @@ fn render_backends(
 fn create_app_summary(
     snapshot: &crate::metrics::MetricsSnapshot,
     system_stats: &crate::tui::SystemStats,
-    buffer_pool: Option<&crate::pool::BufferPool>,
+    buffer_pool: Option<&BufferPoolStats>,
     show_details: bool,
 ) -> Paragraph<'static> {
     /// Color for CPU usage based on threshold
@@ -247,6 +207,30 @@ fn create_app_summary(
         }
     }
 
+    /// Color for session count (highlight if active)
+    const fn session_color(count: usize) -> Color {
+        if count > 0 {
+            styles::VALUE_PRIMARY
+        } else {
+            styles::VALUE_NEUTRAL
+        }
+    }
+
+    /// Color for buffer pool utilization
+    const fn buffer_color(in_use: usize, total: usize) -> Color {
+        let percent = match (in_use * 100).checked_div(total) {
+            Some(v) => v,
+            None => 0,
+        };
+        if percent > 80 {
+            Color::Red
+        } else if percent > 60 {
+            Color::Yellow
+        } else {
+            styles::VALUE_INFO
+        }
+    }
+
     let mut lines = vec![
         Line::from(vec![
             "Uptime: ".fg(styles::LABEL),
@@ -254,8 +238,7 @@ fn create_app_summary(
         ]),
         Line::from(vec![
             "Stateful Sessions: ".fg(styles::LABEL),
-            format_count(snapshot.stateful_sessions as u64)
-                .fg(magnitude_color(snapshot.stateful_sessions as u64)),
+            format!("{}", snapshot.stateful_sessions).fg(session_color(snapshot.stateful_sessions)),
         ]),
         Line::from(vec![
             "CPU: ".fg(styles::LABEL),
@@ -275,8 +258,7 @@ fn create_app_summary(
             "Pipeline: ".fg(styles::LABEL),
             format!(
                 "{} batches (avg {:.1} cmds)",
-                format_count(snapshot.pipeline_batches),
-                avg_batch
+                snapshot.pipeline_batches, avg_batch
             )
             .fg(styles::VALUE_INFO),
         ]));
@@ -288,8 +270,7 @@ fn create_app_summary(
             "Mux Queue: ".fg(styles::LABEL),
             format!(
                 "{} queued, {} completed",
-                format_count(snapshot.pipeline_requests_queued),
-                format_count(snapshot.pipeline_requests_completed)
+                snapshot.pipeline_requests_queued, snapshot.pipeline_requests_completed
             )
             .fg(styles::VALUE_INFO),
         ]));
@@ -297,17 +278,15 @@ fn create_app_summary(
 
     // Add buffer stats in details mode if available
     if show_details && let Some(pool) = buffer_pool {
-        let (_available, in_use, total) = pool.stats();
-        let utilization_percent = buffer_utilization_percent(in_use, total);
+        let usage_percent = if pool.total > 0 {
+            size_as_f64(pool.in_use * 100) / size_as_f64(pool.total)
+        } else {
+            0.0
+        };
         lines.push(Line::from(vec![
             "Buffers: ".fg(styles::LABEL),
-            format!(
-                "{}/{} ({:.0}%)",
-                format_count(in_use as u64),
-                format_count(total as u64),
-                utilization_percent
-            )
-            .fg(load_percentage_color(utilization_percent)),
+            format!("{}/{} ({:.0}%)", pool.in_use, pool.total, usage_percent)
+                .fg(buffer_color(pool.in_use, pool.total)),
         ]));
     }
 
@@ -318,11 +297,28 @@ fn create_app_summary(
 
 /// Create cache summary panel
 fn create_cache_summary(snapshot: &crate::metrics::MetricsSnapshot) -> Paragraph<'static> {
+    /// Color for cache entries (highlight if non-empty)
+    const fn entries_color(count: u64) -> Color {
+        if count > 0 {
+            styles::VALUE_INFO
+        } else {
+            styles::VALUE_NEUTRAL
+        }
+    }
+
     /// Color for hit rate (green if >50%, blue if >0%, gray otherwise)
     const fn hit_rate_color(rate: f64) -> Color {
         if rate > 50.0 {
             styles::VALUE_PRIMARY
         } else if rate > 0.0 {
+            styles::VALUE_INFO
+        } else {
+            styles::VALUE_NEUTRAL
+        }
+    }
+
+    const fn non_zero_color(value: u64) -> Color {
+        if value > 0 {
             styles::VALUE_INFO
         } else {
             styles::VALUE_NEUTRAL
@@ -344,24 +340,20 @@ fn create_cache_summary(snapshot: &crate::metrics::MetricsSnapshot) -> Paragraph
             ]),
             Line::from(vec![
                 "Disk Written: ".fg(styles::LABEL),
-                format_bytes(disk.bytes_written).fg(magnitude_color(disk.bytes_written)),
+                format_bytes(disk.bytes_written).fg(non_zero_color(disk.bytes_written)),
             ]),
             Line::from(vec![
                 "Disk Read: ".fg(styles::LABEL),
-                format_bytes(disk.bytes_read).fg(magnitude_color(disk.bytes_read)),
+                format_bytes(disk.bytes_read).fg(non_zero_color(disk.bytes_read)),
             ]),
             Line::from(vec![
                 "Disk Hits: ".fg(styles::LABEL),
-                format!(
-                    "{} ({:.1}%)",
-                    format_count(disk.disk_hits),
-                    disk.disk_hit_rate
-                )
-                .fg(magnitude_color(disk.disk_hits)),
+                format!("{} ({:.1}%)", disk.disk_hits, disk.disk_hit_rate)
+                    .fg(non_zero_color(disk.disk_hits)),
             ]),
             Line::from(vec![
                 "Write I/Os: ".fg(styles::LABEL),
-                format_count(disk.write_ios).fg(magnitude_color(disk.write_ios)),
+                format!("{}", disk.write_ios).fg(styles::VALUE_NEUTRAL),
             ]),
         ]
     } else {
@@ -369,7 +361,7 @@ fn create_cache_summary(snapshot: &crate::metrics::MetricsSnapshot) -> Paragraph
         vec![
             Line::from(vec![
                 "Entries: ".fg(styles::LABEL),
-                format_count(snapshot.cache_entries).fg(magnitude_color(snapshot.cache_entries)),
+                format!("{}", snapshot.cache_entries).fg(entries_color(snapshot.cache_entries)),
             ]),
             Line::from(vec![
                 "Size: ".fg(styles::LABEL),
@@ -454,12 +446,7 @@ fn backend_metrics_line(
 ) -> Line<'static> {
     Line::from(vec![
         "  Used/Max: ".fg(styles::LABEL),
-        format!(
-            "{}/{}",
-            format_count(active as u64),
-            format_count(max as u64)
-        )
-        .fg(magnitude_color(max as u64)),
+        format!("{active}/{max}").fg(styles::VALUE_SECONDARY),
         " | Cmd/s: ".fg(styles::LABEL),
         cmd_per_sec.fg(styles::VALUE_INFO),
         " | TTFB: ".fg(styles::LABEL),
@@ -483,7 +470,7 @@ fn backend_article_line(avg_size: String, count: u64) -> Line<'static> {
         "  Avg Article: ".fg(styles::LABEL),
         avg_size.fg(styles::VALUE_INFO),
         " | Articles: ".fg(styles::LABEL),
-        format_count(count).fg(magnitude_color(count)),
+        format!("{count}").fg(styles::VALUE_NEUTRAL),
     ])
 }
 
@@ -491,19 +478,14 @@ fn backend_article_line(avg_size: String, count: u64) -> Line<'static> {
 fn backend_error_line(
     errors_4xx: u64,
     errors_5xx: u64,
-    _has_errors: bool,
+    has_errors: bool,
     failures: u64,
 ) -> Line<'static> {
     Line::from(vec![
         "  Errors: ".fg(styles::LABEL),
-        format!(
-            "4xx:{} 5xx:{}",
-            format_count(errors_4xx),
-            format_count(errors_5xx)
-        )
-        .fg(backend_error_count_color(errors_4xx, errors_5xx)),
+        format!("4xx:{errors_4xx} 5xx:{errors_5xx}").fg(error_count_color(has_errors)),
         " | Conn Fails: ".fg(styles::LABEL),
-        format_count(failures).fg(connection_failures_color(failures)),
+        format!("{failures}").fg(connection_failure_color(failures)),
     ])
 }
 
@@ -511,7 +493,7 @@ fn backend_error_line(
 fn backend_details_line(pending: usize, load_ratio: Option<f64>, stateful: usize) -> Line<'static> {
     let mut spans: Vec<Span> = vec![
         "  Load: ".fg(styles::LABEL),
-        format!("{} in-flight", format_count(pending as u64)).fg(magnitude_color(pending as u64)),
+        format!("{pending} in-flight").fg(pending_count_color(pending)),
     ];
 
     if let Some(ratio) = load_ratio {
@@ -520,35 +502,27 @@ fn backend_details_line(pending: usize, load_ratio: Option<f64>, stateful: usize
     }
 
     if stateful > 0 {
-        spans.push(
-            format!(" | Stateful: {}", format_count(stateful as u64))
-                .fg(magnitude_color(stateful as u64)),
-        );
+        spans.push(format!(" | Stateful: {stateful}").fg(Color::Cyan));
     }
 
     Line::from(spans)
 }
 
 /// Render list of backend servers with their stats
-fn render_backend_list(
-    f: &mut Frame,
-    area: Rect,
-    snapshot: &crate::metrics::MetricsSnapshot,
-    servers: &[crate::config::Server],
-    app: &crate::tui::TuiApp,
-) {
-    let items: Vec<ListItem> = snapshot
-        .backend_stats
+fn render_backend_list(f: &mut Frame, area: Rect, state: &DashboardState) {
+    let items: Vec<ListItem> = state
+        .backend_views
         .iter()
-        .zip(servers.iter())
         .enumerate()
-        .map(|(i, (stats, server))| {
-            let (health_icon, health_color) = health_indicator(stats.health_status);
+        .map(|(i, backend)| {
+            let stats = &backend.stats;
+            let server = &backend.server;
+            let (health_icon, health_color) = health_indicator(backend.health_status);
             let error_rate = stats.error_rate_percent();
 
             // Format dynamic text values
-            let cmd_per_sec = app
-                .latest_backend_throughput(i)
+            let cmd_per_sec = backend
+                .latest_throughput()
                 .and_then(super::app::ThroughputPoint::commands_per_sec)
                 .map_or_else(
                     || text::DEFAULT_CMD_RATE.to_string(),
@@ -575,10 +549,10 @@ fn render_backend_list(
                 backend_address_line(
                     &server.host,
                     server.port.get(),
-                    app.backend_traffic_share(i),
+                    state.backend_traffic_share(i),
                 ),
                 backend_metrics_line(
-                    stats.active_connections.get(),
+                    backend.active_connections,
                     server.max_connections.get(),
                     cmd_per_sec,
                     ttfb,
@@ -594,11 +568,11 @@ fn render_backend_list(
             ];
 
             // Add details line in details mode
-            if app.show_details() {
+            if state.show_details {
                 content.push(backend_details_line(
-                    app.backend_pending_count(i),
-                    app.backend_load_ratio(i),
-                    app.backend_stateful_count(i),
+                    state.backend_pending_count(i),
+                    state.backend_load_ratio(i),
+                    state.backend_stateful_count(i),
                 ));
             }
 
@@ -611,34 +585,10 @@ fn render_backend_list(
     f.render_widget(list, area);
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_backend_error_count_color_highlights_any_error() {
-        assert_eq!(backend_error_count_color(0, 0), styles::VALUE_NEUTRAL);
-        assert_eq!(backend_error_count_color(1, 0), Color::Yellow);
-        assert_eq!(backend_error_count_color(0, 1), Color::Red);
-    }
-
-    #[test]
-    fn test_connection_failures_color_highlights_nonzero_failures() {
-        assert_eq!(connection_failures_color(0), styles::VALUE_NEUTRAL);
-        assert_eq!(connection_failures_color(1), Color::Red);
-    }
-
-    #[test]
-    fn test_buffer_utilization_percent_handles_zero_total() {
-        assert_eq!(buffer_utilization_percent(0, 0), 0.0);
-        assert_eq!(buffer_utilization_percent(9, 10), 90.0);
-    }
-}
-
 /// Render data flow visualization as line graphs
-fn render_data_flow(f: &mut Frame, area: Rect, servers: &[crate::config::Server], app: &TuiApp) {
+fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
     // Build chart data in single pass (no nested loops)
-    let (chart_data, max_throughput) = build_chart_data(servers, app);
+    let (chart_data, max_throughput) = build_chart_data(&state.backend_views);
 
     // Calculate chart bounds (extracted for testing)
     let max_throughput_rounded = calculate_chart_bounds(max_throughput);
@@ -730,9 +680,8 @@ fn render_footer(f: &mut Frame, area: Rect) {
 }
 
 /// Render recent log messages
-fn render_logs(f: &mut Frame, area: Rect, app: &TuiApp) {
-    let log_buffer = app.log_buffer();
-    let details = app.show_details();
+fn render_logs(f: &mut Frame, area: Rect, state: &DashboardState) {
+    let details = state.show_details;
     let visible_lines = area.height.saturating_sub(2) as usize;
     let fetch_count = if details {
         visible_lines * 3
@@ -740,12 +689,7 @@ fn render_logs(f: &mut Frame, area: Rect, app: &TuiApp) {
         visible_lines
     };
 
-    let text = log_buffer
-        .with_recent_lines(fetch_count, |lines, skip| {
-            lines.iter().skip(skip).cloned().collect::<Vec<_>>()
-        })
-        .unwrap_or_default()
-        .join("\n");
+    let text = recent_log_lines(&state.log_lines, fetch_count).join("\n");
 
     let mut paragraph = Paragraph::new(text)
         .style(Style::default().fg(Color::Gray))
@@ -756,6 +700,11 @@ fn render_logs(f: &mut Frame, area: Rect, app: &TuiApp) {
     }
 
     f.render_widget(paragraph, area);
+}
+
+fn recent_log_lines(lines: &[String], count: usize) -> &[String] {
+    let start = lines.len().saturating_sub(count);
+    &lines[start..]
 }
 
 /// Render per-user statistics panel
@@ -780,16 +729,13 @@ fn render_user_stats(f: &mut Frame, area: Rect, snapshot: &crate::metrics::Metri
                 " ".into(),
                 sparkline.fg(Color::Blue),
                 " ".into(),
-                format!("{:>5}", format_count(user.active_connections as u64))
-                    .fg(magnitude_color(user.active_connections as u64)),
+                format!("{:>5}", user.active_connections).fg(Color::Green),
             ]),
             Line::from(vec![
                 "  ↑".into(),
-                format!("{:>8}", format_bytes(user.bytes_sent.as_u64()))
-                    .fg(magnitude_color(user.bytes_sent.as_u64())),
+                format!("{:>8}", format_bytes(user.bytes_sent.as_u64())).fg(Color::Blue),
                 "  ↓".into(),
-                format!("{:>8}", format_bytes(user.bytes_received.as_u64()))
-                    .fg(magnitude_color(user.bytes_received.as_u64())),
+                format!("{:>8}", format_bytes(user.bytes_received.as_u64())).fg(Color::Magenta),
             ]),
             Line::from(vec![
                 "  Rate: ".into(),
@@ -833,4 +779,41 @@ fn render_user_stats(f: &mut Frame, area: Rect, snapshot: &crate::metrics::Metri
     let list = List::new(items).block(bordered_block(" Top Users ", styles::BORDER_ACTIVE));
 
     f.render_widget(list, area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recent_log_lines_returns_full_slice_when_count_exceeds_length() {
+        let lines = vec!["a".to_string(), "b".to_string(), "c".to_string()];
+
+        let recent = recent_log_lines(&lines, 10);
+
+        assert_eq!(recent, lines.as_slice());
+    }
+
+    #[test]
+    fn recent_log_lines_returns_tail_slice() {
+        let lines = vec![
+            "one".to_string(),
+            "two".to_string(),
+            "three".to_string(),
+            "four".to_string(),
+        ];
+
+        let recent = recent_log_lines(&lines, 2);
+
+        assert_eq!(recent, &lines[2..]);
+    }
+
+    #[test]
+    fn recent_log_lines_handles_zero_count() {
+        let lines = vec!["one".to_string(), "two".to_string()];
+
+        let recent = recent_log_lines(&lines, 0);
+
+        assert!(recent.is_empty());
+    }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,6 +1,7 @@
 //! TUI rendering and layout
 
 use crate::formatting::format_bytes;
+use crate::tui::RemoteDashboardStatus;
 use crate::tui::constants::{chart, layout, styles, text};
 use crate::tui::dashboard::{BufferPoolStats, DashboardState};
 use crate::tui::helpers::{
@@ -47,13 +48,14 @@ fn bordered_block(title: &'static str, border_color: Color) -> Block<'static> {
 // ============================================================================
 
 /// Render the main UI
-pub fn render_ui(
+pub(crate) fn render_ui(
     f: &mut Frame,
     state: &DashboardState,
     attached_ui_stats: Option<&crate::tui::SystemStats>,
+    remote_status: Option<&RemoteDashboardStatus>,
 ) {
     if let Some(chunks) = dashboard_fullscreen_chunks(state.view_mode, f.area()) {
-        render_title(f, chunks[0], &state.snapshot);
+        render_title(f, chunks[0], &state.snapshot, remote_status);
         render_logs(f, chunks[1], state);
         render_footer(f, chunks[2]);
         return;
@@ -63,7 +65,7 @@ pub fn render_ui(
     let chunks = dashboard_main_chunks(f.area(), show_logs);
 
     // Render each section
-    render_title(f, chunks[0], &state.snapshot);
+    render_title(f, chunks[0], &state.snapshot, remote_status);
     render_summary(f, chunks[1], state, attached_ui_stats);
 
     // Backends area now contains 3 columns: backends, chart, and user stats
@@ -126,26 +128,89 @@ fn dashboard_main_chunks(area: Rect, show_logs: bool) -> Vec<Rect> {
 }
 
 /// Render the title bar
-fn render_title(f: &mut Frame, area: Rect, snapshot: &crate::metrics::MetricsSnapshot) {
-    let title_line = Line::from(vec![
-        "NNTP Proxy ".fg(styles::BORDER_ACTIVE).bold(),
-        "- Real-Time Metrics Dashboard".fg(Color::White),
-    ]);
-
-    let info_line = Line::from(vec![
-        "Uptime: ".fg(styles::LABEL),
-        snapshot.format_uptime().fg(styles::VALUE_PRIMARY).bold(),
-        "  |  Active: ".fg(styles::LABEL),
-        format!("{} connections", snapshot.active_connections).fg(styles::VALUE_SECONDARY),
-        "  |  Total: ".fg(styles::LABEL),
-        format!("{} connections", snapshot.total_connections).fg(styles::VALUE_NEUTRAL),
-    ]);
-
-    let title = Paragraph::new(vec![title_line, info_line])
+fn render_title(
+    f: &mut Frame,
+    area: Rect,
+    snapshot: &crate::metrics::MetricsSnapshot,
+    remote_status: Option<&RemoteDashboardStatus>,
+) {
+    let title = Paragraph::new(build_title_lines(snapshot, remote_status))
         .block(bordered_block("", styles::BORDER_ACTIVE))
         .alignment(Alignment::Center);
 
     f.render_widget(title, area);
+}
+
+fn build_title_lines(
+    snapshot: &crate::metrics::MetricsSnapshot,
+    remote_status: Option<&RemoteDashboardStatus>,
+) -> Vec<Line<'static>> {
+    let title_suffix = remote_status.map_or_else(
+        || Span::from("- Real-Time Metrics Dashboard").fg(Color::White),
+        |status| match status {
+            RemoteDashboardStatus::Connecting { .. } => {
+                Span::from("- Attached Dashboard (connecting)").fg(Color::Yellow)
+            }
+            RemoteDashboardStatus::Connected { .. } => {
+                Span::from("- Attached Dashboard (live)").fg(styles::VALUE_PRIMARY)
+            }
+            RemoteDashboardStatus::Reconnecting { .. } => {
+                Span::from("- Attached Dashboard (reconnecting)").fg(Color::Yellow)
+            }
+        },
+    );
+
+    let info_line = remote_status.map_or_else(
+        || {
+            Line::from(vec![
+                "Uptime: ".fg(styles::LABEL),
+                snapshot.format_uptime().fg(styles::VALUE_PRIMARY).bold(),
+                "  |  Active: ".fg(styles::LABEL),
+                format!("{} connections", snapshot.active_connections).fg(styles::VALUE_SECONDARY),
+                "  |  Total: ".fg(styles::LABEL),
+                format!("{} connections", snapshot.total_connections).fg(styles::VALUE_NEUTRAL),
+            ])
+        },
+        build_remote_title_status_line,
+    );
+
+    vec![
+        Line::from(vec![
+            "NNTP Proxy ".fg(styles::BORDER_ACTIVE).bold(),
+            title_suffix,
+        ]),
+        info_line,
+    ]
+}
+
+fn build_remote_title_status_line(status: &RemoteDashboardStatus) -> Line<'static> {
+    match status {
+        RemoteDashboardStatus::Connecting { target } => Line::from(vec![
+            "Remote: ".fg(styles::LABEL),
+            "connecting".fg(Color::Yellow).bold(),
+            "  |  Target: ".fg(styles::LABEL),
+            target.to_string().fg(styles::VALUE_INFO),
+        ]),
+        RemoteDashboardStatus::Connected { target } => Line::from(vec![
+            "Remote: ".fg(styles::LABEL),
+            "live".fg(styles::VALUE_PRIMARY).bold(),
+            "  |  Target: ".fg(styles::LABEL),
+            target.to_string().fg(styles::VALUE_INFO),
+        ]),
+        RemoteDashboardStatus::Reconnecting {
+            target,
+            retry_delay,
+            ..
+        } => Line::from(vec![
+            "Remote: ".fg(styles::LABEL),
+            "reconnecting".fg(Color::Yellow).bold(),
+            format!(" in {:.1}s", retry_delay.as_secs_f32()).fg(styles::LABEL),
+            "  |  Target: ".fg(styles::LABEL),
+            target.to_string().fg(styles::VALUE_INFO),
+            "  |  Snapshot: ".fg(styles::LABEL),
+            "last known".fg(Color::Yellow),
+        ]),
+    }
 }
 
 /// Render summary statistics
@@ -978,6 +1043,48 @@ mod tests {
         assert_eq!(
             dashboard_main_chunks(Rect::new(0, 0, 80, 24), false).len(),
             4
+        );
+    }
+
+    #[test]
+    fn title_lines_switch_between_local_and_remote_status() {
+        let snapshot = MetricsSnapshot::default();
+        let local_lines = build_title_lines(&snapshot, None)
+            .into_iter()
+            .map(|line| line.to_string())
+            .collect::<Vec<_>>();
+        let remote_lines = build_title_lines(
+            &snapshot,
+            Some(&RemoteDashboardStatus::Reconnecting {
+                target: "127.0.0.1:8120".parse().unwrap(),
+                retry_delay: std::time::Duration::from_secs(1),
+                last_error: "connection dropped".to_string(),
+            }),
+        )
+        .into_iter()
+        .map(|line| line.to_string())
+        .collect::<Vec<_>>();
+
+        assert!(
+            local_lines
+                .iter()
+                .any(|line| line.contains("Real-Time Metrics Dashboard"))
+        );
+        assert!(local_lines.iter().any(|line| line.contains("Uptime:")));
+        assert!(
+            remote_lines
+                .iter()
+                .any(|line| line.contains("Attached Dashboard (reconnecting)"))
+        );
+        assert!(
+            remote_lines
+                .iter()
+                .any(|line| line.contains("Remote: reconnecting"))
+        );
+        assert!(
+            remote_lines
+                .iter()
+                .any(|line| line.contains("Snapshot: last known"))
         );
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -630,10 +630,10 @@ fn render_backend_list(f: &mut Frame, area: Rect, state: &DashboardState) {
         .iter()
         .enumerate()
         .map(|(i, backend)| {
-            let stats = &backend.stats;
+            let backend_stats = &backend.stats;
             let server = &backend.server;
             let (health_icon, health_color) = health_indicator(backend.health_status);
-            let error_rate = stats.error_rate_percent();
+            let error_rate = backend_stats.error_rate_percent();
 
             // Format dynamic text values
             let cmd_per_sec = backend
@@ -644,11 +644,11 @@ fn render_backend_list(f: &mut Frame, area: Rect, state: &DashboardState) {
                     |cps| format!("{:.0}", cps.get()),
                 );
 
-            let ttfb = stats
+            let ttfb = backend_stats
                 .average_ttfb_ms()
                 .map_or_else(|| "N/A".to_string(), |ms| format!("{ms:.1}ms"));
 
-            let avg_size = stats
+            let avg_size = backend_stats
                 .average_article_size()
                 .map_or_else(|| "N/A".to_string(), format_bytes);
 
@@ -672,13 +672,16 @@ fn render_backend_list(f: &mut Frame, area: Rect, state: &DashboardState) {
                     cmd_per_sec,
                     ttfb,
                 ),
-                backend_transfer_line(stats.bytes_sent.as_u64(), stats.bytes_received.as_u64()),
-                backend_article_line(avg_size, stats.article_count.get()),
+                backend_transfer_line(
+                    backend_stats.bytes_sent.as_u64(),
+                    backend_stats.bytes_received.as_u64(),
+                ),
+                backend_article_line(avg_size, backend_stats.article_count.get()),
                 backend_error_line(
-                    stats.errors_4xx.get(),
-                    stats.errors_5xx.get(),
-                    !stats.errors.is_zero(),
-                    stats.connection_failures.get(),
+                    backend_stats.errors_4xx.get(),
+                    backend_stats.errors_5xx.get(),
+                    !backend_stats.errors.is_zero(),
+                    backend_stats.connection_failures.get(),
                 ),
             ];
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -3,7 +3,9 @@
 use crate::formatting::format_bytes;
 use crate::tui::RemoteDashboardStatus;
 use crate::tui::constants::{chart, layout, styles, text};
-use crate::tui::dashboard::{BufferPoolStats, DashboardState};
+use crate::tui::dashboard::{
+    BufferPoolStats, DashboardMetrics, DashboardState, DashboardUserStats,
+};
 use crate::tui::helpers::{
     build_chart_data, calculate_chart_bounds, connection_failure_color, create_sparkline,
     error_count_color, error_rate_color, format_error_rate, format_summary_throughput,
@@ -55,7 +57,7 @@ pub(crate) fn render_ui(
     remote_status: Option<&RemoteDashboardStatus>,
 ) {
     if let Some(chunks) = dashboard_fullscreen_chunks(state.view_mode, f.area()) {
-        render_title(f, chunks[0], &state.snapshot, remote_status);
+        render_title(f, chunks[0], &state.metrics, remote_status);
         render_logs(f, chunks[1], state);
         render_footer(f, chunks[2]);
         return;
@@ -65,7 +67,7 @@ pub(crate) fn render_ui(
     let chunks = dashboard_main_chunks(f.area(), show_logs);
 
     // Render each section
-    render_title(f, chunks[0], &state.snapshot, remote_status);
+    render_title(f, chunks[0], &state.metrics, remote_status);
     render_summary(f, chunks[1], state, attached_ui_stats);
 
     // Backends area now contains 3 columns: backends, chart, and user stats
@@ -131,10 +133,10 @@ fn dashboard_main_chunks(area: Rect, show_logs: bool) -> Vec<Rect> {
 fn render_title(
     f: &mut Frame,
     area: Rect,
-    snapshot: &crate::metrics::MetricsSnapshot,
+    metrics: &DashboardMetrics,
     remote_status: Option<&RemoteDashboardStatus>,
 ) {
-    let title = Paragraph::new(build_title_lines(snapshot, remote_status))
+    let title = Paragraph::new(build_title_lines(metrics, remote_status))
         .block(bordered_block("", styles::BORDER_ACTIVE))
         .alignment(Alignment::Center);
 
@@ -142,7 +144,7 @@ fn render_title(
 }
 
 fn build_title_lines(
-    snapshot: &crate::metrics::MetricsSnapshot,
+    metrics: &DashboardMetrics,
     remote_status: Option<&RemoteDashboardStatus>,
 ) -> Vec<Line<'static>> {
     let title_suffix = remote_status.map_or_else(
@@ -164,11 +166,11 @@ fn build_title_lines(
         || {
             Line::from(vec![
                 "Uptime: ".fg(styles::LABEL),
-                snapshot.format_uptime().fg(styles::VALUE_PRIMARY).bold(),
+                metrics.format_uptime().fg(styles::VALUE_PRIMARY).bold(),
                 "  |  Active: ".fg(styles::LABEL),
-                format!("{} connections", snapshot.active_connections).fg(styles::VALUE_SECONDARY),
+                format!("{} connections", metrics.active_connections).fg(styles::VALUE_SECONDARY),
                 "  |  Total: ".fg(styles::LABEL),
-                format!("{} connections", snapshot.total_connections).fg(styles::VALUE_NEUTRAL),
+                format!("{} connections", metrics.total_connections).fg(styles::VALUE_NEUTRAL),
             ])
         },
         build_remote_title_status_line,
@@ -220,7 +222,7 @@ fn render_summary(
     state: &DashboardState,
     attached_ui_stats: Option<&crate::tui::SystemStats>,
 ) {
-    let snapshot = &state.snapshot;
+    let metrics = &state.metrics;
     let system_stats = &state.system_stats;
 
     // Get latest throughput from history (extracted for testing)
@@ -239,7 +241,7 @@ fn render_summary(
 
     // Left: App summary (uptime, sessions, buffer stats in details mode)
     let left_summary = create_app_summary(
-        snapshot,
+        metrics,
         system_stats,
         state.buffer_pool(),
         state.show_details,
@@ -247,11 +249,11 @@ fn render_summary(
     );
 
     // Middle: Cache summary
-    let middle_summary = create_cache_summary(snapshot);
+    let middle_summary = create_cache_summary(metrics);
 
     // Right: Data transfer summary
     let right_summary =
-        create_transfer_summary(snapshot, &client_to_backend_str, &backend_to_client_str);
+        create_transfer_summary(metrics, &client_to_backend_str, &backend_to_client_str);
 
     f.render_widget(left_summary, summary_chunks[0]);
     f.render_widget(middle_summary, summary_chunks[1]);
@@ -268,7 +270,7 @@ fn render_backends(f: &mut Frame, area: Rect, state: &DashboardState) {
 
     render_backend_list(f, chunks[0], state);
     render_data_flow(f, chunks[1], state);
-    render_user_stats(f, chunks[2], &state.snapshot);
+    render_user_stats(f, chunks[2], &state.top_users);
 }
 
 // ============================================================================
@@ -277,14 +279,14 @@ fn render_backends(f: &mut Frame, area: Rect, state: &DashboardState) {
 
 /// Create app summary panel (uptime, CPU, memory, buffer stats in details mode)
 fn create_app_summary(
-    snapshot: &crate::metrics::MetricsSnapshot,
+    metrics: &DashboardMetrics,
     system_stats: &crate::tui::SystemStats,
     buffer_pool: Option<&BufferPoolStats>,
     show_details: bool,
     attached_ui_stats: Option<&crate::tui::SystemStats>,
 ) -> Paragraph<'static> {
     let lines = build_app_summary_lines(
-        snapshot,
+        metrics,
         system_stats,
         buffer_pool,
         show_details,
@@ -296,7 +298,7 @@ fn create_app_summary(
 }
 
 fn build_app_summary_lines(
-    snapshot: &crate::metrics::MetricsSnapshot,
+    metrics: &DashboardMetrics,
     system_stats: &crate::tui::SystemStats,
     buffer_pool: Option<&BufferPoolStats>,
     show_details: bool,
@@ -334,11 +336,11 @@ fn build_app_summary_lines(
     let mut lines = vec![
         Line::from(vec![
             "Uptime: ".fg(styles::LABEL),
-            snapshot.format_uptime().fg(styles::VALUE_PRIMARY),
+            metrics.format_uptime().fg(styles::VALUE_PRIMARY),
         ]),
         Line::from(vec![
             "Stateful Sessions: ".fg(styles::LABEL),
-            format!("{}", snapshot.stateful_sessions).fg(session_color(snapshot.stateful_sessions)),
+            format!("{}", metrics.stateful_sessions).fg(session_color(metrics.stateful_sessions)),
         ]),
     ];
 
@@ -370,25 +372,25 @@ fn build_app_summary_lines(
         ]);
     }
 
-    if snapshot.pipeline_batches > 0 {
+    if metrics.pipeline_batches > 0 {
         let avg_batch =
-            counter_as_f64(snapshot.pipeline_commands) / counter_as_f64(snapshot.pipeline_batches);
+            counter_as_f64(metrics.pipeline_commands) / counter_as_f64(metrics.pipeline_batches);
         lines.push(Line::from(vec![
             "Pipeline: ".fg(styles::LABEL),
             format!(
                 "{} batches (avg {:.1} cmds)",
-                snapshot.pipeline_batches, avg_batch
+                metrics.pipeline_batches, avg_batch
             )
             .fg(styles::VALUE_INFO),
         ]));
     }
 
-    if snapshot.pipeline_requests_queued > 0 {
+    if metrics.pipeline_requests_queued > 0 {
         lines.push(Line::from(vec![
             "Mux Queue: ".fg(styles::LABEL),
             format!(
                 "{} queued, {} completed",
-                snapshot.pipeline_requests_queued, snapshot.pipeline_requests_completed
+                metrics.pipeline_requests_queued, metrics.pipeline_requests_completed
             )
             .fg(styles::VALUE_INFO),
         ]));
@@ -411,7 +413,7 @@ fn build_app_summary_lines(
 }
 
 /// Create cache summary panel
-fn create_cache_summary(snapshot: &crate::metrics::MetricsSnapshot) -> Paragraph<'static> {
+fn create_cache_summary(metrics: &DashboardMetrics) -> Paragraph<'static> {
     /// Color for cache entries (highlight if non-empty)
     const fn entries_color(count: u64) -> Color {
         if count > 0 {
@@ -441,17 +443,17 @@ fn create_cache_summary(snapshot: &crate::metrics::MetricsSnapshot) -> Paragraph
     }
 
     // Check if this is hybrid cache mode
-    let is_hybrid = snapshot.disk_cache.is_some();
+    let is_hybrid = metrics.disk_cache.is_some();
 
     // Build lines based on cache type
     let lines = if is_hybrid {
         // Hybrid cache: show disk-relevant stats
-        let disk = snapshot.disk_cache.as_ref().unwrap();
+        let disk = metrics.disk_cache.as_ref().unwrap();
         vec![
             Line::from(vec![
                 "Hit Rate: ".fg(styles::LABEL),
-                format!("{:.1}%", snapshot.cache_hit_rate)
-                    .fg(hit_rate_color(snapshot.cache_hit_rate)),
+                format!("{:.1}%", metrics.cache_hit_rate)
+                    .fg(hit_rate_color(metrics.cache_hit_rate)),
             ]),
             Line::from(vec![
                 "Disk Written: ".fg(styles::LABEL),
@@ -476,16 +478,16 @@ fn create_cache_summary(snapshot: &crate::metrics::MetricsSnapshot) -> Paragraph
         vec![
             Line::from(vec![
                 "Entries: ".fg(styles::LABEL),
-                format!("{}", snapshot.cache_entries).fg(entries_color(snapshot.cache_entries)),
+                format!("{}", metrics.cache_entries).fg(entries_color(metrics.cache_entries)),
             ]),
             Line::from(vec![
                 "Size: ".fg(styles::LABEL),
-                format_bytes(snapshot.cache_size_bytes).fg(styles::VALUE_NEUTRAL),
+                format_bytes(metrics.cache_size_bytes).fg(styles::VALUE_NEUTRAL),
             ]),
             Line::from(vec![
                 "Hit Rate: ".fg(styles::LABEL),
-                format!("{:.1}%", snapshot.cache_hit_rate)
-                    .fg(hit_rate_color(snapshot.cache_hit_rate)),
+                format!("{:.1}%", metrics.cache_hit_rate)
+                    .fg(hit_rate_color(metrics.cache_hit_rate)),
             ]),
         ]
     };
@@ -499,7 +501,7 @@ fn create_cache_summary(snapshot: &crate::metrics::MetricsSnapshot) -> Paragraph
 
 /// Create data transfer summary panel
 fn create_transfer_summary<'a>(
-    snapshot: &crate::metrics::MetricsSnapshot,
+    metrics: &DashboardMetrics,
     client_to_backend: &'a str,
     backend_to_client: &'a str,
 ) -> Paragraph<'a> {
@@ -514,7 +516,7 @@ fn create_transfer_summary<'a>(
         ]),
         Line::from(vec![
             "Total: ".fg(styles::LABEL),
-            format_bytes(snapshot.total_bytes()).fg(styles::VALUE_PRIMARY),
+            format_bytes(metrics.total_bytes()).fg(styles::VALUE_PRIMARY),
         ]),
     ])
     .block(bordered_block("Data Transfer", styles::BORDER_NORMAL))
@@ -826,7 +828,7 @@ fn recent_log_lines(lines: &[String], count: usize) -> &[String] {
 }
 
 /// Render per-user statistics panel
-fn render_user_stats(f: &mut Frame, area: Rect, snapshot: &crate::metrics::MetricsSnapshot) {
+fn render_user_stats(f: &mut Frame, area: Rect, top_users: &[DashboardUserStats]) {
     /// Truncate username to fit display width
     fn format_username(username: &str) -> String {
         const MAX_LEN: usize = 12;
@@ -840,7 +842,7 @@ fn render_user_stats(f: &mut Frame, area: Rect, snapshot: &crate::metrics::Metri
     }
 
     /// Create user stat lines
-    fn user_stat_lines(user: &crate::metrics::UserStats, sparkline: String) -> Vec<Line<'static>> {
+    fn user_stat_lines(user: &DashboardUserStats, sparkline: String) -> Vec<Line<'static>> {
         vec![
             Line::from(vec![
                 format_username(&user.username).fg(Color::Cyan),
@@ -864,7 +866,6 @@ fn render_user_stats(f: &mut Frame, area: Rect, snapshot: &crate::metrics::Metri
         ]
     }
 
-    let top_users = top_users_by_bytes(&snapshot.user_stats);
     let max_total = top_users.iter().map(|u| u.total_bytes()).max().unwrap_or(1);
 
     // Header row
@@ -878,7 +879,7 @@ fn render_user_stats(f: &mut Frame, area: Rect, snapshot: &crate::metrics::Metri
 
     // User rows - functional map
     let user_items: Vec<ListItem> = top_users
-        .into_iter()
+        .iter()
         .map(|user| {
             let sparkline = create_sparkline(user.total_bytes(), max_total);
             ListItem::new(user_stat_lines(user, sparkline))
@@ -895,26 +896,25 @@ fn render_user_stats(f: &mut Frame, area: Rect, snapshot: &crate::metrics::Metri
     f.render_widget(list, area);
 }
 
-fn top_users_by_bytes(users: &[crate::metrics::UserStats]) -> Vec<&crate::metrics::UserStats> {
-    let mut sorted_users = users.iter().collect::<Vec<_>>();
-    sorted_users.sort_by_key(|user| std::cmp::Reverse(user.total_bytes()));
-    sorted_users.into_iter().take(10).collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::metrics::MetricsSnapshot;
-    use crate::metrics::UserStats;
+    use crate::metrics::{CommandCount, ErrorCount};
     use crate::tui::app::ViewMode;
-    use crate::tui::dashboard::BufferPoolStats;
+    use crate::tui::dashboard::{BufferPoolStats, DashboardMetrics};
     use ratatui::layout::Rect;
 
-    fn user_stats(name: &str, total_bytes: u64) -> UserStats {
-        UserStats {
+    fn user_stats(name: &str, total_bytes: u64) -> DashboardUserStats {
+        DashboardUserStats {
             username: name.to_string(),
+            active_connections: 0,
+            total_connections: crate::types::TotalConnections::new(0),
             bytes_sent: crate::types::BytesSent::new(total_bytes),
-            ..Default::default()
+            bytes_received: crate::types::BytesReceived::ZERO,
+            bytes_sent_per_sec: crate::types::BytesPerSecondRate::new(0),
+            bytes_received_per_sec: crate::types::BytesPerSecondRate::new(0),
+            total_commands: CommandCount::new(0),
+            errors: ErrorCount::new(0),
         }
     }
 
@@ -951,38 +951,31 @@ mod tests {
     }
 
     #[test]
-    fn top_users_by_bytes_sorts_descending() {
-        let users = vec![
-            user_stats("alice", 10),
+    fn render_user_stats_uses_pre_sorted_users() {
+        let users = [
             user_stats("bob", 30),
             user_stats("carol", 20),
+            user_stats("alice", 10),
         ];
-
-        let top_users = top_users_by_bytes(&users);
-
-        let usernames = top_users
+        let rendered = users
             .iter()
-            .map(|user| user.username.as_str())
-            .collect::<Vec<_>>();
-        assert_eq!(usernames, vec!["bob", "carol", "alice"]);
-    }
-
-    #[test]
-    fn top_users_by_bytes_caps_results_at_ten() {
-        let users = (0..12)
-            .map(|i| user_stats(&format!("user{i}"), i))
+            .map(|user| {
+                user_stat_lines_for_test(user)
+                    .into_iter()
+                    .next()
+                    .unwrap()
+                    .to_string()
+            })
             .collect::<Vec<_>>();
 
-        let top_users = top_users_by_bytes(&users);
-
-        assert_eq!(top_users.len(), 10);
-        assert_eq!(top_users[0].username, "user11");
-        assert_eq!(top_users[9].username, "user2");
+        assert!(rendered[0].contains("bob"));
+        assert!(rendered[1].contains("carol"));
+        assert!(rendered[2].contains("alice"));
     }
 
     #[test]
     fn app_summary_lines_switch_between_local_and_remote_stats() {
-        let snapshot = MetricsSnapshot::default();
+        let metrics = DashboardMetrics::default();
         let system_stats = crate::tui::SystemStats::default();
         let buffer_pool = BufferPoolStats {
             available: 3,
@@ -991,12 +984,12 @@ mod tests {
         };
 
         let local_lines =
-            build_app_summary_lines(&snapshot, &system_stats, Some(&buffer_pool), true, None)
+            build_app_summary_lines(&metrics, &system_stats, Some(&buffer_pool), true, None)
                 .into_iter()
                 .map(|line| line.to_string())
                 .collect::<Vec<_>>();
         let remote_lines = build_app_summary_lines(
-            &snapshot,
+            &metrics,
             &system_stats,
             Some(&buffer_pool),
             true,
@@ -1051,13 +1044,13 @@ mod tests {
 
     #[test]
     fn title_lines_switch_between_local_and_remote_status() {
-        let snapshot = MetricsSnapshot::default();
-        let local_lines = build_title_lines(&snapshot, None)
+        let metrics = DashboardMetrics::default();
+        let local_lines = build_title_lines(&metrics, None)
             .into_iter()
             .map(|line| line.to_string())
             .collect::<Vec<_>>();
         let remote_lines = build_title_lines(
-            &snapshot,
+            &metrics,
             Some(&RemoteDashboardStatus::Reconnecting {
                 target: "127.0.0.1:8120".parse().unwrap(),
                 retry_delay: std::time::Duration::from_secs(1),
@@ -1089,5 +1082,40 @@ mod tests {
                 .iter()
                 .any(|line| line.contains("Snapshot: last known"))
         );
+    }
+
+    fn user_stat_lines_for_test(user: &DashboardUserStats) -> Vec<Line<'static>> {
+        fn format_username(username: &str) -> String {
+            const MAX_LEN: usize = 12;
+            const TRUNCATE_AT: usize = 9;
+            if username.len() > MAX_LEN {
+                let truncated: String = username.chars().take(TRUNCATE_AT).collect();
+                format!("{truncated}...")
+            } else {
+                format!("{username:<MAX_LEN$}")
+            }
+        }
+
+        vec![
+            Line::from(vec![
+                format_username(&user.username).fg(Color::Cyan),
+                " ".into(),
+                create_sparkline(user.total_bytes(), user.total_bytes()).fg(Color::Blue),
+                " ".into(),
+                format!("{:>5}", user.active_connections).fg(Color::Green),
+            ]),
+            Line::from(vec![
+                "  ↑".into(),
+                format!("{:>8}", format_bytes(user.bytes_sent.as_u64())).fg(Color::Blue),
+                "  ↓".into(),
+                format!("{:>8}", format_bytes(user.bytes_received.as_u64())).fg(Color::Magenta),
+            ]),
+            Line::from(vec![
+                "  Rate: ".into(),
+                format!("↑{}/s", format_bytes(user.bytes_sent_per_sec.get())).fg(Color::Cyan),
+                " ".into(),
+                format!("↓{}/s", format_bytes(user.bytes_received_per_sec.get())).fg(Color::Yellow),
+            ]),
+        ]
     }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -52,52 +52,15 @@ pub fn render_ui(
     state: &DashboardState,
     attached_ui_stats: Option<&crate::tui::SystemStats>,
 ) {
-    use crate::tui::app::ViewMode;
-
-    // Check if we're in log fullscreen mode
-    if state.view_mode == ViewMode::LogFullscreen {
-        // Fullscreen logs - show only title and logs
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .margin(1)
-            .constraints([
-                Constraint::Length(layout::TITLE_HEIGHT),
-                Constraint::Min(10), // Most of screen for logs
-                Constraint::Length(layout::FOOTER_HEIGHT),
-            ])
-            .split(f.area());
-
+    if let Some(chunks) = dashboard_fullscreen_chunks(state.view_mode, f.area()) {
         render_title(f, chunks[0], &state.snapshot);
         render_logs(f, chunks[1], state);
         render_footer(f, chunks[2]);
         return;
     }
 
-    // Normal mode - show all panels
-    // Determine if we have enough space for a log window
-    // We need at least 40 lines total to fit everything comfortably
-    let show_logs = f.area().height >= layout::MIN_HEIGHT_FOR_LOGS;
-
-    // Create main layout - dynamically add log section based on available space
-    let chunks = if show_logs {
-        Layout::default()
-            .direction(Direction::Vertical)
-            .margin(1)
-            .constraints([
-                Constraint::Length(layout::TITLE_HEIGHT),
-                Constraint::Length(layout::SUMMARY_HEIGHT),
-                Constraint::Min(layout::MIN_CHART_HEIGHT),
-                Constraint::Length(layout::LOG_WINDOW_HEIGHT),
-                Constraint::Length(layout::FOOTER_HEIGHT),
-            ])
-            .split(f.area())
-    } else {
-        Layout::default()
-            .direction(Direction::Vertical)
-            .margin(1)
-            .constraints(layout::main_sections())
-            .split(f.area())
-    };
+    let show_logs = should_show_dashboard_logs(f.area().height);
+    let chunks = dashboard_main_chunks(f.area(), show_logs);
 
     // Render each section
     render_title(f, chunks[0], &state.snapshot);
@@ -111,6 +74,54 @@ pub fn render_ui(
         render_footer(f, chunks[4]);
     } else {
         render_footer(f, chunks[3]);
+    }
+}
+
+fn should_show_dashboard_logs(area_height: u16) -> bool {
+    area_height >= layout::MIN_HEIGHT_FOR_LOGS
+}
+
+fn dashboard_fullscreen_chunks(
+    view_mode: crate::tui::app::ViewMode,
+    area: Rect,
+) -> Option<[Rect; 3]> {
+    if view_mode != crate::tui::app::ViewMode::LogFullscreen {
+        return None;
+    }
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([
+            Constraint::Length(layout::TITLE_HEIGHT),
+            Constraint::Min(10),
+            Constraint::Length(layout::FOOTER_HEIGHT),
+        ])
+        .split(area);
+    Some([chunks[0], chunks[1], chunks[2]])
+}
+
+fn dashboard_main_chunks(area: Rect, show_logs: bool) -> Vec<Rect> {
+    if show_logs {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .margin(1)
+            .constraints([
+                Constraint::Length(layout::TITLE_HEIGHT),
+                Constraint::Length(layout::SUMMARY_HEIGHT),
+                Constraint::Min(layout::MIN_CHART_HEIGHT),
+                Constraint::Length(layout::LOG_WINDOW_HEIGHT),
+                Constraint::Length(layout::FOOTER_HEIGHT),
+            ])
+            .split(area)
+            .to_vec()
+    } else {
+        Layout::default()
+            .direction(Direction::Vertical)
+            .margin(1)
+            .constraints(layout::main_sections())
+            .split(area)
+            .to_vec()
     }
 }
 
@@ -827,7 +838,9 @@ mod tests {
     use super::*;
     use crate::metrics::MetricsSnapshot;
     use crate::metrics::UserStats;
+    use crate::tui::app::ViewMode;
     use crate::tui::dashboard::BufferPoolStats;
+    use ratatui::layout::Rect;
 
     fn user_stats(name: &str, total_bytes: u64) -> UserStats {
         UserStats {
@@ -945,6 +958,26 @@ mod tests {
             !remote_lines
                 .iter()
                 .any(|line| line.contains("CPU:") && !line.contains("proxy"))
+        );
+    }
+
+    #[test]
+    fn dashboard_layout_helpers_distinguish_modes_and_height() {
+        assert!(should_show_dashboard_logs(layout::MIN_HEIGHT_FOR_LOGS));
+        assert!(!should_show_dashboard_logs(layout::MIN_HEIGHT_FOR_LOGS - 1));
+
+        assert!(
+            dashboard_fullscreen_chunks(ViewMode::LogFullscreen, Rect::new(0, 0, 80, 24)).is_some()
+        );
+        assert!(dashboard_fullscreen_chunks(ViewMode::Normal, Rect::new(0, 0, 80, 24)).is_none());
+
+        assert_eq!(
+            dashboard_main_chunks(Rect::new(0, 0, 80, 24), true).len(),
+            5
+        );
+        assert_eq!(
+            dashboard_main_chunks(Rect::new(0, 0, 80, 24), false).len(),
+            4
         );
     }
 }

--- a/src/types/tui.rs
+++ b/src/types/tui.rs
@@ -42,7 +42,7 @@ impl Default for HistorySize {
 ///
 /// This is distinct from `metrics::BytesPerSecond` (u64) which is used for rate calculations.
 /// This type includes display formatting methods for the TUI.
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 pub struct Throughput(f64);
 
 impl Throughput {
@@ -111,7 +111,7 @@ impl From<f64> for Throughput {
 }
 
 /// Type-safe command rate in commands per second
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, serde::Serialize, serde::Deserialize)]
 pub struct CommandsPerSecond(f64);
 
 impl CommandsPerSecond {

--- a/tests/cache/cache_before_precheck.rs
+++ b/tests/cache/cache_before_precheck.rs
@@ -23,8 +23,6 @@ use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 
-use crate::test_helpers::get_available_port;
-
 /// Count how many times backends are queried
 #[derive(Clone)]
 struct BackendQueryCounter {
@@ -53,17 +51,13 @@ impl BackendQueryCounter {
 
 /// Spawn mock server that counts queries
 fn spawn_counting_mock_server(
-    port: u16,
+    listener: TcpListener,
     name: &str,
     counter: BackendQueryCounter,
     has_article: bool,
 ) -> tokio::task::AbortHandle {
     let name = name.to_string();
     let task = tokio::spawn(async move {
-        let listener = TcpListener::bind(format!("127.0.0.1:{port}"))
-            .await
-            .unwrap();
-
         loop {
             let (mut stream, _) = listener.accept().await.unwrap();
             let counter = counter.clone();
@@ -161,6 +155,25 @@ fn spawn_counting_mock_server(
     task.abort_handle()
 }
 
+async fn spawn_test_proxy(proxy: NntpProxy) -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+
+    tokio::spawn(async move {
+        while let Ok((stream, addr)) = listener.accept().await {
+            let proxy = proxy.clone();
+            tokio::spawn(async move {
+                proxy
+                    .handle_client_per_command_routing(stream, addr.into())
+                    .await
+                    .ok();
+            });
+        }
+    });
+
+    port
+}
+
 /// CRITICAL TEST: Cache check must happen BEFORE adaptive prechecking for STAT
 ///
 /// Bug history:
@@ -174,14 +187,14 @@ fn spawn_counting_mock_server(
 /// - Second STAT: Cache hit, ZERO backend queries (instant response)
 #[tokio::test]
 async fn test_stat_cache_hit_zero_backend_queries() {
-    let proxy_port = get_available_port().await.unwrap();
-    let backend_port = get_available_port().await.unwrap();
+    let backend_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let backend_port = backend_listener.local_addr().unwrap().port();
 
     // Create counter to track backend queries
     let counter = BackendQueryCounter::new();
 
     // Spawn counting mock server (has article)
-    let _mock = spawn_counting_mock_server(backend_port, "TestBackend", counter.clone(), true);
+    let _mock = spawn_counting_mock_server(backend_listener, "TestBackend", counter.clone(), true);
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // Create proxy config with caching and adaptive precheck
@@ -204,20 +217,7 @@ async fn test_stat_cache_hit_zero_backend_queries() {
     let proxy = nntp_proxy::NntpProxy::new(config.clone(), RoutingMode::PerCommand)
         .await
         .unwrap();
-    let listener = TcpListener::bind(format!("127.0.0.1:{proxy_port}"))
-        .await
-        .unwrap();
-    let _proxy_handle = tokio::spawn(async move {
-        while let Ok((stream, addr)) = listener.accept().await {
-            let proxy = proxy.clone();
-            tokio::spawn(async move {
-                proxy
-                    .handle_client_per_command_routing(stream, addr.into())
-                    .await
-                    .ok();
-            });
-        }
-    });
+    let proxy_port = spawn_test_proxy(proxy).await;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     // Connect client
@@ -284,11 +284,11 @@ async fn test_stat_cache_hit_zero_backend_queries() {
 /// CRITICAL TEST: HEAD command cache hits must not query backends
 #[tokio::test]
 async fn test_head_cache_hit_zero_backend_queries() {
-    let proxy_port = get_available_port().await.unwrap();
-    let backend_port = get_available_port().await.unwrap();
+    let backend_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let backend_port = backend_listener.local_addr().unwrap().port();
 
     let counter = BackendQueryCounter::new();
-    let _mock = spawn_counting_mock_server(backend_port, "TestBackend", counter.clone(), true);
+    let _mock = spawn_counting_mock_server(backend_listener, "TestBackend", counter.clone(), true);
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let config = Config {
@@ -309,20 +309,7 @@ async fn test_head_cache_hit_zero_backend_queries() {
     let proxy = NntpProxy::new(config.clone(), RoutingMode::PerCommand)
         .await
         .unwrap();
-    let listener = TcpListener::bind(format!("127.0.0.1:{proxy_port}"))
-        .await
-        .unwrap();
-    let _proxy_handle = tokio::spawn(async move {
-        while let Ok((stream, addr)) = listener.accept().await {
-            let proxy = proxy.clone();
-            tokio::spawn(async move {
-                proxy
-                    .handle_client_per_command_routing(stream, addr.into())
-                    .await
-                    .ok();
-            });
-        }
-    });
+    let proxy_port = spawn_test_proxy(proxy).await;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let mut client = TcpStream::connect(format!("127.0.0.1:{proxy_port}"))
@@ -392,11 +379,11 @@ async fn test_head_cache_hit_zero_backend_queries() {
 /// CRITICAL TEST: ARTICLE command cache hits must not query backends
 #[tokio::test]
 async fn test_article_cache_hit_zero_backend_queries() {
-    let proxy_port = get_available_port().await.unwrap();
-    let backend_port = get_available_port().await.unwrap();
+    let backend_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let backend_port = backend_listener.local_addr().unwrap().port();
 
     let counter = BackendQueryCounter::new();
-    let _mock = spawn_counting_mock_server(backend_port, "TestBackend", counter.clone(), true);
+    let _mock = spawn_counting_mock_server(backend_listener, "TestBackend", counter.clone(), true);
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let config = Config {
@@ -417,20 +404,7 @@ async fn test_article_cache_hit_zero_backend_queries() {
     let proxy = NntpProxy::new(config.clone(), RoutingMode::PerCommand)
         .await
         .unwrap();
-    let listener = TcpListener::bind(format!("127.0.0.1:{proxy_port}"))
-        .await
-        .unwrap();
-    let _proxy_handle = tokio::spawn(async move {
-        while let Ok((stream, addr)) = listener.accept().await {
-            let proxy = proxy.clone();
-            tokio::spawn(async move {
-                proxy
-                    .handle_client_per_command_routing(stream, addr.into())
-                    .await
-                    .ok();
-            });
-        }
-    });
+    let proxy_port = spawn_test_proxy(proxy).await;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let mut client = TcpStream::connect(format!("127.0.0.1:{proxy_port}"))
@@ -500,11 +474,11 @@ async fn test_article_cache_hit_zero_backend_queries() {
 /// Fake-backend test: without article payload caching, ARTICLE requests still go upstream.
 #[tokio::test]
 async fn test_article_without_payload_cache_queries_backend_each_time() {
-    let proxy_port = get_available_port().await.unwrap();
-    let backend_port = get_available_port().await.unwrap();
+    let backend_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let backend_port = backend_listener.local_addr().unwrap().port();
 
     let counter = BackendQueryCounter::new();
-    let _mock = spawn_counting_mock_server(backend_port, "TestBackend", counter.clone(), true);
+    let _mock = spawn_counting_mock_server(backend_listener, "TestBackend", counter.clone(), true);
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let config = Config {
@@ -525,20 +499,7 @@ async fn test_article_without_payload_cache_queries_backend_each_time() {
     let proxy = NntpProxy::new(config.clone(), RoutingMode::PerCommand)
         .await
         .unwrap();
-    let listener = TcpListener::bind(format!("127.0.0.1:{proxy_port}"))
-        .await
-        .unwrap();
-    let _proxy_handle = tokio::spawn(async move {
-        while let Ok((stream, addr)) = listener.accept().await {
-            let proxy = proxy.clone();
-            tokio::spawn(async move {
-                proxy
-                    .handle_client_per_command_routing(stream, addr.into())
-                    .await
-                    .ok();
-            });
-        }
-    });
+    let proxy_port = spawn_test_proxy(proxy).await;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let mut client = TcpStream::connect(format!("127.0.0.1:{proxy_port}"))
@@ -579,12 +540,12 @@ async fn test_article_without_payload_cache_queries_backend_each_time() {
 /// CRITICAL TEST: Cached 430s must not trigger backend queries
 #[tokio::test]
 async fn test_cached_430_zero_backend_queries() {
-    let proxy_port = get_available_port().await.unwrap();
-    let backend_port = get_available_port().await.unwrap();
+    let backend_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let backend_port = backend_listener.local_addr().unwrap().port();
 
     let counter = BackendQueryCounter::new();
     // Server doesn't have article (returns 430)
-    let _mock = spawn_counting_mock_server(backend_port, "TestBackend", counter.clone(), false);
+    let _mock = spawn_counting_mock_server(backend_listener, "TestBackend", counter.clone(), false);
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     let config = Config {
@@ -605,20 +566,7 @@ async fn test_cached_430_zero_backend_queries() {
     let proxy = NntpProxy::new(config.clone(), RoutingMode::PerCommand)
         .await
         .unwrap();
-    let listener = TcpListener::bind(format!("127.0.0.1:{proxy_port}"))
-        .await
-        .unwrap();
-    let _proxy_handle = tokio::spawn(async move {
-        while let Ok((stream, addr)) = listener.accept().await {
-            let proxy = proxy.clone();
-            tokio::spawn(async move {
-                proxy
-                    .handle_client_per_command_routing(stream, addr.into())
-                    .await
-                    .ok();
-            });
-        }
-    });
+    let proxy_port = spawn_test_proxy(proxy).await;
     tokio::time::sleep(Duration::from_millis(200)).await;
 
     let mut client = TcpStream::connect(format!("127.0.0.1:{proxy_port}"))

--- a/tests/proxy/routing/backend_availability.rs
+++ b/tests/proxy/routing/backend_availability.rs
@@ -9,10 +9,28 @@
 use anyhow::Result;
 use nntp_proxy::RoutingMode;
 use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 use crate::test_helpers::{
     connect_and_read_greeting, send_article_read_multiline_response, setup_proxy_with_backends,
 };
+
+async fn read_line(stream: &mut tokio::net::TcpStream, context: &str) -> Result<String> {
+    let mut bytes = Vec::with_capacity(128);
+    let mut byte = [0u8; 1];
+
+    loop {
+        let n = tokio::time::timeout(Duration::from_secs(2), stream.read(&mut byte)).await??;
+        if n == 0 {
+            anyhow::bail!("Connection closed while reading {context}");
+        }
+
+        bytes.push(byte[0]);
+        if byte[0] == b'\n' {
+            return String::from_utf8(bytes).map_err(Into::into);
+        }
+    }
+}
 
 #[tokio::test]
 async fn test_all_backends_exhausted_returns_430() -> Result<()> {
@@ -184,6 +202,45 @@ async fn test_retry_stops_after_all_backends_tried() -> Result<()> {
         duration < Duration::from_secs(5),
         "Should not take more than 5 seconds"
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_pipelined_missing_articles_fall_back_to_430_responses() -> Result<()> {
+    let (proxy_port, _backend_ports, _mock_handles) = setup_proxy_with_backends(
+        vec![("Backend1", false), ("Backend2", false)],
+        RoutingMode::PerCommand,
+    )
+    .await?;
+
+    let mut client = connect_and_read_greeting(proxy_port).await?;
+
+    let (status, body) =
+        send_article_read_multiline_response(&mut client, "<cached-missing@example.com>").await?;
+    assert!(status.starts_with("430"));
+    assert!(body.is_empty());
+
+    client
+        .write_all(
+            b"ARTICLE <cached-missing@example.com>\r\nARTICLE <cached-missing@example.com>\r\n",
+        )
+        .await?;
+    client.flush().await?;
+
+    let first = read_line(&mut client, "first pipelined ARTICLE response").await?;
+    let second = read_line(&mut client, "second pipelined ARTICLE response").await?;
+
+    assert!(
+        first.starts_with("430"),
+        "Expected 430 for first pipelined cached-missing ARTICLE, got: {first}"
+    );
+    assert!(
+        second.starts_with("430"),
+        "Expected 430 for second pipelined cached-missing ARTICLE, got: {second}"
+    );
+
+    client.write_all(b"QUIT\r\n").await?;
 
     Ok(())
 }

--- a/tests/test_property_integration.rs
+++ b/tests/test_property_integration.rs
@@ -41,7 +41,6 @@ async fn setup_test_proxy() -> Result<(u16, u16, tokio::task::AbortHandle)> {
     // Find available ports
     let backend_listener = TcpListener::bind("127.0.0.1:0").await?;
     let backend_port = backend_listener.local_addr()?.port();
-    drop(backend_listener);
 
     let proxy_listener = TcpListener::bind("127.0.0.1:0").await?;
     let proxy_port = proxy_listener.local_addr()?.port();
@@ -53,7 +52,7 @@ async fn setup_test_proxy() -> Result<(u16, u16, tokio::task::AbortHandle)> {
         .on_command("DATE", "111 20251120120000\r\n")
         .on_command("LIST", "215 List follows\r\n.\r\n")
         .on_command("QUIT", "205 Goodbye\r\n")
-        .spawn();
+        .spawn_on_listener(backend_listener);
 
     tokio::time::sleep(Duration::from_millis(100)).await;
 


### PR DESCRIPTION
## Summary
- add a serializable dashboard snapshot shared by local and remote TUI rendering
- add headless websocket publishing plus a read-only attached TUI client with reconnect support
- polish the attached UX with explicit remote connection state, clearer listener/connect errors, and websocket lifecycle logging
- fix test port-race flakes in the remote/property and cache-before-precheck suites

## Details
- `--ui headless --tui-listen HOST:PORT` publishes dashboard state over websocket
- `--ui tui --tui-attach HOST:PORT` attaches a separate terminal to the live dashboard
- attached mode keeps the last snapshot visible while reconnecting and shows proxy/UI resource usage together
- local and remote modes share the same dashboard snapshot/rendering pipeline

## Validation
- `cargo test -q`
- `cargo clippy -q --all-targets --all-features -- -D warnings`
