### PR TITLE
Use hickory resolver for backend DNS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Backend DNS resolution now uses hickory’s TTL-aware caching behavior, with refreshed lookup handling that avoids unnecessary IPv4 cache clears on IPv6-unreachable failures.
+
 ## [0.5.1] - 2026-06-05
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +511,16 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -552,6 +572,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam"
@@ -776,6 +802,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "divan"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -956,6 +993,15 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "foyer"
@@ -1299,6 +1345,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-net"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "hickory-proto",
+ "idna",
+ "ipnet",
+ "jni",
+ "rand 0.10.1",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.1",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.1",
+ "resolv-conf",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "http"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1465,6 +1581,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1673,27 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -1522,6 +1741,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,6 +1782,55 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "jobserver"
@@ -1644,6 +1934,12 @@ name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1814,6 +2110,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1859,6 +2161,7 @@ dependencies = [
  "flate2",
  "foyer",
  "futures",
+ "hickory-resolver",
  "iai-callgrind",
  "memchr",
  "moka",
@@ -2014,6 +2317,10 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
@@ -2223,6 +2530,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,6 +2551,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
 ]
 
 [[package]]
@@ -2556,6 +2883,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2671,6 +3004,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2692,7 +3034,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2841,6 +3183,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2876,6 +3234,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "static_assertions"
@@ -2951,6 +3315,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sysinfo"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,6 +3337,27 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3137,6 +3533,31 @@ dependencies = [
  "num-conv",
  "time-core",
 ]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -3474,10 +3895,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
 name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -3525,6 +3964,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3731,6 +4180,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,6 +4200,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -3833,6 +4297,17 @@ checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
  "windows-core",
  "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -4054,12 +4529,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
 name = "yenc"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b18d9bd0fdec2bda9866bd18dcef7f99c08f051a0a660ea2de08daa2514b21"
 dependencies = [
  "crc32fast",
+]
+
+[[package]]
+name = "yoke"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
 ]
 
 [[package]]
@@ -4083,10 +4587,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,7 @@ twox-hash = "2.1.2"
 rand = "0.10"  # Jittered backoff for stale-connection retries
 flate2 = { version = "1.1", default-features = false, features = ["rust_backend"] }  # RFC 8054 COMPRESS DEFLATE
 pin-project-lite = "0.2"  # Safe pin projection (already in dep tree via tokio)
+hickory-resolver = { version = "0.26", features = ["tokio", "system-config"] }  # DNS lookups with TTL-aware caching from system resolver config
 
 [dev-dependencies]
 tokio = { version = "1.52", features = ["test-util"] }  # Paused time for deterministic async tests

--- a/src/connection_error.rs
+++ b/src/connection_error.rs
@@ -1,5 +1,6 @@
 //! Connection error types for the NNTP proxy
 
+use std::error::Error as StdError;
 use std::io::ErrorKind;
 use thiserror::Error;
 
@@ -63,6 +64,28 @@ pub enum ConnectionError {
     #[error("No DNS addresses found for {address}")]
     DnsNoAddresses { address: String },
 
+    #[error("Failed to initialize DNS resolver for backend '{backend}': {source}")]
+    DnsResolverInit {
+        backend: String,
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
+
+    #[error("Failed to build DNS resolver for backend '{backend}': {source}")]
+    DnsResolverBuild {
+        backend: String,
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
+
+    #[error("Failed to resolve {address} for backend '{backend}': {source}")]
+    DnsLookup {
+        backend: String,
+        address: String,
+        #[source]
+        source: Box<dyn StdError + Send + Sync>,
+    },
+
     #[error("Password required but not configured for backend '{backend}'")]
     PasswordRequired { backend: String },
 
@@ -71,6 +94,40 @@ pub enum ConnectionError {
 
     #[error("Compression required but not supported by backend '{backend}': {response}")]
     CompressionRequired { backend: String, response: String },
+}
+
+impl ConnectionError {
+    pub fn dns_resolver_init(
+        backend: impl Into<String>,
+        source: impl StdError + Send + Sync + 'static,
+    ) -> Self {
+        Self::DnsResolverInit {
+            backend: backend.into(),
+            source: Box::new(source),
+        }
+    }
+
+    pub fn dns_resolver_build(
+        backend: impl Into<String>,
+        source: impl StdError + Send + Sync + 'static,
+    ) -> Self {
+        Self::DnsResolverBuild {
+            backend: backend.into(),
+            source: Box::new(source),
+        }
+    }
+
+    pub fn dns_lookup(
+        backend: impl Into<String>,
+        address: impl Into<String>,
+        source: impl StdError + Send + Sync + 'static,
+    ) -> Self {
+        Self::DnsLookup {
+            backend: backend.into(),
+            address: address.into(),
+            source: Box::new(source),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -166,5 +223,41 @@ mod tests {
         assert!(msg.contains("Connection limit exceeded"));
         assert!(msg.contains("news.example.com"));
         assert!(msg.contains("482"));
+    }
+
+    #[test]
+    fn test_dns_resolver_init_error() {
+        let err =
+            ConnectionError::dns_resolver_init("dns-backend", std::io::Error::other("bad config"));
+
+        let msg = err.to_string();
+        assert!(msg.contains("Failed to initialize DNS resolver"));
+        assert!(msg.contains("dns-backend"));
+        assert!(err.source().is_some());
+    }
+
+    #[test]
+    fn test_dns_resolver_build_error() {
+        let err =
+            ConnectionError::dns_resolver_build("dns-backend", std::io::Error::other("build"));
+
+        let msg = err.to_string();
+        assert!(msg.contains("Failed to build DNS resolver"));
+        assert!(msg.contains("dns-backend"));
+        assert!(err.source().is_some());
+    }
+
+    #[test]
+    fn test_dns_lookup_error() {
+        let err = ConnectionError::dns_lookup(
+            "dns-backend",
+            "example.com:119",
+            std::io::Error::other("lookup"),
+        );
+
+        let msg = err.to_string();
+        assert!(msg.contains("Failed to resolve example.com:119"));
+        assert!(msg.contains("dns-backend"));
+        assert!(err.source().is_some());
     }
 }

--- a/src/pool/deadpool_connection.rs
+++ b/src/pool/deadpool_connection.rs
@@ -4,16 +4,18 @@
 //! creation of optimized TCP/TLS connections to NNTP servers.
 
 use deadpool::managed;
-use std::collections::VecDeque;
+use hickory_resolver::TokioResolver;
+use hickory_resolver::proto::rr::RecordType;
+use smallvec::SmallVec;
 use std::io;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio::sync::Notify;
-use tokio::sync::RwLock;
 
 use crate::connection_error::ConnectionError;
 use crate::protocol::{RequestContext, authinfo_pass, authinfo_user};
@@ -22,6 +24,27 @@ use crate::tls::{TlsConfig, TlsManager};
 
 /// Type alias for the deadpool connection pool
 pub type Pool = managed::Pool<TcpManager>;
+
+/// Shared DNS resolver instance for all managers.
+static DNS_RESOLVER: OnceLock<TokioResolver> = OnceLock::new();
+static NEXT_ADDR_START: AtomicUsize = AtomicUsize::new(0);
+static NEXT_IPV4_ROTATION: AtomicUsize = AtomicUsize::new(0);
+
+/// Initialize or return the shared DNS resolver.
+fn dns_resolver() -> Result<&'static TokioResolver, ConnectionError> {
+    if let Some(resolver) = DNS_RESOLVER.get() {
+        return Ok(resolver);
+    }
+
+    let resolver = TokioResolver::builder_tokio()
+        .map_err(|error| ConnectionError::dns_resolver_init("global", error))?
+        .build()
+        .map_err(|error| ConnectionError::dns_resolver_build("global", error))?;
+    let _ = DNS_RESOLVER.set(resolver);
+    Ok(DNS_RESOLVER
+        .get()
+        .expect("DNS resolver should be initialized after set"))
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CompressionSupport {
@@ -88,8 +111,6 @@ pub struct TcpManager {
     pub(crate) tls_config: TlsConfig,
     /// Cached TLS manager with pre-loaded certificates (avoids base64 decode overhead)
     pub(crate) tls_manager: Option<Arc<TlsManager>>,
-    resolved_socket_addrs: Arc<RwLock<Option<Arc<[SocketAddr]>>>>,
-    next_resolved_socket_addr: Arc<AtomicUsize>,
     pub(crate) recv_buffer_size: usize,
     pub(crate) send_buffer_size: usize,
     /// Wire compression mode: None = auto-detect, Some(true) = require, Some(false) = disable
@@ -111,67 +132,47 @@ impl TcpManager {
         })
     }
 
-    fn ip_literal_socket_addr(&self) -> Option<SocketAddr> {
-        self.host
-            .parse::<IpAddr>()
-            .ok()
-            .map(|ip| SocketAddr::new(ip, self.port))
-    }
-
-    async fn resolve_socket_addrs(&self) -> Result<Arc<[SocketAddr]>, ConnectionError> {
-        if let Some(socket_addr) = self.ip_literal_socket_addr() {
-            return Ok(Arc::from([socket_addr]));
-        }
-
-        if let Some(addrs) = self.resolved_socket_addrs.read().await.as_ref() {
-            if addrs.is_empty() {
-                return Err(ConnectionError::DnsNoAddresses {
-                    address: format!("{}:{}", self.host, self.port),
-                });
-            }
-            return Ok(addrs.clone());
-        }
-
-        let mut cached_addrs = self.resolved_socket_addrs.write().await;
-        if let Some(addrs) = cached_addrs.as_ref() {
-            if addrs.is_empty() {
-                return Err(ConnectionError::DnsNoAddresses {
-                    address: format!("{}:{}", self.host, self.port),
-                });
-            }
-            return Ok(addrs.clone());
-        }
-
-        let addrs = tokio::net::lookup_host((self.host.as_str(), self.port))
-            .await?
-            .collect::<Vec<_>>();
+    async fn lookup_socket_addrs(&self) -> Result<SmallVec<[SocketAddr; 4]>, ConnectionError> {
+        let resolver = dns_resolver()?;
+        let lookup = resolver
+            .lookup_ip(self.host.as_str())
+            .await
+            .map_err(|error| {
+                ConnectionError::dns_lookup(
+                    &self.name,
+                    format!("{}:{}", self.host, self.port),
+                    error,
+                )
+            })?;
+        let mut addrs: SmallVec<[SocketAddr; 4]> = SmallVec::new();
+        addrs.extend(
+            lookup
+                .iter()
+                .map(|ip_addr| SocketAddr::new(ip_addr, self.port)),
+        );
         if addrs.is_empty() {
             return Err(ConnectionError::DnsNoAddresses {
                 address: format!("{}:{}", self.host, self.port),
             });
         }
 
-        let addrs: Arc<[SocketAddr]> = Arc::from(addrs);
-        *cached_addrs = Some(addrs.clone());
-        Ok(addrs)
-    }
-
-    async fn refresh_socket_addrs(&self) -> Result<Arc<[SocketAddr]>, ConnectionError> {
-        if let Some(socket_addr) = self.ip_literal_socket_addr() {
-            return Ok(Arc::from([socket_addr]));
+        let ipv4_positions: SmallVec<[usize; 4]> = addrs
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, addr)| addr.is_ipv4().then_some(idx))
+            .collect();
+        if ipv4_positions.len() > 1 {
+            let shift = NEXT_IPV4_ROTATION.fetch_add(1, Ordering::Relaxed) % ipv4_positions.len();
+            if shift != 0 {
+                let mut rotated_ipv4: SmallVec<[SocketAddr; 4]> =
+                    ipv4_positions.iter().map(|&idx| addrs[idx]).collect();
+                rotated_ipv4.rotate_left(shift);
+                for (idx, addr) in ipv4_positions.into_iter().zip(rotated_ipv4) {
+                    addrs[idx] = addr;
+                }
+            }
         }
 
-        let addrs = tokio::net::lookup_host((self.host.as_str(), self.port))
-            .await?
-            .collect::<Vec<_>>();
-        if addrs.is_empty() {
-            return Err(ConnectionError::DnsNoAddresses {
-                address: format!("{}:{}", self.host, self.port),
-            });
-        }
-
-        let addrs: Arc<[SocketAddr]> = Arc::from(addrs);
-        *self.resolved_socket_addrs.write().await = Some(addrs.clone());
         Ok(addrs)
     }
 
@@ -185,28 +186,6 @@ impl TcpManager {
                         io::ErrorKind::NetworkUnreachable | io::ErrorKind::HostUnreachable
                     )
             )
-    }
-
-    async fn remove_cached_ipv6_socket_addrs(&self) {
-        let mut cached_addrs = self.resolved_socket_addrs.write().await;
-        let Some(addrs) = cached_addrs.as_ref() else {
-            return;
-        };
-
-        let ipv4_addrs = addrs
-            .iter()
-            .copied()
-            .filter(SocketAddr::is_ipv4)
-            .collect::<Vec<_>>();
-        if ipv4_addrs.len() == addrs.len() {
-            return;
-        }
-
-        *cached_addrs = if ipv4_addrs.is_empty() {
-            None
-        } else {
-            Some(Arc::<[SocketAddr]>::from(ipv4_addrs))
-        };
     }
 
     /// Create a new `TcpManager` with optional TLS configuration
@@ -245,8 +224,6 @@ impl TcpManager {
             password: options.password,
             tls_config,
             tls_manager,
-            resolved_socket_addrs: Arc::new(RwLock::new(None)),
-            next_resolved_socket_addr: Arc::new(AtomicUsize::new(0)),
             recv_buffer_size: options.recv_buffer_size,
             send_buffer_size: options.send_buffer_size,
             compress: options.compress,
@@ -261,7 +238,7 @@ impl TcpManager {
         socket_addr: SocketAddr,
     ) -> Result<TcpStream, ConnectionError> {
         // Create tokio TcpSocket (non-blocking from the start)
-        let socket = if socket_addr.is_ipv4() {
+        let connect_socket = if socket_addr.is_ipv4() {
             tokio::net::TcpSocket::new_v4()?
         } else {
             tokio::net::TcpSocket::new_v6()?
@@ -269,56 +246,50 @@ impl TcpManager {
 
         // Pre-connect options (buffer sizes, reuse)
         if self.recv_buffer_size > 0 {
-            socket.set_recv_buffer_size(Self::socket_buffer_size_u32(
+            connect_socket.set_recv_buffer_size(Self::socket_buffer_size_u32(
                 self.recv_buffer_size,
                 "receive",
             )?)?;
         }
         if self.send_buffer_size > 0 {
-            socket.set_send_buffer_size(Self::socket_buffer_size_u32(
+            connect_socket.set_send_buffer_size(Self::socket_buffer_size_u32(
                 self.send_buffer_size,
                 "send",
             )?)?;
         }
-        socket.set_reuseaddr(true)?;
+        connect_socket.set_reuseaddr(true)?;
 
         // Async connect — does NOT block the tokio worker thread
-        let tcp_stream = socket.connect(socket_addr).await?;
+        let tcp_stream = connect_socket.connect(socket_addr).await?;
 
         // Post-connect options via socket2::SockRef (keepalive with params, nodelay)
-        let sock_ref = socket2::SockRef::from(&tcp_stream);
-        sock_ref.set_keepalive(true)?;
+        let stream_socket = socket2::SockRef::from(&tcp_stream);
+        stream_socket.set_keepalive(true)?;
         let keepalive = socket2::TcpKeepalive::new()
             .with_time(crate::constants::duration_polyfill::from_minutes(1))
             .with_interval(std::time::Duration::from_secs(10));
-        sock_ref.set_tcp_keepalive(&keepalive)?;
-        sock_ref.set_tcp_nodelay(true)?;
+        stream_socket.set_tcp_keepalive(&keepalive)?;
+        stream_socket.set_tcp_nodelay(true)?;
 
         Ok(tcp_stream)
     }
 
     async fn create_connected_tcp_stream(&self) -> Result<TcpStream, ConnectionError> {
-        let addrs = self.resolve_socket_addrs().await?;
-        let last_error = match self.try_resolved_socket_addrs(&addrs).await {
-            Ok(tcp_stream) => return Ok(tcp_stream),
-            Err(last_error) => last_error,
-        };
-
-        if self.ip_literal_socket_addr().is_some() {
-            return Err(
-                last_error.unwrap_or_else(|| ConnectionError::DnsNoAddresses {
-                    address: format!("{}:{}", self.host, self.port),
-                }),
-            );
+        let addrs = self.lookup_socket_addrs().await?;
+        if let Ok(tcp_stream) = self.try_resolved_socket_addrs(&addrs).await {
+            return Ok(tcp_stream);
         }
 
         tracing::debug!(
             backend = %self.name,
             host = %self.host,
-            "All cached backend socket addresses failed; refreshing DNS before final connect pass"
+            "All resolved backend socket addresses failed; refreshing DNS before final connect pass"
         );
 
-        let addrs = self.refresh_socket_addrs().await?;
+        let resolver = dns_resolver()?;
+        resolver.clear_lookup_cache(self.host.as_str(), RecordType::A);
+        resolver.clear_lookup_cache(self.host.as_str(), RecordType::AAAA);
+        let addrs = self.lookup_socket_addrs().await?;
         self.try_resolved_socket_addrs(&addrs)
             .await
             .map_err(|last_error| {
@@ -332,23 +303,28 @@ impl TcpManager {
         &self,
         addrs: &[SocketAddr],
     ) -> Result<TcpStream, Option<ConnectionError>> {
-        let start = self
-            .next_resolved_socket_addr
-            .fetch_add(1, Ordering::Relaxed)
-            % addrs.len();
+        if addrs.is_empty() {
+            return Err(None);
+        }
+
         let mut last_error = None;
-
-        let mut remaining_addrs = (0..addrs.len())
-            .map(|offset| addrs[(start + offset) % addrs.len()])
-            .collect::<VecDeque<_>>();
-
-        while let Some(socket_addr) = remaining_addrs.pop_front() {
+        let mut skip_ipv6 = false;
+        let start = NEXT_ADDR_START.fetch_add(1, Ordering::Relaxed) % addrs.len();
+        for offset in 0..addrs.len() {
+            let socket_addr = addrs[(start + offset) % addrs.len()];
+            if skip_ipv6 && socket_addr.is_ipv6() {
+                continue;
+            }
             match self.connect_socket_addr(socket_addr).await {
                 Ok(tcp_stream) => return Ok(tcp_stream),
                 Err(error) => {
                     if Self::is_ipv6_network_unreachable(socket_addr, &error) {
-                        self.remove_cached_ipv6_socket_addrs().await;
-                        remaining_addrs.retain(SocketAddr::is_ipv4);
+                        let resolver = match dns_resolver() {
+                            Ok(r) => r,
+                            Err(e) => return Err(Some(e)),
+                        };
+                        resolver.clear_lookup_cache(self.host.as_str(), RecordType::AAAA);
+                        skip_ipv6 = true;
                     }
 
                     tracing::debug!(
@@ -761,6 +737,8 @@ impl managed::Manager for TcpManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
     use tokio::io::AsyncReadExt;
     use tokio::net::TcpListener;
 
@@ -817,51 +795,6 @@ mod tests {
     }
 
     #[test]
-    fn ip_literal_socket_addr_parses_ipv4_without_dns() {
-        let manager = TcpManager::new(
-            "127.0.0.1".to_string(),
-            119,
-            "IpBackend".to_string(),
-            TcpManagerOptions::default(),
-        )
-        .unwrap();
-
-        assert_eq!(
-            manager.ip_literal_socket_addr(),
-            Some(SocketAddr::from(([127, 0, 0, 1], 119)))
-        );
-    }
-
-    #[test]
-    fn ip_literal_socket_addr_parses_ipv6_without_dns() {
-        let manager = TcpManager::new(
-            "::1".to_string(),
-            563,
-            "IpBackend".to_string(),
-            TcpManagerOptions::default(),
-        )
-        .unwrap();
-
-        assert_eq!(
-            manager.ip_literal_socket_addr(),
-            Some(SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 563)))
-        );
-    }
-
-    #[test]
-    fn ip_literal_socket_addr_leaves_hostnames_for_dns() {
-        let manager = TcpManager::new(
-            "news.example.com".to_string(),
-            119,
-            "DnsBackend".to_string(),
-            TcpManagerOptions::default(),
-        )
-        .unwrap();
-
-        assert_eq!(manager.ip_literal_socket_addr(), None);
-    }
-
-    #[test]
     fn ipv6_network_unreachable_matches_error_kind_only_for_ipv6() {
         let ipv6_addr = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 563));
         let ipv4_addr = SocketAddr::from(([127, 0, 0, 1], 563));
@@ -875,57 +808,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn remove_cached_ipv6_socket_addrs_keeps_only_ipv4_addresses() {
-        let manager = TcpManager::new(
-            "test.example.com".to_string(),
-            563,
-            "DnsBackend".to_string(),
-            TcpManagerOptions::default(),
-        )
-        .unwrap();
-        let ipv6_addr = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 563));
-        let ipv4_addr = SocketAddr::from(([127, 0, 0, 1], 563));
-        *manager.resolved_socket_addrs.write().await = Some(Arc::from([ipv6_addr, ipv4_addr]));
-
-        manager.remove_cached_ipv6_socket_addrs().await;
-
-        let cached_addrs = manager
-            .resolved_socket_addrs
-            .read()
-            .await
-            .as_ref()
-            .expect("cached addresses should remain initialized")
-            .clone();
-        assert_eq!(&*cached_addrs, &[ipv4_addr]);
-    }
-
-    #[tokio::test]
-    async fn remove_cached_ipv6_socket_addrs_clears_ipv6_only_cache() {
-        let manager = TcpManager::new(
-            "test.example.com".to_string(),
-            563,
-            "DnsBackend".to_string(),
-            TcpManagerOptions::default(),
-        )
-        .unwrap();
-        let ipv6_addr = SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 563));
-        *manager.resolved_socket_addrs.write().await = Some(Arc::from([ipv6_addr]));
-
-        manager.remove_cached_ipv6_socket_addrs().await;
-
-        assert!(
-            manager.resolved_socket_addrs.read().await.is_none(),
-            "IPv6-only cached address list should be cleared instead of retained as an empty cache"
-        );
-    }
-
-    #[tokio::test]
-    async fn create_connected_tcp_stream_refreshes_dns_after_cached_addresses_fail() {
-        let live_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let live_addr = live_listener.local_addr().unwrap();
-        let stale_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let stale_addr = stale_listener.local_addr().unwrap();
-        drop(stale_listener);
+    async fn create_connected_tcp_stream_resolves_hostname() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let live_addr = listener.local_addr().unwrap();
 
         let manager = TcpManager::new(
             "localhost".to_string(),
@@ -934,21 +819,32 @@ mod tests {
             TcpManagerOptions::default(),
         )
         .unwrap();
-        *manager.resolved_socket_addrs.write().await = Some(Arc::from([stale_addr]));
 
-        let accept = tokio::spawn(async move { live_listener.accept().await.unwrap() });
+        let accept = tokio::spawn(async move { listener.accept().await.unwrap() });
         let stream = manager.create_connected_tcp_stream().await.unwrap();
         let _accepted = accept.await.unwrap();
 
         assert_eq!(stream.peer_addr().unwrap(), live_addr);
-        let cached_addrs = manager
-            .resolved_socket_addrs
-            .read()
-            .await
-            .as_ref()
-            .expect("successful refresh should update cached addresses")
-            .clone();
-        assert!(cached_addrs.contains(&live_addr));
+    }
+
+    #[tokio::test]
+    async fn create_connected_tcp_stream_ip_literal_skips_dns() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let live_addr = listener.local_addr().unwrap();
+
+        let manager = TcpManager::new(
+            live_addr.ip().to_string(),
+            live_addr.port(),
+            "IpBackend".to_string(),
+            TcpManagerOptions::default(),
+        )
+        .unwrap();
+
+        let accept = tokio::spawn(async move { listener.accept().await.unwrap() });
+        let stream = manager.create_connected_tcp_stream().await.unwrap();
+        let _accepted = accept.await.unwrap();
+
+        assert_eq!(stream.peer_addr().unwrap(), live_addr);
     }
 
     #[test]
@@ -1019,14 +915,6 @@ mod tests {
         assert_eq!(cloned.name, manager.name);
         assert_eq!(cloned.username, manager.username);
         assert_eq!(cloned.password, manager.password);
-        assert!(Arc::ptr_eq(
-            &cloned.resolved_socket_addrs,
-            &manager.resolved_socket_addrs
-        ));
-        assert!(Arc::ptr_eq(
-            &cloned.next_resolved_socket_addr,
-            &manager.next_resolved_socket_addr
-        ));
     }
 
     #[test]
@@ -1043,14 +931,14 @@ mod tests {
         )
         .unwrap();
 
-        let debug_str = format!("{manager:?}");
-        assert!(debug_str.contains("TcpManager"));
-        assert!(debug_str.contains("news.example.com"));
-        assert!(debug_str.contains("119"));
+        let debug_output = format!("{manager:?}");
+        assert!(debug_output.contains("TcpManager"));
+        assert!(debug_output.contains("news.example.com"));
+        assert!(debug_output.contains("119"));
     }
 
     #[tokio::test]
-    async fn create_optimized_stream_tries_next_resolved_address_after_connect_error() {
+    async fn try_resolved_socket_addrs_tries_next_address_after_connect_error() {
         let unavailable_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let unavailable_addr = unavailable_listener.local_addr().unwrap();
         drop(unavailable_listener);
@@ -1068,15 +956,13 @@ mod tests {
             TcpManagerOptions::default(),
         )
         .unwrap();
-        *manager.resolved_socket_addrs.write().await =
-            Some(Arc::from([unavailable_addr, available_addr]));
 
         let stream = manager
-            .create_optimized_stream()
+            .try_resolved_socket_addrs(&[unavailable_addr, available_addr])
             .await
             .expect("second resolved address should be tried after first connect error");
 
-        assert_eq!(stream.connection_type(), "TCP");
+        assert_eq!(stream.peer_addr().unwrap(), available_addr);
         accept_task.await.unwrap();
     }
 
@@ -1101,10 +987,10 @@ mod tests {
         assert!(manager.tls_manager.is_some());
 
         // Verify TLS manager is an Arc (cheap clone)
-        let arc_clone = manager.tls_manager.as_ref().unwrap().clone();
+        let cloned_tls_manager = manager.tls_manager.as_ref().unwrap().clone();
         assert!(Arc::ptr_eq(
             manager.tls_manager.as_ref().unwrap(),
-            &arc_clone
+            &cloned_tls_manager
         ));
     }
 


### PR DESCRIPTION
## Summary

This PR makes backend DNS resolution TTL-aware by switching `TcpManager` to `hickory-resolver` and simplifying the DNS path to one direct flow.

It removes local DNS state/indirection and keeps retry behavior explicit:
- resolve addresses from hickory
- retry next address on connect failure
- on IPv6 network-unreachable, clear only AAAA cache and continue with available IPv4 addresses

It also reduces DNS-path allocations by using stack-friendly address storage and queue-free retry iteration.

## Testing

Added/updated tests to cover DNS resolver init/build/lookup errors, retry behavior across resolved addresses, and IPv6-unreachable handling while preserving IPv4 retry behavior.
