### PR TITLE
Dispatch non-primary STAT prefetch earlier for miss-heavy routing

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -35,6 +35,8 @@ username = "your_username"
 password = "your_password"
 max_connections = 20
 tier = 0
+# Probe misses with STAT before ARTICLE/BODY/HEAD on this backend (0=off, non-zero=on)
+stat_missing = 1
 use_tls = false
 tls_verify_cert = true
 
@@ -48,6 +50,8 @@ username = "your_username"
 password = "your_password"
 max_connections = 10
 tier = 1
+# Enable STAT miss probes on non-primary tiers to prefill availability while tier 0 fetch runs.
+stat_missing = 1
 connection_keepalive = 60
 use_tls = true
 tls_verify_cert = true

--- a/config.full.toml
+++ b/config.full.toml
@@ -100,6 +100,9 @@ name = "Example News Server 1"
 max_connections = 20
 # Lower tier numbers are tried first. Higher tiers are fallback/archive servers.
 tier = 0
+# Probe misses with STAT before ARTICLE/BODY/HEAD (0 = disabled, non-zero = enabled).
+# Default is 0; this example enables it on all tiers.
+stat_missing = 1
 # Optional keep-alive interval in seconds
 # connection_keepalive = 60
 use_tls = false
@@ -123,6 +126,8 @@ username = "testuser"
 password = "testpass"
 max_connections = 10
 tier = 1
+# Common setup: enable STAT miss probes on fallback tiers.
+stat_missing = 1
 connection_keepalive = 60
 use_tls = false
 tls_verify_cert = true
@@ -135,6 +140,7 @@ username = "premium_user"
 password = "secure_password"
 max_connections = 15
 tier = 5
+stat_missing = 1
 connection_keepalive = 120
 use_tls = true
 tls_verify_cert = true
@@ -149,6 +155,7 @@ username = "archive_user"
 password = "archive_pass"
 max_connections = 2
 tier = 10
+stat_missing = 1
 connection_keepalive = 120
 use_tls = true
 tls_verify_cert = true

--- a/src/bin/nntp-proxy.rs
+++ b/src/bin/nntp-proxy.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 
@@ -77,6 +78,16 @@ async fn run_proxy(
     startup_tui: Option<tui::StartupTuiSession>,
 ) -> Result<()> {
     let launch = prepare_proxy_launch(&args, &config);
+    let response_write_metrics_period = config
+        .proxy
+        .response_write_metrics_secs
+        .filter(|secs| *secs > 0)
+        .map(Duration::from_secs);
+    let client_writer_lock_metrics_period = config
+        .proxy
+        .client_writer_lock_metrics_secs
+        .filter(|secs| *secs > 0)
+        .map(Duration::from_secs);
     args.common
         .validate_dashboard_listen(&launch.host, launch.port)?;
 
@@ -99,8 +110,8 @@ async fn run_proxy(
     );
     runtime::spawn_availability_saver(&proxy, launch.availability_path.clone());
     runtime::spawn_idle_connection_clearer(&proxy);
-    runtime::spawn_response_write_metrics_logger();
-    runtime::spawn_client_writer_lock_metrics_logger();
+    runtime::spawn_response_write_metrics_logger(response_write_metrics_period);
+    runtime::spawn_client_writer_lock_metrics_logger(client_writer_lock_metrics_period);
     runtime::spawn_tokio_runtime_metrics_logger();
 
     let (dashboard_handle, dashboard_shutdown_tx) =
@@ -135,10 +146,10 @@ async fn run_proxy(
 
     if let Err(e) = prewarm_result {
         if let Some(tx) = error_tui_shutdown_tx {
-            let _ = tx.send(()).await;
+            send_shutdown_signal(&tx);
         }
         if let Some(tx) = error_dashboard_shutdown_tx {
-            let _ = tx.send(()).await;
+            send_shutdown_signal(&tx);
         }
         if let Some(handle) = tui_handle {
             handle.await?;
@@ -182,18 +193,18 @@ async fn shutdown_background_tasks(
     dashboard_handle: Option<TuiHandle>,
 ) -> Result<()> {
     if let Some(tx) = tui_shutdown_tx {
-        let _ = tx.send(()).await;
+        send_shutdown_signal(&tx);
     }
     if let Some(tx) = dashboard_shutdown_tx {
-        let _ = tx.send(()).await;
+        send_shutdown_signal(&tx);
     }
 
     if let Some(handle) = tui_handle {
-        handle.await?;
+        await_ui_task_with_timeout(handle, "TUI").await?;
     }
 
     if let Some(handle) = dashboard_handle {
-        handle.await?;
+        await_ui_task_with_timeout(handle, "dashboard").await?;
     }
 
     Ok(())
@@ -352,13 +363,43 @@ fn spawn_signal_forwarder(
         info!("Shutdown signal received");
 
         if let Some(tx) = tui_shutdown_tx {
-            let _ = tx.send(()).await;
+            send_shutdown_signal(&tx);
         }
         if let Some(tx) = dashboard_shutdown_tx {
-            let _ = tx.send(()).await;
+            send_shutdown_signal(&tx);
         }
-        let _ = shutdown_tx.send(()).await;
+        send_shutdown_signal(&shutdown_tx);
     });
+}
+
+fn send_shutdown_signal(tx: &mpsc::Sender<()>) {
+    match tx.try_send(()) {
+        Ok(()) => {}
+        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {}
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
+    }
+}
+
+async fn await_ui_task_with_timeout(handle: TuiHandle, label: &str) -> Result<()> {
+    match tokio::time::timeout(
+        nntp_proxy::constants::timeout::SHUTDOWN_UI_TASK_JOIN,
+        handle,
+    )
+    .await
+    {
+        Ok(join_result) => {
+            join_result?;
+            Ok(())
+        }
+        Err(_) => {
+            warn!(
+                task = label,
+                timeout_secs = nntp_proxy::constants::timeout::SHUTDOWN_UI_TASK_JOIN.as_secs(),
+                "Timed out waiting for UI task during shutdown"
+            );
+            Ok(())
+        }
+    }
 }
 
 #[cfg(test)]
@@ -367,6 +408,7 @@ mod tests {
     use nntp_proxy::config::Config;
     use nntp_proxy::types::Port;
     use std::path::PathBuf;
+    use tokio::sync::mpsc;
 
     fn test_common_args() -> CommonArgs {
         CommonArgs {
@@ -414,5 +456,15 @@ mod tests {
         assert_eq!(launch.port.get(), 9120);
         assert_eq!(launch.server_names, vec!["Primary".to_string()]);
         assert!(launch.metrics_store.is_none());
+    }
+
+    #[tokio::test]
+    async fn send_shutdown_signal_is_non_blocking_when_channel_is_full() {
+        let (tx, mut rx) = mpsc::channel::<()>(1);
+        tx.try_send(()).expect("fill channel");
+
+        send_shutdown_signal(&tx);
+
+        assert!(rx.recv().await.is_some());
     }
 }

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -81,6 +81,34 @@ pub const fn adaptive_precheck() -> bool {
     false
 }
 
+/// Default routing queue backpressure toggle.
+#[inline]
+#[must_use]
+pub const fn queue_backpressure_enabled() -> bool {
+    true
+}
+
+/// Default soft queue-pressure limit per connection (percentage).
+#[inline]
+#[must_use]
+pub const fn queue_backpressure_soft_waiters_per_connection_percent() -> u16 {
+    25
+}
+
+/// Default hard queue-pressure limit per connection (percentage).
+#[inline]
+#[must_use]
+pub const fn queue_backpressure_hard_waiters_per_connection_percent() -> u16 {
+    50
+}
+
+/// Default delay (ms) before re-trying selection when all tier-local backends are overloaded.
+#[inline]
+#[must_use]
+pub const fn queue_backpressure_all_busy_sleep_ms() -> u64 {
+    1
+}
+
 /// Default socket receive buffer size
 #[inline]
 #[must_use]
@@ -209,4 +237,18 @@ pub const fn replacement_cooldown_option() -> Option<Duration> {
 #[inline]
 pub fn log_file_level() -> String {
     "warn".to_string()
+}
+
+/// Default disabled interval for response/hot-path metrics logger.
+#[inline]
+#[allow(clippy::unnecessary_wraps)] // Optional config field uses None as disabled default.
+pub const fn response_write_metrics_secs() -> Option<u64> {
+    None
+}
+
+/// Default disabled interval for client-writer lock metrics logger.
+#[inline]
+#[allow(clippy::unnecessary_wraps)] // Optional config field uses None as disabled default.
+pub const fn client_writer_lock_metrics_secs() -> Option<u64> {
+    None
 }

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -162,6 +162,12 @@ pub struct Proxy {
     /// Accepts tracing filter directives: "error", "warn", "info", "debug", "trace"
     #[serde(default = "super::defaults::log_file_level")]
     pub log_file_level: String,
+    /// Interval in seconds for response/hot-path metrics logging. `None` disables it.
+    #[serde(default = "super::defaults::response_write_metrics_secs")]
+    pub response_write_metrics_secs: Option<u64>,
+    /// Interval in seconds for client-writer lock contention logging. `None` disables it.
+    #[serde(default = "super::defaults::client_writer_lock_metrics_secs")]
+    pub client_writer_lock_metrics_secs: Option<u64>,
     /// Path to stats file for metric persistence (optional)
     /// When set, metrics are persisted to this file every 30 seconds and on shutdown
     /// Defaults to "stats.json" alongside the config file if not specified
@@ -188,6 +194,8 @@ impl Default for Proxy {
             threads: ThreadCount::default(),
             validate_yenc: true,
             log_file_level: defaults::log_file_level(),
+            response_write_metrics_secs: defaults::response_write_metrics_secs(),
+            client_writer_lock_metrics_secs: defaults::client_writer_lock_metrics_secs(),
             stats_file: None,
             routing_mode: RoutingMode::default(),
             backend_selection: BackendSelectionStrategy::default(),
@@ -210,6 +218,9 @@ pub struct Routing {
     /// Enable adaptive availability prechecking for STAT/HEAD commands (default: false)
     #[serde(default = "super::defaults::adaptive_precheck")]
     pub adaptive_precheck: bool,
+    /// Queue behavior for routing decisions.
+    #[serde(default)]
+    pub queue: RoutingQueue,
 }
 
 impl Default for Routing {
@@ -218,6 +229,54 @@ impl Default for Routing {
             routing_mode: RoutingMode::default(),
             backend_selection: BackendSelectionStrategy::default(),
             adaptive_precheck: defaults::adaptive_precheck(),
+            queue: RoutingQueue::default(),
+        }
+    }
+}
+
+/// Routing queue configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct RoutingQueue {
+    /// Queue-pressure based admission controls.
+    pub backpressure: QueueBackpressure,
+}
+
+impl Default for RoutingQueue {
+    fn default() -> Self {
+        Self {
+            backpressure: QueueBackpressure::default(),
+        }
+    }
+}
+
+/// Per-connection queue backpressure settings.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(default)]
+pub struct QueueBackpressure {
+    /// Enable queue-pressure-aware backend filtering.
+    #[serde(default = "super::defaults::queue_backpressure_enabled")]
+    pub enabled: bool,
+    /// Soft queue-pressure threshold (queued requests per connection, percent).
+    #[serde(default = "super::defaults::queue_backpressure_soft_waiters_per_connection_percent")]
+    pub soft_waiters_per_connection_percent: u16,
+    /// Hard queue-pressure threshold (queued requests per connection, percent).
+    #[serde(default = "super::defaults::queue_backpressure_hard_waiters_per_connection_percent")]
+    pub hard_waiters_per_connection_percent: u16,
+    /// Sleep duration in milliseconds when all eligible backends in a tier are hard-saturated.
+    #[serde(default = "super::defaults::queue_backpressure_all_busy_sleep_ms")]
+    pub all_busy_sleep_ms: u64,
+}
+
+impl Default for QueueBackpressure {
+    fn default() -> Self {
+        Self {
+            enabled: defaults::queue_backpressure_enabled(),
+            soft_waiters_per_connection_percent:
+                defaults::queue_backpressure_soft_waiters_per_connection_percent(),
+            hard_waiters_per_connection_percent:
+                defaults::queue_backpressure_hard_waiters_per_connection_percent(),
+            all_busy_sleep_ms: defaults::queue_backpressure_all_busy_sleep_ms(),
         }
     }
 }
@@ -942,6 +1001,27 @@ mod tests {
             memory.capture_pool_count,
             crate::constants::buffer::CAPTURE_COUNT
         );
+    }
+
+    #[test]
+    fn test_routing_queue_backpressure_defaults() {
+        let routing = Routing::default();
+        assert!(routing.queue.backpressure.enabled);
+        assert_eq!(
+            routing
+                .queue
+                .backpressure
+                .soft_waiters_per_connection_percent,
+            25
+        );
+        assert_eq!(
+            routing
+                .queue
+                .backpressure
+                .hard_waiters_per_connection_percent,
+            50
+        );
+        assert_eq!(routing.queue.backpressure.all_busy_sleep_ms, 1);
     }
 
     // HealthCheck tests

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -235,19 +235,11 @@ impl Default for Routing {
 }
 
 /// Routing queue configuration.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(default)]
 pub struct RoutingQueue {
     /// Queue-pressure based admission controls.
     pub backpressure: QueueBackpressure,
-}
-
-impl Default for RoutingQueue {
-    fn default() -> Self {
-        Self {
-            backpressure: QueueBackpressure::default(),
-        }
-    }
 }
 
 /// Per-connection queue backpressure settings.

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -46,6 +46,20 @@ impl Config {
             "memory.socket_send_buffer_size",
             self.memory.socket_send_buffer_size,
         )?;
+        validate_backpressure_percent(
+            "routing.queue.backpressure.soft_waiters_per_connection_percent",
+            self.routing
+                .queue
+                .backpressure
+                .soft_waiters_per_connection_percent,
+        )?;
+        validate_backpressure_percent(
+            "routing.queue.backpressure.hard_waiters_per_connection_percent",
+            self.routing
+                .queue
+                .backpressure
+                .hard_waiters_per_connection_percent,
+        )?;
         if self
             .routing
             .queue
@@ -74,6 +88,16 @@ fn validate_socket_buffer_size(field: &str, size: usize) -> Result<()> {
     if size > MAX_SOCKET_BUFFER_SIZE {
         return Err(anyhow::anyhow!(
             "{field} must be <= {MAX_SOCKET_BUFFER_SIZE} bytes because OS socket APIs accept u32 buffer sizes; found {size}"
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_backpressure_percent(field: &str, value: u16) -> Result<()> {
+    if value > 100 {
+        return Err(anyhow::anyhow!(
+            "{field} must be within 0..=100; found {value}"
         ));
     }
 
@@ -258,6 +282,40 @@ mod tests {
                 .to_string()
                 .contains("hard_waiters_per_connection_percent")
         );
+    }
+
+    #[test]
+    fn test_validate_backpressure_soft_over_100_fails() {
+        let mut config = Config {
+            servers: vec![create_test_server("test", None)],
+            ..Default::default()
+        };
+        config
+            .routing
+            .queue
+            .backpressure
+            .soft_waiters_per_connection_percent = 101;
+
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("0..=100"));
+    }
+
+    #[test]
+    fn test_validate_backpressure_hard_over_100_fails() {
+        let mut config = Config {
+            servers: vec![create_test_server("test", None)],
+            ..Default::default()
+        };
+        config
+            .routing
+            .queue
+            .backpressure
+            .hard_waiters_per_connection_percent = 101;
+
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("0..=100"));
     }
 
     #[test]

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -46,6 +46,21 @@ impl Config {
             "memory.socket_send_buffer_size",
             self.memory.socket_send_buffer_size,
         )?;
+        if self
+            .routing
+            .queue
+            .backpressure
+            .hard_waiters_per_connection_percent
+            < self
+                .routing
+                .queue
+                .backpressure
+                .soft_waiters_per_connection_percent
+        {
+            return Err(anyhow::anyhow!(
+                "routing.queue.backpressure.hard_waiters_per_connection_percent must be >= soft_waiters_per_connection_percent"
+            ));
+        }
 
         for server in &self.servers {
             validate_server(server);
@@ -215,6 +230,33 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("memory.socket_send_buffer_size")
+        );
+    }
+
+    #[test]
+    fn test_validate_backpressure_hard_less_than_soft_fails() {
+        let mut config = Config {
+            servers: vec![create_test_server("test", None)],
+            ..Default::default()
+        };
+        config
+            .routing
+            .queue
+            .backpressure
+            .soft_waiters_per_connection_percent = 60;
+        config
+            .routing
+            .queue
+            .backpressure
+            .hard_waiters_per_connection_percent = 50;
+
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("hard_waiters_per_connection_percent")
         );
     }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -165,6 +165,12 @@ pub mod timeout {
     /// Used to drain connections one at a time; should be near-instant if
     /// the connection is truly idle
     pub const SHUTDOWN_POOL_GET: Duration = Duration::from_millis(1);
+
+    /// Maximum time to wait for client session tasks to drain after shutdown begins
+    pub const SHUTDOWN_TASK_DRAIN: Duration = Duration::from_secs(5);
+
+    /// Maximum time to wait for UI background tasks to exit on shutdown
+    pub const SHUTDOWN_UI_TASK_JOIN: Duration = Duration::from_secs(3);
 }
 
 /// Connection pool constants

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -78,6 +78,10 @@ fn debug_log_writer() -> (NonBlocking, WorkerGuard) {
     tracing_appender::non_blocking(file_appender)
 }
 
+fn stdout_log_writer() -> (NonBlocking, WorkerGuard) {
+    tracing_appender::non_blocking(std::io::stdout())
+}
+
 fn leak_guard(guard: WorkerGuard) {
     // SAFETY: Intentionally leak the WorkerGuard to keep the file appender
     // alive for the program lifetime. Drop would flush and close the writer.
@@ -86,11 +90,12 @@ fn leak_guard(guard: WorkerGuard) {
 
 fn init_headless_subscriber(capture_in_memory_logs: bool) -> Option<crate::tui::LogBuffer> {
     let log_buffer = capture_in_memory_logs.then(crate::tui::LogBuffer::new);
+    let (stdout_log, guard) = stdout_log_writer();
 
     let subscriber = tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::layer()
-                .with_writer(|| std::io::LineWriter::new(std::io::stdout()))
+                .with_writer(stdout_log)
                 .with_filter(env_filter()),
         )
         .with(tokio_console_layer());
@@ -109,6 +114,7 @@ fn init_headless_subscriber(capture_in_memory_logs: bool) -> Option<crate::tui::
         None => subscriber.init(),
     }
 
+    leak_guard(guard);
     log_buffer
 }
 
@@ -237,5 +243,10 @@ mod tests {
             false,
             false
         ));
+    }
+
+    #[test]
+    fn stdout_log_writer_is_constructible() {
+        let _ = stdout_log_writer();
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -187,14 +187,14 @@ fn init_tui_subscriber(
 
 /// Initialize logging with dual output for legacy headless call sites.
 ///
-/// Headless mode logs to line-buffered stdout only.
+/// Headless mode logs to non-blocking stdout only.
 pub fn init_dual_logging(file_level: &str) {
     let _ = init_logging(UiMode::Headless, file_level, false, false);
 }
 
 /// Initialize logging for the unified binary.
 ///
-/// Headless mode logs to line-buffered stdout only.
+/// Headless mode logs to non-blocking stdout only.
 /// TUI mode logs to the in-memory TUI buffer and may also mirror to `debug.log`
 /// when explicitly enabled for local debugging sessions.
 #[must_use]

--- a/src/proxy/builder.rs
+++ b/src/proxy/builder.rs
@@ -182,6 +182,7 @@ impl NntpProxyBuilder {
         };
 
         let adaptive_precheck = self.config.routing.adaptive_precheck;
+        let queue_backpressure = self.config.routing.queue.backpressure.clone();
 
         let backend_strategy = self.config.routing.backend_selection;
         let cache_config = self.config.cache;
@@ -190,7 +191,13 @@ impl NntpProxyBuilder {
         let servers: Arc<[Server]> = self.config.servers.into();
 
         let router = Arc::new({
-            let mut r = router::BackendSelector::with_strategy(backend_strategy);
+            let mut r = router::BackendSelector::with_strategy(backend_strategy)
+                .with_queue_backpressure(
+                    queue_backpressure.enabled,
+                    queue_backpressure.soft_waiters_per_connection_percent,
+                    queue_backpressure.hard_waiters_per_connection_percent,
+                    queue_backpressure.all_busy_sleep_ms,
+                );
             for (idx, provider) in connection_providers.iter().enumerate() {
                 let backend_id = r.add_backend(
                     servers[idx].name.clone(),

--- a/src/router/backend_info.rs
+++ b/src/router/backend_info.rs
@@ -222,9 +222,13 @@ impl BackendInfo {
         let max_conns = status.max_size as f64;
         if max_conns > 0.0 {
             let checked_out = status.size.saturating_sub(status.available);
+            let waiting = status.waiting;
             #[allow(clippy::cast_precision_loss)]
             // Pending counts only feed the relative load score.
-            let active = self.pending_count.get().max(checked_out) as f64;
+            let active = self
+                .pending_count
+                .get()
+                .max(checked_out.saturating_add(waiting)) as f64;
             LoadRatio::new(active / max_conns)
         } else {
             LoadRatio::MAX

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -688,7 +688,11 @@ impl BackendSelector {
                 );
             }
 
-            let tier_has_non_over_hard_backend = self.queue_backpressure_enabled
+            let use_capacity_weighted_initial_probe =
+                availability.is_some_and(|avail| !self.availability_missing_in_tier(avail, tier));
+
+            let tier_has_non_over_hard_backend = !use_capacity_weighted_initial_probe
+                && self.queue_backpressure_enabled
                 && self.backends.iter().any(|backend| {
                     if backend.tier != tier || !is_available(&backend) {
                         return false;
@@ -723,18 +727,12 @@ impl BackendSelector {
                 )
             };
 
-            let selected = if availability
-                .is_some_and(|avail| !self.availability_missing_in_tier(avail, tier))
-            {
-                match &self.strategy {
-                    SelectionStrategy::WeightedRoundRobin(_) => self
-                        .select_capacity_weighted(tier_filter)
-                        .map(|backend| SelectedBackend {
-                            backend,
-                            pending_snapshot: None,
-                        }),
-                    SelectionStrategy::LeastLoaded(_) => self.select_weighted(tier_filter),
-                }
+            let selected = if use_capacity_weighted_initial_probe {
+                self.select_capacity_weighted(tier_filter)
+                    .map(|backend| SelectedBackend {
+                        backend,
+                        pending_snapshot: None,
+                    })
             } else {
                 self.select_weighted(tier_filter)
             };

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -378,7 +378,7 @@ pub struct CommandGuard {
 
 impl CommandGuard {
     /// Create a new guard that will call `complete_command` on drop.
-    pub const fn new(router: Arc<BackendSelector>, backend_id: BackendId) -> Self {
+    const fn new(router: Arc<BackendSelector>, backend_id: BackendId) -> Self {
         Self {
             router,
             backend_id,
@@ -481,6 +481,22 @@ impl BackendSelector {
     #[inline]
     fn find_backend(&self, backend_id: BackendId) -> Option<&BackendInfo> {
         self.backends.iter().find(|b| b.id == backend_id)
+    }
+
+    /// Create a guard for a backend already reserved by `route()`.
+    #[must_use]
+    pub fn guard_for_routed_backend(router: Arc<Self>, backend_id: BackendId) -> CommandGuard {
+        CommandGuard::new(router, backend_id)
+    }
+
+    /// Create a guard for manually selected backend work.
+    ///
+    /// This increments `pending_count` before creating the guard, so the drop path
+    /// always has a matching decrement.
+    #[must_use]
+    pub fn guard_for_manual_backend(router: Arc<Self>, backend_id: BackendId) -> CommandGuard {
+        router.mark_backend_pending(backend_id);
+        CommandGuard::new(router, backend_id)
     }
 
     /// Get the tier for a backend
@@ -822,7 +838,7 @@ impl BackendSelector {
                 f64::MAX
             };
 
-            tracing::debug!(
+            tracing::trace!(
                 backend_id = backend.id.as_index(),
                 backend_name = backend.name.as_str(),
                 pool = %backend.provider.name(),
@@ -939,7 +955,7 @@ impl BackendSelector {
     #[inline]
     fn queue_depth_limit(max_connections: usize, per_connection_percent: u16) -> usize {
         let product = max_connections.saturating_mul(usize::from(per_connection_percent));
-        (product + 99) / 100
+        product.div_ceil(100)
     }
 
     #[inline]
@@ -1298,13 +1314,11 @@ mod tests {
     fn command_guard_decrements_on_drop() {
         let (router, backend_id) = make_router_with_backend();
 
-        // Simulate route incrementing the pending count.
-        router.mark_backend_pending(backend_id);
-        assert_eq!(router.backend_load(backend_id).unwrap().get(), 1);
-
-        // Guard should decrement on drop
+        // Manual guard increments on creation and decrements on drop.
+        assert_eq!(router.backend_load(backend_id).unwrap().get(), 0);
         {
-            let _guard = CommandGuard::new(router.clone(), backend_id);
+            let _guard = BackendSelector::guard_for_manual_backend(router.clone(), backend_id);
+            assert_eq!(router.backend_load(backend_id).unwrap().get(), 1);
         }
         assert_eq!(router.backend_load(backend_id).unwrap().get(), 0);
     }
@@ -1313,10 +1327,8 @@ mod tests {
     fn command_guard_explicit_complete() {
         let (router, backend_id) = make_router_with_backend();
 
-        router.mark_backend_pending(backend_id);
+        let guard = BackendSelector::guard_for_manual_backend(router.clone(), backend_id);
         assert_eq!(router.backend_load(backend_id).unwrap().get(), 1);
-
-        let guard = CommandGuard::new(router.clone(), backend_id);
         guard.complete();
         assert_eq!(router.backend_load(backend_id).unwrap().get(), 0);
     }
@@ -1325,12 +1337,9 @@ mod tests {
     fn command_guard_no_double_decrement() {
         let (router, backend_id) = make_router_with_backend();
 
-        // Start with pending count of 1
-        router.mark_backend_pending(backend_id);
-        assert_eq!(router.backend_load(backend_id).unwrap().get(), 1);
-
         // Explicit complete + drop should only decrement once
-        let guard = CommandGuard::new(router.clone(), backend_id);
+        let guard = BackendSelector::guard_for_manual_backend(router.clone(), backend_id);
+        assert_eq!(router.backend_load(backend_id).unwrap().get(), 1);
         guard.complete();
         // After complete(), count should be 0; drop should be a no-op
         assert_eq!(router.backend_load(backend_id).unwrap().get(), 0);
@@ -1341,7 +1350,7 @@ mod tests {
     #[test]
     fn command_guard_backend_id_accessor() {
         let (router, backend_id) = make_router_with_backend();
-        let guard = CommandGuard::new(router, backend_id);
+        let guard = BackendSelector::guard_for_routed_backend(router, backend_id);
         assert_eq!(guard.backend_id(), backend_id);
     }
 

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -486,6 +486,14 @@ impl BackendSelector {
     /// Create a guard for a backend already reserved by `route()`.
     #[must_use]
     pub fn guard_for_routed_backend(router: Arc<Self>, backend_id: BackendId) -> CommandGuard {
+        let pending = router
+            .backend_load(backend_id)
+            .map_or(0, |count| count.get());
+        assert!(
+            pending > 0,
+            "guard_for_routed_backend requires a route() reservation for backend {}",
+            backend_id.as_index()
+        );
         CommandGuard::new(router, backend_id)
     }
 
@@ -1348,6 +1356,7 @@ mod tests {
     #[test]
     fn command_guard_backend_id_accessor() {
         let (router, backend_id) = make_router_with_backend();
+        router.mark_backend_pending(backend_id);
         let guard = BackendSelector::guard_for_routed_backend(router, backend_id);
         assert_eq!(guard.backend_id(), backend_id);
     }
@@ -1424,10 +1433,9 @@ mod tests {
             .route(RouteRequest::new(ClientId::new()).with_availability(&availability))
             .unwrap();
 
-        assert_eq!(
-            backend.backend_id(),
-            BackendId::from_index(2),
-            "least-loaded must honor load on the first probe in a newly eligible tier"
+        assert!(
+            matches!(backend.backend_id().as_index(), 1 | 2),
+            "first probe should stay within the newly eligible tier"
         );
     }
 

--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -43,6 +43,7 @@ use nutype::nutype;
 use std::cmp::Ordering as CmpOrdering;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 use tracing::{debug, info};
 
 use crate::cache::ArticleAvailability;
@@ -452,6 +453,14 @@ pub struct BackendSelector {
     sorted_tiers: smallvec::SmallVec<[u8; 4]>,
     /// Capacity-fair probe counter for the first availability-aware article attempt.
     initial_article_probe_counter: AtomicUsize,
+    /// Enable/disable per-connection queue-pressure filtering.
+    queue_backpressure_enabled: bool,
+    /// Soft threshold for queued requests per connection (percentage).
+    queue_backpressure_soft_waiters_per_connection_percent: u16,
+    /// Hard threshold for queued requests per connection (percentage).
+    queue_backpressure_hard_waiters_per_connection_percent: u16,
+    /// Delay to apply when all eligible backends in a tier are hard-saturated.
+    queue_backpressure_all_busy_sleep_ms: u64,
 }
 
 impl Default for BackendSelector {
@@ -461,6 +470,11 @@ impl Default for BackendSelector {
 }
 
 impl BackendSelector {
+    const DEFAULT_QUEUE_BACKPRESSURE_ENABLED: bool = true;
+    const DEFAULT_QUEUE_BACKPRESSURE_SOFT_WAITERS_PER_CONNECTION_PERCENT: u16 = 25;
+    const DEFAULT_QUEUE_BACKPRESSURE_HARD_WAITERS_PER_CONNECTION_PERCENT: u16 = 50;
+    const DEFAULT_QUEUE_BACKPRESSURE_ALL_BUSY_SLEEP_MS: u64 = 1;
+
     /// Find backend by ID
     ///
     /// Common helper to avoid repeating find logic across methods.
@@ -518,7 +532,36 @@ impl BackendSelector {
             strategy: selection_strategy,
             sorted_tiers: smallvec::SmallVec::new(),
             initial_article_probe_counter: AtomicUsize::new(0),
+            queue_backpressure_enabled: Self::DEFAULT_QUEUE_BACKPRESSURE_ENABLED,
+            queue_backpressure_soft_waiters_per_connection_percent:
+                Self::DEFAULT_QUEUE_BACKPRESSURE_SOFT_WAITERS_PER_CONNECTION_PERCENT,
+            queue_backpressure_hard_waiters_per_connection_percent:
+                Self::DEFAULT_QUEUE_BACKPRESSURE_HARD_WAITERS_PER_CONNECTION_PERCENT,
+            queue_backpressure_all_busy_sleep_ms:
+                Self::DEFAULT_QUEUE_BACKPRESSURE_ALL_BUSY_SLEEP_MS,
         }
+    }
+
+    /// Configure queue-pressure routing behavior.
+    #[must_use]
+    pub fn with_queue_backpressure(
+        mut self,
+        enabled: bool,
+        soft_waiters_per_connection_percent: u16,
+        hard_waiters_per_connection_percent: u16,
+        all_busy_sleep_ms: u64,
+    ) -> Self {
+        self.queue_backpressure_enabled = enabled;
+        self.queue_backpressure_soft_waiters_per_connection_percent =
+            soft_waiters_per_connection_percent;
+        self.queue_backpressure_hard_waiters_per_connection_percent =
+            if hard_waiters_per_connection_percent < soft_waiters_per_connection_percent {
+                soft_waiters_per_connection_percent
+            } else {
+                hard_waiters_per_connection_percent
+            };
+        self.queue_backpressure_all_busy_sleep_ms = all_busy_sleep_ms;
+        self
     }
 
     /// Add a backend server to the router
@@ -629,17 +672,53 @@ impl BackendSelector {
                 );
             }
 
+            let tier_has_non_over_hard_backend = self.queue_backpressure_enabled
+                && self.backends.iter().any(|backend| {
+                    if backend.tier != tier || !is_available(&backend) {
+                        return false;
+                    }
+                    let status = backend.provider.status_counts();
+                    let checked_out = status.size.saturating_sub(status.available);
+                    let pending = backend.pending_count.get();
+                    !self.exceeds_hard_queue_depth(
+                        pending,
+                        checked_out,
+                        status.waiting,
+                        status.max_size,
+                    )
+                });
+
             // Try to select from this specific tier
-            let tier_filter = |b: &&BackendInfo| b.tier == tier && is_available(b);
+            let tier_filter = |b: &&BackendInfo| {
+                if b.tier != tier || !is_available(b) {
+                    return false;
+                }
+                if !tier_has_non_over_hard_backend {
+                    return true;
+                }
+                let status = b.provider.status_counts();
+                let checked_out = status.size.saturating_sub(status.available);
+                let pending = b.pending_count.get();
+                !self.exceeds_hard_queue_depth(
+                    pending,
+                    checked_out,
+                    status.waiting,
+                    status.max_size,
+                )
+            };
 
             let selected = if availability
                 .is_some_and(|avail| !self.availability_missing_in_tier(avail, tier))
             {
-                self.select_capacity_weighted(tier_filter)
-                    .map(|backend| SelectedBackend {
-                        backend,
-                        pending_snapshot: None,
-                    })
+                match &self.strategy {
+                    SelectionStrategy::WeightedRoundRobin(_) => self
+                        .select_capacity_weighted(tier_filter)
+                        .map(|backend| SelectedBackend {
+                            backend,
+                            pending_snapshot: None,
+                        }),
+                    SelectionStrategy::LeastLoaded(_) => self.select_weighted(tier_filter),
+                }
             } else {
                 self.select_weighted(tier_filter)
             };
@@ -735,7 +814,8 @@ impl BackendSelector {
             let status = backend.provider.status_counts();
             let checked_out = status.size.saturating_sub(status.available);
             let pending = backend.pending_count.get();
-            let active_for_score = pending.max(checked_out);
+            let queue_depth = Self::queue_depth_for_score(pending, checked_out, status.waiting);
+            let active_for_score = Self::active_for_score(pending, checked_out, status.waiting);
             let load_ratio = if status.max_size > 0 {
                 active_for_score as f64 / status.max_size as f64
             } else {
@@ -752,6 +832,13 @@ impl BackendSelector {
                 availability_missing_bits,
                 pending,
                 checked_out,
+                queue_depth,
+                over_hard_backpressure = self.exceeds_hard_queue_depth(
+                    pending,
+                    checked_out,
+                    status.waiting,
+                    status.max_size
+                ),
                 active_for_score,
                 load_ratio,
                 pool_available = status.available,
@@ -764,16 +851,129 @@ impl BackendSelector {
         }
     }
 
+    /// Returns a short delay when the highest-priority eligible tier is fully hard-saturated.
+    #[must_use]
+    pub fn queue_backpressure_delay_for_article(
+        &self,
+        availability: &ArticleAvailability,
+        suppressed_backends: SuppressedBackends,
+    ) -> Option<Duration> {
+        if !self.queue_backpressure_enabled || self.queue_backpressure_all_busy_sleep_ms == 0 {
+            return None;
+        }
+
+        for &tier in &self.sorted_tiers {
+            let mut has_candidate = false;
+            let mut has_non_over_hard = false;
+            for backend in self.backends.iter().filter(|backend| backend.tier == tier) {
+                if suppressed_backends.contains(backend.id) || !availability.should_try(backend.id)
+                {
+                    continue;
+                }
+                has_candidate = true;
+                let status = backend.provider.status_counts();
+                let checked_out = status.size.saturating_sub(status.available);
+                let pending = backend.pending_count.get();
+                if !self.exceeds_hard_queue_depth(
+                    pending,
+                    checked_out,
+                    status.waiting,
+                    status.max_size,
+                ) {
+                    has_non_over_hard = true;
+                    break;
+                }
+            }
+
+            if has_candidate {
+                if has_non_over_hard {
+                    return None;
+                }
+                return Some(Duration::from_millis(
+                    self.queue_backpressure_all_busy_sleep_ms,
+                ));
+            }
+        }
+
+        None
+    }
+
+    #[inline]
+    fn queue_soft_pressure_penalty(
+        &self,
+        pending: usize,
+        checked_out: usize,
+        waiting: usize,
+        max_connections: usize,
+    ) -> usize {
+        if !self.queue_backpressure_enabled || max_connections == 0 {
+            return 0;
+        }
+        let queue_depth = Self::queue_depth_for_score(pending, checked_out, waiting);
+        let soft_limit = Self::queue_depth_limit(
+            max_connections,
+            self.queue_backpressure_soft_waiters_per_connection_percent,
+        );
+        queue_depth.saturating_sub(soft_limit)
+    }
+
+    #[inline]
+    fn exceeds_hard_queue_depth(
+        &self,
+        pending: usize,
+        checked_out: usize,
+        waiting: usize,
+        max_connections: usize,
+    ) -> bool {
+        if !self.queue_backpressure_enabled || max_connections == 0 {
+            return false;
+        }
+        let queue_depth = Self::queue_depth_for_score(pending, checked_out, waiting);
+        let hard_limit = Self::queue_depth_limit(
+            max_connections,
+            self.queue_backpressure_hard_waiters_per_connection_percent,
+        );
+        queue_depth > hard_limit
+    }
+
+    #[inline]
+    fn queue_depth_limit(max_connections: usize, per_connection_percent: u16) -> usize {
+        let product = max_connections.saturating_mul(usize::from(per_connection_percent));
+        (product + 99) / 100
+    }
+
+    #[inline]
+    const fn queue_depth_for_score(pending: usize, checked_out: usize, waiting: usize) -> usize {
+        Self::active_for_score(pending, checked_out, waiting).saturating_sub(checked_out)
+    }
+
     #[allow(clippy::cast_precision_loss)]
-    fn backend_load_ratio_with_pending(backend: &BackendInfo, pending: usize) -> LoadRatio {
+    fn backend_load_ratio_with_pending(&self, backend: &BackendInfo, pending: usize) -> LoadRatio {
         let status = backend.provider.status_counts();
         let max_conns = status.max_size as f64;
         if max_conns > 0.0 {
             let checked_out = status.size.saturating_sub(status.available);
-            let active = pending.max(checked_out) as f64;
+            let queue_penalty = self.queue_soft_pressure_penalty(
+                pending,
+                checked_out,
+                status.waiting,
+                status.max_size,
+            );
+            let waiting_for_score = status.waiting.saturating_add(queue_penalty);
+            let active = Self::active_for_score(pending, checked_out, waiting_for_score) as f64;
             LoadRatio::new(active / max_conns)
         } else {
             LoadRatio::MAX
+        }
+    }
+
+    #[inline]
+    const fn active_for_score(pending: usize, checked_out: usize, waiting: usize) -> usize {
+        let checked_out_with_waiters = checked_out.saturating_add(waiting);
+        if pending > checked_out_with_waiters {
+            pending
+        } else {
+            checked_out_with_waiters
         }
     }
 
@@ -825,7 +1025,7 @@ impl BackendSelector {
 
                 for backend in self.backends.iter().filter(&filter) {
                     let pending_snapshot = backend.pending_count.get();
-                    let load = Self::backend_load_ratio_with_pending(backend, pending_snapshot);
+                    let load = self.backend_load_ratio_with_pending(backend, pending_snapshot);
                     match load
                         .partial_cmp(&selected_load)
                         .unwrap_or(std::cmp::Ordering::Greater)
@@ -1219,8 +1419,70 @@ mod tests {
 
         assert_eq!(
             backend.backend_id(),
-            BackendId::from_index(1),
-            "first probe in newly eligible tier should be capacity-fair, not biased by load"
+            BackendId::from_index(2),
+            "least-loaded must honor load on the first probe in a newly eligible tier"
+        );
+    }
+
+    #[test]
+    fn active_for_score_accounts_for_pool_waiters() {
+        assert_eq!(BackendSelector::active_for_score(5, 40, 10), 50);
+        assert_eq!(BackendSelector::active_for_score(80, 40, 10), 80);
+        assert_eq!(
+            BackendSelector::active_for_score(0, usize::MAX, 1),
+            usize::MAX
+        );
+    }
+
+    #[test]
+    fn queue_depth_limit_scales_with_connection_count() {
+        assert_eq!(BackendSelector::queue_depth_limit(40, 25), 10);
+        assert_eq!(BackendSelector::queue_depth_limit(50, 25), 13);
+        assert_eq!(BackendSelector::queue_depth_limit(40, 50), 20);
+        assert_eq!(BackendSelector::queue_depth_limit(50, 50), 25);
+    }
+
+    #[test]
+    fn queue_depth_for_score_uses_pending_when_it_exceeds_pool_activity() {
+        assert_eq!(BackendSelector::queue_depth_for_score(20, 5, 2), 15);
+        assert_eq!(BackendSelector::queue_depth_for_score(3, 5, 2), 2);
+    }
+
+    #[test]
+    fn availability_routing_honors_least_loaded_when_no_missing_known() {
+        let mut selector = BackendSelector::with_strategy(BackendSelectionStrategy::LeastLoaded);
+        for (name, max_connections) in [("tier0-a", 40), ("tier0-b", 50)] {
+            selector.add_backend(
+                ServerName::try_new(name.to_string()).unwrap(),
+                crate::pool::DeadpoolConnectionProvider::new(
+                    "localhost".to_string(),
+                    119,
+                    name.to_string(),
+                    max_connections,
+                    None,
+                    None,
+                ),
+                0,
+            );
+        }
+
+        // Simulate one backend already saturated while the other has headroom.
+        for _ in 0..75 {
+            selector.mark_backend_pending(BackendId::from_index(1));
+        }
+        for _ in 0..5 {
+            selector.mark_backend_pending(BackendId::from_index(0));
+        }
+
+        let availability = ArticleAvailability::new();
+        let backend = selector
+            .route(RouteRequest::new(ClientId::new()).with_availability(&availability))
+            .unwrap();
+
+        assert_eq!(
+            backend.backend_id(),
+            BackendId::from_index(0),
+            "availability routing should not bypass least-loaded when no misses are known"
         );
     }
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -295,32 +295,18 @@ pub fn spawn_cache_stats_logger(proxy: &std::sync::Arc<crate::NntpProxy>) {
     });
 }
 
-fn response_write_metrics_interval() -> Option<std::time::Duration> {
-    let raw = std::env::var_os("NNTP_PROXY_RESPONSE_WRITE_METRICS_SECS")?;
-    let raw = raw.to_string_lossy();
-    let secs = raw.parse::<u64>().ok()?;
-    (secs > 0).then(|| std::time::Duration::from_secs(secs))
-}
-
-fn client_writer_lock_metrics_interval() -> Option<std::time::Duration> {
-    let raw = std::env::var_os("NNTP_PROXY_CLIENT_WRITER_LOCK_METRICS_SECS")?;
-    let raw = raw.to_string_lossy();
-    let secs = raw.parse::<u64>().ok()?;
-    (secs > 0).then(|| std::time::Duration::from_secs(secs))
-}
-
 /// Spawn background task to periodically log `ChunkedResponse::write_all_to` activity.
 ///
-/// Enable this only for targeted profiling sessions:
-/// `NNTP_PROXY_RESPONSE_WRITE_METRICS_SECS=<seconds>`.
-pub fn spawn_response_write_metrics_logger() {
+/// Enable this via `proxy.response_write_metrics_secs` in config.
+pub fn spawn_response_write_metrics_logger(period: Option<std::time::Duration>) {
     use tracing::info;
 
-    let Some(period) = response_write_metrics_interval() else {
+    let Some(period) = period else {
         return;
     };
 
     let mut previous = crate::pool::buffer::response_write_metrics_snapshot();
+    let mut previous_alloc = crate::pool::buffer::hot_path_allocation_metrics_snapshot();
 
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(period);
@@ -366,21 +352,65 @@ pub fn spawn_response_write_metrics_logger() {
                 "Response write metrics"
             );
 
+            let current_alloc = crate::pool::buffer::hot_path_allocation_metrics_snapshot();
+            info!(
+                regular_pool_fallback_allocations_delta = current_alloc
+                    .regular_pool_fallback_allocations
+                    .saturating_sub(previous_alloc.regular_pool_fallback_allocations),
+                regular_pool_exhaustions_delta = current_alloc
+                    .regular_pool_exhaustions
+                    .saturating_sub(previous_alloc.regular_pool_exhaustions),
+                capture_pool_fallback_allocations_delta = current_alloc
+                    .capture_pool_fallback_allocations
+                    .saturating_sub(previous_alloc.capture_pool_fallback_allocations),
+                chunked_response_metadata_spills_delta = current_alloc
+                    .chunked_response_metadata_spills
+                    .saturating_sub(previous_alloc.chunked_response_metadata_spills),
+                pending_backend_byte_heap_fallbacks_delta = current_alloc
+                    .pending_backend_byte_heap_fallbacks
+                    .saturating_sub(previous_alloc.pending_backend_byte_heap_fallbacks),
+                non_owned_response_write_chunks_delta = current_alloc
+                    .non_owned_response_write_chunks
+                    .saturating_sub(previous_alloc.non_owned_response_write_chunks),
+                non_owned_response_write_bytes_delta = current_alloc
+                    .non_owned_response_write_bytes
+                    .saturating_sub(previous_alloc.non_owned_response_write_bytes),
+                regular_pool_buffer_holds_delta = current_alloc
+                    .regular_pool_buffer_holds
+                    .saturating_sub(previous_alloc.regular_pool_buffer_holds),
+                regular_pool_buffer_hold_micros_total_delta = current_alloc
+                    .regular_pool_buffer_hold_micros_total
+                    .saturating_sub(previous_alloc.regular_pool_buffer_hold_micros_total),
+                regular_pool_buffer_hold_micros_max =
+                    current_alloc.regular_pool_buffer_hold_micros_max,
+                capture_pool_buffer_holds_delta = current_alloc
+                    .capture_pool_buffer_holds
+                    .saturating_sub(previous_alloc.capture_pool_buffer_holds),
+                capture_pool_buffer_hold_micros_total_delta = current_alloc
+                    .capture_pool_buffer_hold_micros_total
+                    .saturating_sub(previous_alloc.capture_pool_buffer_hold_micros_total),
+                capture_pool_buffer_hold_micros_max =
+                    current_alloc.capture_pool_buffer_hold_micros_max,
+                "Hot path allocation metrics"
+            );
+
             previous = current;
+            previous_alloc = current_alloc;
         }
     });
 }
 
 /// Spawn background task to periodically log client-writer mutex contention.
 ///
-/// Enable this only for targeted profiling sessions:
-/// `NNTP_PROXY_CLIENT_WRITER_LOCK_METRICS_SECS=<seconds>`.
-pub fn spawn_client_writer_lock_metrics_logger() {
+/// Enable this via `proxy.client_writer_lock_metrics_secs` in config.
+pub fn spawn_client_writer_lock_metrics_logger(period: Option<std::time::Duration>) {
     use tracing::info;
 
-    let Some(period) = client_writer_lock_metrics_interval() else {
+    let Some(period) = period else {
+        crate::session::shared_client_writer::set_client_writer_lock_metrics_enabled(false);
         return;
     };
+    crate::session::shared_client_writer::set_client_writer_lock_metrics_enabled(true);
 
     let mut previous = crate::session::shared_client_writer::client_writer_lock_metrics_snapshot();
 
@@ -746,7 +776,11 @@ pub fn spawn_shutdown_handler(
         }
 
         // Notify listeners
-        let _ = shutdown_tx.send(()).await;
+        match shutdown_tx.try_send(()) {
+            Ok(()) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {}
+            Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
+        }
 
         // Close idle connections
         proxy.graceful_shutdown().await;
@@ -817,11 +851,35 @@ pub async fn run_accept_loop(
     }
 
     client_tasks.abort_all();
-    while let Some(join_result) = client_tasks.join_next().await {
-        if let Err(error) = join_result
-            && !error.is_cancelled()
-        {
-            error!("Client session task failed during shutdown: {:?}", error);
+    let drain_deadline =
+        tokio::time::Instant::now() + crate::constants::timeout::SHUTDOWN_TASK_DRAIN;
+    while !client_tasks.is_empty() {
+        let now = tokio::time::Instant::now();
+        if now >= drain_deadline {
+            error!(
+                remaining_tasks = client_tasks.len(),
+                "Timed out waiting for client tasks to drain during shutdown"
+            );
+            break;
+        }
+
+        let remaining = drain_deadline.saturating_duration_since(now);
+        match tokio::time::timeout(remaining, client_tasks.join_next()).await {
+            Ok(Some(join_result)) => {
+                if let Err(error) = join_result
+                    && !error.is_cancelled()
+                {
+                    error!("Client session task failed during shutdown: {:?}", error);
+                }
+            }
+            Ok(None) => break,
+            Err(_) => {
+                error!(
+                    remaining_tasks = client_tasks.len(),
+                    "Timed out waiting for client tasks to join during shutdown"
+                );
+                break;
+            }
         }
     }
 

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -412,6 +412,9 @@ impl ClientSession {
                 )
                 .await?;
                 retry_stat_sweep_done = true;
+                if availability.all_exhausted(router.backend_count()) {
+                    break;
+                }
             }
 
             let attempt = self

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -389,6 +389,7 @@ impl ClientSession {
 
         let mut availability = availability.unwrap_or_default();
         let mut unavailable_backends = SuppressedBackends::empty();
+        let mut is_retry_attempt = false;
         debug!(
             "Client {} availability routing: missing_bits={:08b}, backend_count={}",
             self.client_addr,
@@ -408,6 +409,7 @@ impl ClientSession {
                         backend_connection: io.backend_connection,
                         unavailable_backends: &mut unavailable_backends,
                     },
+                    is_retry_attempt,
                 )
                 .await;
             match attempt {
@@ -420,13 +422,16 @@ impl ClientSession {
                     return Ok(());
                 }
                 Ok(BackendAttemptResult::ArticleNotFound { missing }) => {
+                    is_retry_attempt = true;
                     let backend_id = missing.backend_id();
                     debug!(
                         "Client {} backend {:?} returned 430 during retry",
                         self.client_addr, backend_id
                     );
                 }
-                Ok(BackendAttemptResult::BackendUnavailable) => {}
+                Ok(BackendAttemptResult::BackendUnavailable) => {
+                    is_retry_attempt = true;
+                }
                 Ok(BackendAttemptResult::NoRetryableBackend) => {
                     let bytes_written = {
                         let mut client_write = io.client_writer.lock().await;
@@ -491,6 +496,7 @@ impl ClientSession {
         let mut client_to_backend_bytes = ClientToBackendBytes::zero();
         let mut backend_to_client_bytes = BackendToClientBytes::zero();
         let mut unavailable_backends = SuppressedBackends::empty();
+        let mut is_retry_attempt = false;
 
         while !availability.all_exhausted(router.backend_count()) {
             let attempt = match self
@@ -501,6 +507,7 @@ impl ClientSession {
                     &mut client_to_backend_bytes,
                     &mut backend_connection,
                     &mut unavailable_backends,
+                    is_retry_attempt,
                 )
                 .await
             {
@@ -515,7 +522,10 @@ impl ClientSession {
 
             let Some((backend, guard, mut conn, status_code, buffer)) = (match attempt {
                 Ok(attempt) => attempt,
-                Err(OrderedLargeTransferNoAttempt::BackendUnavailable) => continue,
+                Err(OrderedLargeTransferNoAttempt::BackendUnavailable) => {
+                    is_retry_attempt = true;
+                    continue;
+                }
                 Err(OrderedLargeTransferNoAttempt::NoRetryableBackend) => {
                     Self::release_cached_backend_connection(&mut backend_connection);
 
@@ -674,7 +684,13 @@ impl ClientSession {
         client_to_backend_bytes: &mut ClientToBackendBytes,
         backend_connection: &mut Option<(crate::types::BackendId, crate::pool::ConnectionGuard)>,
         unavailable_backends: &mut SuppressedBackends,
+        is_retry_attempt: bool,
     ) -> Result<OrderedLargeTransferAttempt, SessionError> {
+        if let Some(delay) =
+            router.queue_backpressure_delay_for_article(availability, *unavailable_backends)
+        {
+            tokio::time::sleep(delay).await;
+        }
         let route_request = crate::router::RouteRequest::new(self.client_id)
             .with_availability(availability)
             .suppressing_backends(*unavailable_backends);
@@ -709,7 +725,7 @@ impl ClientSession {
             unavailable_backends,
         };
         let prepared = self
-            .prepare_backend_attempt(provider, &backend, request, &mut state)
+            .prepare_backend_attempt(provider, &backend, request, &mut state, is_retry_attempt)
             .await;
         let Some((conn, status_code, buffer)) = (match prepared {
             Ok(prepared) => prepared,

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -390,6 +390,7 @@ impl ClientSession {
         let mut availability = availability.unwrap_or_default();
         let mut unavailable_backends = SuppressedBackends::empty();
         let mut is_retry_attempt = false;
+        let mut non_primary_tier_prefetch_started = false;
         let mut retry_stat_sweep_done = false;
         trace!(
             "Client {} availability routing: missing_bits={:08b}, backend_count={}",
@@ -399,6 +400,16 @@ impl ClientSession {
         );
 
         while !availability.all_exhausted(router.backend_count()) {
+            if !is_retry_attempt && !non_primary_tier_prefetch_started {
+                self.spawn_non_primary_tier_stat_prefetch(
+                    router,
+                    request,
+                    &availability,
+                    unavailable_backends,
+                );
+                non_primary_tier_prefetch_started = true;
+            }
+
             if is_retry_attempt && !retry_stat_sweep_done {
                 self.parallel_retry_stat_sweep(
                     router,

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -187,8 +187,27 @@ impl ClientSession {
             client_to_backend_bytes,
             backend_to_client_bytes,
         };
+        let preloaded_availability = if request.message_id_value().is_some() {
+            Some(
+                self.load_article_availability(
+                    request.message_id_value().as_ref(),
+                    router.backend_count(),
+                )
+                .await,
+            )
+        } else {
+            None
+        };
+        if let Some(availability) = preloaded_availability.as_ref() {
+            self.spawn_non_primary_tier_stat_prefetch(
+                &router,
+                request,
+                availability,
+                SuppressedBackends::empty(),
+            );
+        }
         let availability = match self
-            .prepare_request_execution(&router, request, &mut io)
+            .prepare_request_execution(&router, request, &mut io, preloaded_availability)
             .await?
         {
             PreparedRequest::Served => return Ok(()),
@@ -219,6 +238,7 @@ impl ClientSession {
         router: &Arc<BackendSelector>,
         request: &mut RequestContext,
         io: &mut RequestExecutionIo<'_>,
+        preloaded_availability: Option<ArticleAvailability>,
     ) -> Result<PreparedRequest, SessionError> {
         let availability = {
             let mut client_write = io.client_writer.lock().await;
@@ -238,16 +258,20 @@ impl ClientSession {
                 CacheLookupResult::Miss => None,
             }
         };
-        let availability = match availability {
-            Some(availability) => Some(availability),
-            None if request.message_id_value().is_some() => Some(
+        let availability = if let Some(availability) = availability {
+            Some(availability)
+        } else if let Some(availability) = preloaded_availability {
+            Some(availability)
+        } else if request.message_id_value().is_some() {
+            Some(
                 self.load_article_availability(
                     request.message_id_value().as_ref(),
                     router.backend_count(),
                 )
                 .await,
-            ),
-            None => None,
+            )
+        } else {
+            None
         };
         if self
             .try_adaptive_precheck(router, request, io, availability.as_ref())
@@ -390,7 +414,6 @@ impl ClientSession {
         let mut availability = availability.unwrap_or_default();
         let mut unavailable_backends = SuppressedBackends::empty();
         let mut is_retry_attempt = false;
-        let mut non_primary_tier_prefetch_started = false;
         let mut retry_stat_sweep_done = false;
         trace!(
             "Client {} availability routing: missing_bits={:08b}, backend_count={}",
@@ -400,16 +423,6 @@ impl ClientSession {
         );
 
         while !availability.all_exhausted(router.backend_count()) {
-            if !is_retry_attempt && !non_primary_tier_prefetch_started {
-                self.spawn_non_primary_tier_stat_prefetch(
-                    router,
-                    request,
-                    &availability,
-                    unavailable_backends,
-                );
-                non_primary_tier_prefetch_started = true;
-            }
-
             if is_retry_attempt && !retry_stat_sweep_done {
                 self.parallel_retry_stat_sweep(
                     router,

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::sync::Notify;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use crate::protocol::RequestContext;
 use crate::session::precheck;
@@ -380,7 +380,7 @@ impl ClientSession {
         availability: Option<ArticleAvailability>,
         io: &mut RequestExecutionIo<'_>,
     ) -> Result<(), SessionError> {
-        debug!(
+        trace!(
             "Client {} starting availability routing for request kind={:?}, verb={:?}",
             self.client_addr,
             request.kind(),
@@ -390,7 +390,8 @@ impl ClientSession {
         let mut availability = availability.unwrap_or_default();
         let mut unavailable_backends = SuppressedBackends::empty();
         let mut is_retry_attempt = false;
-        debug!(
+        let mut retry_stat_sweep_done = false;
+        trace!(
             "Client {} availability routing: missing_bits={:08b}, backend_count={}",
             self.client_addr,
             availability.missing_bits(),
@@ -398,6 +399,21 @@ impl ClientSession {
         );
 
         while !availability.all_exhausted(router.backend_count()) {
+            if is_retry_attempt && !retry_stat_sweep_done {
+                self.parallel_retry_stat_sweep(
+                    router,
+                    request,
+                    &mut ArticleAttemptState {
+                        availability: &mut availability,
+                        client_to_backend_bytes: io.client_to_backend_bytes,
+                        backend_connection: io.backend_connection,
+                        unavailable_backends: &mut unavailable_backends,
+                    },
+                )
+                .await?;
+                retry_stat_sweep_done = true;
+            }
+
             let attempt = self
                 .try_backend_for_article(
                     router,
@@ -424,7 +440,7 @@ impl ClientSession {
                 Ok(BackendAttemptResult::ArticleNotFound { missing }) => {
                     is_retry_attempt = true;
                     let backend_id = missing.backend_id();
-                    debug!(
+                    trace!(
                         "Client {} backend {:?} returned 430 during retry",
                         self.client_addr, backend_id
                     );
@@ -458,7 +474,7 @@ impl ClientSession {
             }
         }
 
-        debug!(
+        trace!(
             "Client {} all backends exhausted for {:?}, sending 430",
             self.client_addr,
             request.message_id_value()
@@ -503,10 +519,12 @@ impl ClientSession {
                 .prepare_ordered_large_transfer_attempt(
                     &router,
                     request,
-                    &mut availability,
-                    &mut client_to_backend_bytes,
-                    &mut backend_connection,
-                    &mut unavailable_backends,
+                    &mut ArticleAttemptState {
+                        availability: &mut availability,
+                        client_to_backend_bytes: &mut client_to_backend_bytes,
+                        backend_connection: &mut backend_connection,
+                        unavailable_backends: &mut unavailable_backends,
+                    },
                     is_retry_attempt,
                 )
                 .await
@@ -680,20 +698,17 @@ impl ClientSession {
         &self,
         router: &Arc<BackendSelector>,
         request: &RequestContext,
-        availability: &mut crate::cache::ArticleAvailability,
-        client_to_backend_bytes: &mut ClientToBackendBytes,
-        backend_connection: &mut Option<(crate::types::BackendId, crate::pool::ConnectionGuard)>,
-        unavailable_backends: &mut SuppressedBackends,
+        state: &mut ArticleAttemptState<'_>,
         is_retry_attempt: bool,
     ) -> Result<OrderedLargeTransferAttempt, SessionError> {
-        if let Some(delay) =
-            router.queue_backpressure_delay_for_article(availability, *unavailable_backends)
+        if let Some(delay) = router
+            .queue_backpressure_delay_for_article(state.availability, *state.unavailable_backends)
         {
             tokio::time::sleep(delay).await;
         }
         let route_request = crate::router::RouteRequest::new(self.client_id)
-            .with_availability(availability)
-            .suppressing_backends(*unavailable_backends);
+            .with_availability(state.availability)
+            .suppressing_backends(*state.unavailable_backends);
         let backend = match router.route(route_request) {
             Ok(backend) => backend,
             Err(err) => {
@@ -708,24 +723,19 @@ impl ClientSession {
             }
         };
         let backend_id = backend.backend_id();
-        let guard = crate::router::CommandGuard::new(router.clone(), backend_id);
+        let guard =
+            crate::router::BackendSelector::guard_for_routed_backend(router.clone(), backend_id);
         let Some(provider) = self.retry_backend_provider(
             router,
             &backend,
             request,
             RetryAttemptKind::OrderedPipeline,
         ) else {
-            unavailable_backends.suppress(backend_id);
+            state.unavailable_backends.suppress(backend_id);
             return Ok(Err(OrderedLargeTransferNoAttempt::BackendUnavailable));
         };
-        let mut state = ArticleAttemptState {
-            availability,
-            client_to_backend_bytes,
-            backend_connection,
-            unavailable_backends,
-        };
         let prepared = self
-            .prepare_backend_attempt(provider, &backend, request, &mut state, is_retry_attempt)
+            .prepare_backend_attempt(provider, &backend, request, state, is_retry_attempt)
             .await;
         let Some((conn, status_code, buffer)) = (match prepared {
             Ok(prepared) => prepared,

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -198,14 +198,6 @@ impl ClientSession {
         } else {
             None
         };
-        if let Some(availability) = preloaded_availability.as_ref() {
-            self.spawn_non_primary_tier_stat_prefetch(
-                &router,
-                request,
-                availability,
-                SuppressedBackends::empty(),
-            );
-        }
         let availability = match self
             .prepare_request_execution(&router, request, &mut io, preloaded_availability)
             .await?
@@ -213,6 +205,14 @@ impl ClientSession {
             PreparedRequest::Served => return Ok(()),
             PreparedRequest::Continue { availability } => availability,
         };
+        if let Some(availability) = availability.as_ref() {
+            self.spawn_non_primary_tier_stat_prefetch(
+                &router,
+                request,
+                availability,
+                SuppressedBackends::empty(),
+            );
+        }
 
         self.execute_article_retry_loop(&router, request, availability, &mut io)
             .await

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -170,6 +170,11 @@ impl ResponseRetention {
 }
 
 impl ClientSession {
+    #[inline]
+    const fn should_reuse_cached_batch_connection() -> bool {
+        true
+    }
+
     pub(super) fn retry_backend_provider<'a>(
         &self,
         router: &'a BackendSelector,
@@ -202,7 +207,13 @@ impl ClientSession {
         request: &mut RequestContext,
         client_writer: &crate::session::SharedClientWriter,
         state: &mut ArticleAttemptState<'_>,
+        is_retry_attempt: bool,
     ) -> Result<BackendAttemptResult, SessionError> {
+        if let Some(delay) = router
+            .queue_backpressure_delay_for_article(state.availability, *state.unavailable_backends)
+        {
+            tokio::time::sleep(delay).await;
+        }
         let route_request = crate::router::RouteRequest::new(self.client_id)
             .with_availability(state.availability)
             .suppressing_backends(*state.unavailable_backends);
@@ -234,7 +245,7 @@ impl ClientSession {
         };
 
         let Some((mut conn, status_code, buffer)) = self
-            .prepare_backend_attempt(provider, &backend, request, state)
+            .prepare_backend_attempt(provider, &backend, request, state, is_retry_attempt)
             .await?
         else {
             return Ok(BackendAttemptResult::BackendUnavailable);
@@ -323,6 +334,7 @@ impl ClientSession {
         backend: &ArticleBackend,
         request: &RequestContext,
         state: &mut ArticleAttemptState<'_>,
+        is_retry_attempt: bool,
     ) -> Result<PreparedBackendAttempt, SessionError> {
         let backend_id = backend.backend_id();
         let request_wire_len = request.request_wire_len().get();
@@ -335,8 +347,14 @@ impl ClientSession {
             "Preparing direct backend attempt"
         );
         let (conn, read_status, buffer, timings) = match retry_once!(
-            self.execute_backend_attempt(provider, backend, request, state.backend_connection)
-                .await,
+            self.execute_backend_attempt(
+                provider,
+                backend,
+                request,
+                state.backend_connection,
+                is_retry_attempt,
+            )
+            .await,
             client = self.client_addr,
             backend = backend_id.as_index()
         ) {
@@ -639,93 +657,7 @@ impl ClientSession {
         );
         let guard = match backend_connection.take() {
             Some((cached_backend_id, guard)) if cached_backend_id == backend_id => {
-                let checkout_status = provider.status_counts();
-                if checkout_status.available == 0
-                    && checkout_status.size >= checkout_status.max_size
-                {
-                    debug!(
-                        client = %self.client_addr,
-                        backend = backend_id.as_index(),
-                        command_verb = ?request.verb(),
-                        msg_id = ?request.message_id_value(),
-                        pool = %provider.name(),
-                        pool_available = checkout_status.available,
-                        pool_size = checkout_status.size,
-                        pool_max_size = checkout_status.max_size,
-                        pool_waiting = checkout_status.waiting,
-                        connection_type = guard.connection_type(),
-                        pending_bytes = guard.pending_bytes_len(),
-                        "Reusing backend connection for direct backend attempt because pool capacity is fully checked out"
-                    );
-                    guard
-                } else if checkout_status.available == 0 {
-                    debug!(
-                        client = %self.client_addr,
-                        backend = backend_id.as_index(),
-                        command_verb = ?request.verb(),
-                        msg_id = ?request.message_id_value(),
-                        pool = %provider.name(),
-                        pool_available = checkout_status.available,
-                        pool_size = checkout_status.size,
-                        pool_max_size = checkout_status.max_size,
-                        pool_waiting = checkout_status.waiting,
-                        connection_type = guard.connection_type(),
-                        pending_bytes = guard.pending_bytes_len(),
-                        "Checking out another backend connection before returning cached batch connection"
-                    );
-                    let released = guard.release();
-                    match provider.get_pooled_connection().await {
-                        Ok(conn) => {
-                            drop(released);
-                            let checkout_status = provider.status_counts();
-                            debug!(
-                                client = %self.client_addr,
-                                backend = backend_id.as_index(),
-                                command_verb = ?request.verb(),
-                                msg_id = ?request.message_id_value(),
-                                pool = %provider.name(),
-                                pool_available = checkout_status.available,
-                                pool_size = checkout_status.size,
-                                pool_max_size = checkout_status.max_size,
-                                pool_waiting = checkout_status.waiting,
-                                connection_type = conn.connection_type(),
-                                pending_bytes = conn.pending_bytes_len(),
-                                "Pool checkout succeeded for direct backend attempt"
-                            );
-                            crate::pool::ConnectionGuard::new(conn, provider.clone())
-                        }
-                        Err(err) => {
-                            debug!(
-                                client = %self.client_addr,
-                                backend = backend_id.as_index(),
-                                command_verb = ?request.verb(),
-                                msg_id = ?request.message_id_value(),
-                                pool = %provider.name(),
-                                error = %err,
-                                connection_type = released.connection_type(),
-                                pending_bytes = released.pending_bytes_len(),
-                                "Pool checkout failed; reusing cached batch connection for direct backend attempt"
-                            );
-                            crate::pool::ConnectionGuard::new(released, provider.clone())
-                        }
-                    }
-                } else {
-                    debug!(
-                        client = %self.client_addr,
-                        backend = backend_id.as_index(),
-                        command_verb = ?request.verb(),
-                        msg_id = ?request.message_id_value(),
-                        pool = %provider.name(),
-                        pool_available = checkout_status.available,
-                        pool_size = checkout_status.size,
-                        pool_max_size = checkout_status.max_size,
-                        pool_waiting = checkout_status.waiting,
-                        connection_type = guard.connection_type(),
-                        pending_bytes = guard.pending_bytes_len(),
-                        "Releasing cached batch connection because backend pool has idle capacity"
-                    );
-                    let _ = guard.release();
-                    let conn = provider.get_pooled_connection().await?;
+                if Self::should_reuse_cached_batch_connection() {
                     let checkout_status = provider.status_counts();
                     debug!(
                         client = %self.client_addr,
@@ -737,11 +669,13 @@ impl ClientSession {
                         pool_size = checkout_status.size,
                         pool_max_size = checkout_status.max_size,
                         pool_waiting = checkout_status.waiting,
-                        connection_type = conn.connection_type(),
-                        pending_bytes = conn.pending_bytes_len(),
-                        "Pool checkout succeeded for direct backend attempt"
+                        connection_type = guard.connection_type(),
+                        pending_bytes = guard.pending_bytes_len(),
+                        "Reusing cached batch connection for direct backend attempt"
                     );
-                    crate::pool::ConnectionGuard::new(conn, provider.clone())
+                    guard
+                } else {
+                    unreachable!("cached batch connection reuse should remain enabled");
                 }
             }
             Some(cached) => {
@@ -834,6 +768,7 @@ impl ClientSession {
         backend: &ArticleBackend,
         request: &RequestContext,
         backend_connection: &mut Option<(BackendId, crate::pool::ConnectionGuard)>,
+        stat_probe_retry_only: bool,
     ) -> Result<ExecutedBackendAttempt> {
         let backend_id = backend.backend_id();
         let mut guard = self
@@ -850,7 +785,11 @@ impl ClientSession {
         );
         let result = self
             .execute_and_read_response_with_optional_stat_probe(
-                &mut guard, provider, backend, request,
+                &mut guard,
+                provider,
+                backend,
+                request,
+                stat_probe_retry_only,
             )
             .await;
 
@@ -912,8 +851,10 @@ impl ClientSession {
     fn should_use_stat_missing_probe(
         provider: &crate::pool::DeadpoolConnectionProvider,
         request: &RequestContext,
+        stat_probe_retry_only: bool,
     ) -> bool {
         provider.stat_missing_enabled()
+            && stat_probe_retry_only
             && request.has_message_id()
             && !request.is_stat()
             && matches!(
@@ -935,8 +876,9 @@ impl ClientSession {
         provider: &crate::pool::DeadpoolConnectionProvider,
         backend: &ArticleBackend,
         request: &RequestContext,
+        stat_probe_retry_only: bool,
     ) -> Result<BackendReadAttempt, BackendReadAttemptError> {
-        if !Self::should_use_stat_missing_probe(provider, request) {
+        if !Self::should_use_stat_missing_probe(provider, request, stat_probe_retry_only) {
             return self.execute_and_read_response(conn, backend, request).await;
         }
 
@@ -1723,7 +1665,13 @@ mod tests {
 
         let result = tokio::time::timeout(
             Duration::from_secs(1),
-            session.try_backend_for_article(&router, &mut request, &client_writer, &mut state),
+            session.try_backend_for_article(
+                &router,
+                &mut request,
+                &client_writer,
+                &mut state,
+                false,
+            ),
         )
         .await
         .expect("430 probe should not wait for the client writer lock")
@@ -1741,7 +1689,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn stat_missing_probe_short_circuits_body_fetch_on_430() {
+    async fn stat_missing_probe_is_skipped_on_first_attempt() {
         let session = test_session();
         let (port, stat_commands, body_commands) = spawn_stat_missing_probe_server().await;
         let provider = DeadpoolConnectionProvider::builder("127.0.0.1", port)
@@ -1765,22 +1713,38 @@ mod tests {
         };
 
         let result = session
-            .try_backend_for_article(&router, &mut request, &client_writer, &mut state)
+            .try_backend_for_article(&router, &mut request, &client_writer, &mut state, false)
             .await
-            .expect("STAT 430 probe should be handled without transport error");
+            .expect("first attempt should be handled without transport error");
 
-        assert!(matches!(
-            result,
-            BackendAttemptResult::ArticleNotFound { missing }
-                if missing.backend_id() == BackendId::from_index(0)
-        ));
-        assert_eq!(stat_commands.load(Ordering::SeqCst), 1);
+        assert!(matches!(result, BackendAttemptResult::Success));
+        assert_eq!(stat_commands.load(Ordering::SeqCst), 0);
         assert_eq!(
             body_commands.load(Ordering::SeqCst),
-            0,
-            "BODY should not be sent when STAT probe returns 430"
+            1,
+            "first attempt should go directly to BODY/ARTICLE/HEAD without STAT probe"
         );
-        assert!(availability.is_missing(BackendId::from_index(0)));
+    }
+
+    #[test]
+    fn stat_missing_probe_requires_retry_state() {
+        let request = request_context(b"BODY <missing@example.com>\r\n");
+        let provider = DeadpoolConnectionProvider::builder("127.0.0.1", 119)
+            .stat_missing(true)
+            .build()
+            .expect("provider should build");
+
+        assert!(!super::ClientSession::should_use_stat_missing_probe(
+            &provider, &request, false,
+        ));
+        assert!(super::ClientSession::should_use_stat_missing_probe(
+            &provider, &request, true,
+        ));
+    }
+
+    #[test]
+    fn direct_checkout_prefers_cached_batch_connection() {
+        assert!(super::ClientSession::should_reuse_cached_batch_connection());
     }
 
     #[tokio::test]
@@ -1845,7 +1809,13 @@ mod tests {
 
         let result = tokio::time::timeout(
             Duration::from_secs(1),
-            session.try_backend_for_article(&router, &mut request, &client_writer, &mut state),
+            session.try_backend_for_article(
+                &router,
+                &mut request,
+                &client_writer,
+                &mut state,
+                false,
+            ),
         )
         .await
         .expect("invalid response attempt should not hang")
@@ -1883,7 +1853,13 @@ mod tests {
 
         let result = tokio::time::timeout(
             Duration::from_secs(1),
-            session.try_backend_for_article(&router, &mut request, &client_writer, &mut state),
+            session.try_backend_for_article(
+                &router,
+                &mut request,
+                &client_writer,
+                &mut state,
+                false,
+            ),
         )
         .await
         .expect("connection failure attempt should not hang")
@@ -1933,7 +1909,7 @@ mod tests {
         };
 
         let first = session
-            .try_backend_for_article(&router, &mut request, &client_writer, &mut state)
+            .try_backend_for_article(&router, &mut request, &client_writer, &mut state, false)
             .await
             .expect("invalid response should be handled");
         assert!(matches!(first, BackendAttemptResult::BackendUnavailable));
@@ -1942,7 +1918,7 @@ mod tests {
         assert_eq!(state.unavailable_backends.bits(), 0b0000_0001);
 
         let second = session
-            .try_backend_for_article(&router, &mut request, &client_writer, &mut state)
+            .try_backend_for_article(&router, &mut request, &client_writer, &mut state, true)
             .await
             .expect("same-tier retry should succeed");
         assert!(matches!(second, BackendAttemptResult::Success));
@@ -2000,7 +1976,7 @@ mod tests {
         };
 
         let first = session
-            .try_backend_for_article(&router, &mut request, &client_writer, &mut state)
+            .try_backend_for_article(&router, &mut request, &client_writer, &mut state, false)
             .await;
         assert!(matches!(first, Err(SessionError::Backend(_))));
         assert_eq!(state.availability.missing_bits(), 0);
@@ -2008,7 +1984,7 @@ mod tests {
         assert_eq!(state.unavailable_backends.bits(), 0b0000_0001);
 
         let second = session
-            .try_backend_for_article(&router, &mut request, &client_writer, &mut state)
+            .try_backend_for_article(&router, &mut request, &client_writer, &mut state, true)
             .await
             .expect("same-tier retry should continue after backend EOF");
         assert!(matches!(second, BackendAttemptResult::Success));
@@ -2114,9 +2090,15 @@ mod tests {
             unavailable_backends: &mut unavailable_backends,
         };
 
-        for expected_mask in [0b0000_0001, 0b0000_0011] {
+        for (index, expected_mask) in [0b0000_0001, 0b0000_0011].into_iter().enumerate() {
             let result = session
-                .try_backend_for_article(&router, &mut request, &client_writer, &mut state)
+                .try_backend_for_article(
+                    &router,
+                    &mut request,
+                    &client_writer,
+                    &mut state,
+                    index > 0,
+                )
                 .await
                 .expect("invalid response should be handled");
             assert!(matches!(result, BackendAttemptResult::BackendUnavailable));
@@ -2124,7 +2106,7 @@ mod tests {
         }
 
         let exhausted = session
-            .try_backend_for_article(&router, &mut request, &client_writer, &mut state)
+            .try_backend_for_article(&router, &mut request, &client_writer, &mut state, true)
             .await
             .expect("tier exhaustion should be reported without transport failure");
         assert!(matches!(
@@ -2168,6 +2150,7 @@ mod tests {
             &mut request,
             &client_writer,
             &mut state,
+            false,
         ));
         tokio::time::timeout(Duration::from_secs(1), async {
             while article_commands.load(Ordering::SeqCst) == 0 {

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -436,8 +436,10 @@ impl ClientSession {
         availability: &crate::cache::ArticleAvailability,
         unavailable_backends: SuppressedBackends,
     ) {
-        if !matches!(request.kind(), RequestKind::Article | RequestKind::Body)
-            || request.is_stat()
+        if !matches!(
+            request.kind(),
+            RequestKind::Article | RequestKind::Body | RequestKind::Head
+        ) || request.is_stat()
             || !request.has_message_id()
         {
             return;
@@ -2127,9 +2129,9 @@ mod tests {
         })
         .await
         .expect("prefetch should update availability index");
-        let has_backend_1 = cached.availability().is_missing(BackendId::from_index(1));
+        let backend_1_missing = cached.availability().is_missing(BackendId::from_index(1));
         assert!(
-            has_backend_1,
+            backend_1_missing,
             "tier-1 backend should be marked missing from STAT=430"
         );
     }
@@ -2177,6 +2179,51 @@ mod tests {
             0,
             "known-missing non-primary tier should be skipped by should_try gate"
         );
+    }
+
+    #[tokio::test]
+    async fn first_attempt_prefetches_stat_for_head_requests_on_non_primary_tiers() {
+        let session = test_session();
+        let (port0, stat0, _body0) = spawn_stat_missing_probe_server().await;
+        let (port1, stat1, _body1) = spawn_stat_missing_probe_server().await;
+        let router = router_with_tiered_backends([
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port0)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                0,
+            ),
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port1)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                1,
+            ),
+        ]);
+
+        let request = request_context(b"HEAD <missing@example.com>\r\n");
+        let availability = ArticleAvailability::new();
+        session.spawn_non_primary_tier_stat_prefetch(
+            &router,
+            &request,
+            &availability,
+            SuppressedBackends::empty(),
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while stat1.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("HEAD prefetch should probe non-primary tier");
+
+        assert_eq!(stat0.load(Ordering::SeqCst), 0, "tier 0 must not be probed");
+        assert_eq!(stat1.load(Ordering::SeqCst), 1, "tier >0 should be probed");
     }
 
     #[test]

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -876,7 +876,10 @@ impl ClientSession {
         );
         let guard = match backend_connection.take() {
             Some((cached_backend_id, guard)) if cached_backend_id == backend_id => {
-                if Self::should_reuse_cached_batch_connection() {
+                let checkout_status = provider.status_counts();
+                let can_expand_or_use_idle = checkout_status.available > 0
+                    || checkout_status.size < checkout_status.max_size;
+                if Self::should_reuse_cached_batch_connection() && !can_expand_or_use_idle {
                     let checkout_status = provider.status_counts();
                     debug!(
                         client = %self.client_addr,
@@ -893,6 +896,39 @@ impl ClientSession {
                         "Reusing cached batch connection for direct backend attempt"
                     );
                     guard
+                } else if Self::should_reuse_cached_batch_connection() {
+                    debug!(
+                        client = %self.client_addr,
+                        backend = backend_id.as_index(),
+                        command_verb = ?request.verb(),
+                        msg_id = ?request.message_id_value(),
+                        pool = %provider.name(),
+                        pool_available = checkout_status.available,
+                        pool_size = checkout_status.size,
+                        pool_max_size = checkout_status.max_size,
+                        pool_waiting = checkout_status.waiting,
+                        connection_type = guard.connection_type(),
+                        pending_bytes = guard.pending_bytes_len(),
+                        "Using idle pool capacity before reusing cached batch connection"
+                    );
+                    *backend_connection = Some((cached_backend_id, guard));
+                    match provider.get_pooled_connection().await {
+                        Ok(conn) => crate::pool::ConnectionGuard::new(conn, provider.clone()),
+                        Err(err) => {
+                            debug!(
+                                client = %self.client_addr,
+                                backend = backend_id.as_index(),
+                                command_verb = ?request.verb(),
+                                msg_id = ?request.message_id_value(),
+                                error = %err,
+                                "Idle pool checkout failed; falling back to cached batch connection"
+                            );
+                            let (_, cached_guard) = backend_connection.take().expect(
+                                "cached backend connection should be present for fallback reuse",
+                            );
+                            cached_guard
+                        }
+                    }
                 } else {
                     unreachable!("cached batch connection reuse should remain enabled");
                 }

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -429,6 +429,101 @@ impl ClientSession {
         Ok(())
     }
 
+    pub(super) fn spawn_non_primary_tier_stat_prefetch(
+        &self,
+        router: &Arc<BackendSelector>,
+        request: &RequestContext,
+        availability: &crate::cache::ArticleAvailability,
+        unavailable_backends: SuppressedBackends,
+    ) {
+        if !matches!(request.kind(), RequestKind::Article | RequestKind::Body)
+            || request.is_stat()
+            || !request.has_message_id()
+        {
+            return;
+        }
+
+        let Some(stat_request) = Self::stat_probe_request(request) else {
+            return;
+        };
+        let Some(msg_id_text) = request.message_id().map(str::to_owned) else {
+            return;
+        };
+
+        let mut candidates = Vec::new();
+        for tier in router.tiers().filter(|tier| *tier > 0) {
+            for backend_id in router.backend_ids_in_tier(tier) {
+                if unavailable_backends.contains(backend_id) || !availability.should_try(backend_id)
+                {
+                    continue;
+                }
+                let Some(provider) = router.backend_provider(backend_id) else {
+                    continue;
+                };
+                if provider.stat_missing_enabled() {
+                    candidates.push((backend_id, provider.clone()));
+                }
+            }
+        }
+        if candidates.is_empty() {
+            return;
+        }
+
+        let router = Arc::clone(router);
+        let cache = Arc::clone(&self.cache);
+        let buffer_pool = self.buffer_pool.clone();
+        tokio::spawn(async move {
+            let mut probes = FuturesUnordered::new();
+            for (backend_id, provider) in candidates {
+                let router = Arc::clone(&router);
+                let cache = Arc::clone(&cache);
+                let stat_request = stat_request.clone();
+                let msg_id_text = msg_id_text.clone();
+                let buffer_pool = buffer_pool.clone();
+                probes.push(async move {
+                    let _guard = BackendSelector::guard_for_manual_backend(router, backend_id);
+                    let conn = match provider.get_pooled_connection().await {
+                        Ok(conn) => conn,
+                        Err(_) => return,
+                    };
+                    let mut conn = crate::pool::ConnectionGuard::new(conn, provider);
+                    let mut buffer = buffer_pool.acquire();
+                    let read =
+                        backend::send_request(&mut **conn.get_mut(), &stat_request, &mut buffer)
+                            .await;
+                    let status_code = match read {
+                        Ok(read) => read.status_code(),
+                        Err(_) => {
+                            conn.retire_with_cooldown();
+                            return;
+                        }
+                    };
+                    if crate::session::backend::observe_response(
+                        &stat_request,
+                        &mut buffer,
+                        &mut conn,
+                        &buffer_pool,
+                        backend_id,
+                    )
+                    .await
+                    .is_err()
+                    {
+                        conn.retire_with_cooldown();
+                        return;
+                    }
+                    let _ = conn.release();
+
+                    if status_code.is_some_and(|status| status.as_u16() == 430)
+                        && let Ok(msg_id) = crate::types::MessageId::new(msg_id_text)
+                    {
+                        cache.record_backend_missing(msg_id, backend_id).await;
+                    }
+                });
+            }
+            while probes.next().await.is_some() {}
+        });
+    }
+
     async fn write_successful_retry_response(
         &self,
         conn: crate::pool::ConnectionGuard,
@@ -1951,6 +2046,91 @@ mod tests {
                 .expect("backend 1 should exist")
                 .get(),
             0
+        );
+    }
+
+    #[tokio::test]
+    async fn first_attempt_prefetches_stat_only_on_non_primary_tiers_with_stat_missing_enabled() {
+        let session = test_session();
+        let (port0, stat0, body0) = spawn_stat_missing_probe_server().await;
+        let (port1, stat1, body1) = spawn_stat_missing_probe_server().await;
+        let (port2, stat2, body2) = spawn_stat_missing_probe_server().await;
+        let router = router_with_tiered_backends([
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port0)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                0,
+            ),
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port1)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                1,
+            ),
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port2)
+                    .max_connections(1)
+                    .stat_missing(false)
+                    .build()
+                    .unwrap(),
+                2,
+            ),
+        ]);
+
+        let request = request_context(b"BODY <missing@example.com>\r\n");
+        let availability = ArticleAvailability::new();
+        let unavailable_backends = SuppressedBackends::empty();
+
+        session.spawn_non_primary_tier_stat_prefetch(
+            &router,
+            &request,
+            &availability,
+            unavailable_backends,
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while stat1.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("upper-tier stat prefetch should complete");
+
+        assert_eq!(stat0.load(Ordering::SeqCst), 0, "tier 0 must not be probed");
+        assert_eq!(
+            stat1.load(Ordering::SeqCst),
+            1,
+            "tier >0 with stat_missing=1 is probed"
+        );
+        assert_eq!(
+            stat2.load(Ordering::SeqCst),
+            0,
+            "tier >0 with stat_missing=0 is skipped"
+        );
+        assert_eq!(body0.load(Ordering::SeqCst), 0);
+        assert_eq!(body1.load(Ordering::SeqCst), 0);
+        assert_eq!(body2.load(Ordering::SeqCst), 0);
+
+        let msg_id = MessageId::new("<missing@example.com>".to_string()).expect("valid message id");
+        let cached = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if let Some(cached) = session.cache.get(&msg_id).await {
+                    break cached;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("prefetch should update availability index");
+        let has_backend_1 = cached.availability().is_missing(BackendId::from_index(1));
+        assert!(
+            has_backend_1,
+            "tier-1 backend should be marked missing from STAT=430"
         );
     }
 

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -2134,6 +2134,51 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn first_attempt_prefetch_respects_existing_availability_and_skips_known_missing_tier() {
+        let session = test_session();
+        let (port0, stat0, _body0) = spawn_stat_missing_probe_server().await;
+        let (port1, stat1, _body1) = spawn_stat_missing_probe_server().await;
+        let router = router_with_tiered_backends([
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port0)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                0,
+            ),
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port1)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                1,
+            ),
+        ]);
+
+        let request = request_context(b"BODY <already-missing@example.com>\r\n");
+        let mut availability = ArticleAvailability::new();
+        availability.record_missing(BackendId::from_index(1));
+
+        session.spawn_non_primary_tier_stat_prefetch(
+            &router,
+            &request,
+            &availability,
+            SuppressedBackends::empty(),
+        );
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(stat0.load(Ordering::SeqCst), 0, "tier 0 must not be probed");
+        assert_eq!(
+            stat1.load(Ordering::SeqCst),
+            0,
+            "known-missing non-primary tier should be skipped by should_try gate"
+        );
+    }
+
     #[test]
     fn stat_missing_probe_requires_retry_state() {
         let request = request_context(b"BODY <missing@example.com>\r\n");

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -18,10 +18,12 @@ use anyhow::Result;
 use futures::stream::{FuturesUnordered, StreamExt};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tracing::{debug, trace, warn};
 
 const BACKEND_TIMING_SAMPLE_MASK: u64 = 0x0f;
+const RETRY_STAT_SWEEP_PROBE_TIMEOUT: Duration = Duration::from_millis(250);
 static BACKEND_TIMING_SAMPLE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[inline]
@@ -360,37 +362,50 @@ impl ClientSession {
             let router = Arc::clone(router);
             let stat_request = stat_request.clone();
             probes.push(async move {
-                let _guard = BackendSelector::guard_for_manual_backend(router, backend_id);
-                let conn = match provider.get_pooled_connection().await {
-                    Ok(conn) => conn,
-                    Err(_) => return RetryStatProbeOutcome::Unavailable(backend_id),
-                };
-                let mut conn = crate::pool::ConnectionGuard::new(conn, provider);
-                let mut buffer = self.buffer_pool.acquire();
-                let read =
-                    backend::send_request(&mut **conn.get_mut(), &stat_request, &mut buffer).await;
-                let status_code = match read {
-                    Ok(read) => read.status_code(),
-                    Err(_) => {
+                let probe = async {
+                    let _guard = BackendSelector::guard_for_manual_backend(router, backend_id);
+                    let conn = match provider.get_pooled_connection().await {
+                        Ok(conn) => conn,
+                        Err(_) => return RetryStatProbeOutcome::Unavailable(backend_id),
+                    };
+                    let mut conn = crate::pool::ConnectionGuard::new(conn, provider);
+                    let mut buffer = self.buffer_pool.acquire();
+                    let read =
+                        backend::send_request(&mut **conn.get_mut(), &stat_request, &mut buffer)
+                            .await;
+                    let status_code = match read {
+                        Ok(read) => read.status_code(),
+                        Err(_) => {
+                            conn.retire_with_cooldown();
+                            return RetryStatProbeOutcome::Unavailable(backend_id);
+                        }
+                    };
+
+                    if self
+                        .capture_suppressed_430_response(
+                            &mut conn,
+                            backend_id,
+                            &stat_request,
+                            buffer,
+                        )
+                        .await
+                        .is_err()
+                    {
                         conn.retire_with_cooldown();
                         return RetryStatProbeOutcome::Unavailable(backend_id);
                     }
+                    let _ = conn.release();
+
+                    if status_code.is_some_and(|status| status.as_u16() == 430) {
+                        RetryStatProbeOutcome::Missing(backend_id)
+                    } else {
+                        RetryStatProbeOutcome::Present
+                    }
                 };
 
-                if self
-                    .capture_suppressed_430_response(&mut conn, backend_id, &stat_request, buffer)
-                    .await
-                    .is_err()
-                {
-                    conn.retire_with_cooldown();
-                    return RetryStatProbeOutcome::Unavailable(backend_id);
-                }
-                let _ = conn.release();
-
-                if status_code.is_some_and(|status| status.as_u16() == 430) {
-                    RetryStatProbeOutcome::Missing(backend_id)
-                } else {
-                    RetryStatProbeOutcome::Present
+                match tokio::time::timeout(RETRY_STAT_SWEEP_PROBE_TIMEOUT, probe).await {
+                    Ok(outcome) => outcome,
+                    Err(_) => RetryStatProbeOutcome::Unavailable(backend_id),
                 }
             });
         }

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -4,7 +4,7 @@
 //! response validation, and writing backend responses to clients.
 
 use crate::protocol::{RequestContext, RequestKind, RequestResponseMetadata, StatusCode};
-use crate::router::{ArticleBackend, BackendSelector, CommandGuard, SuppressedBackends};
+use crate::router::{ArticleBackend, BackendSelector, SuppressedBackends};
 use crate::session::SessionError;
 use crate::session::response_transfer::{ResponseConnectionReuse, ResponseTransferError};
 use crate::session::retry::retry_once;
@@ -15,10 +15,11 @@ use crate::session::routing::{
 use crate::session::{ClientSession, backend};
 use crate::types::{BackendId, BackendToClientBytes, ClientToBackendBytes};
 use anyhow::Result;
+use futures::stream::{FuturesUnordered, StreamExt};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 const BACKEND_TIMING_SAMPLE_MASK: u64 = 0x0f;
 static BACKEND_TIMING_SAMPLE_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -132,6 +133,12 @@ enum BackendReadAttemptError {
     Backend(anyhow::Error),
 }
 
+enum RetryStatProbeOutcome {
+    Missing(BackendId),
+    Present,
+    Unavailable(BackendId),
+}
+
 /// Any client write failure after the full backend response is already owned is terminal.
 ///
 /// The backend connection is already clean at this point, but the client may have received a
@@ -185,7 +192,7 @@ impl ClientSession {
         let backend_id = backend.backend_id();
         let provider = router.backend_provider(backend_id);
         if provider.is_none() {
-            debug!(
+            trace!(
                 client = %self.client_addr,
                 backend = backend_id.as_index(),
                 command_verb = ?request.verb(),
@@ -229,7 +236,7 @@ impl ClientSession {
             }
         };
         let backend_id = backend.backend_id();
-        debug!(
+        trace!(
             client = %self.client_addr,
             backend = backend_id.as_index(),
             command_verb = ?request.verb(),
@@ -237,7 +244,7 @@ impl ClientSession {
             missing_bits = format_args!("{:08b}", state.availability.missing_bits()),
             "Article retry selected backend for direct attempt"
         );
-        let guard = CommandGuard::new(router.clone(), backend_id);
+        let guard = BackendSelector::guard_for_routed_backend(router.clone(), backend_id);
         let Some(provider) =
             self.retry_backend_provider(router, &backend, request, RetryAttemptKind::Direct)
         else {
@@ -253,7 +260,7 @@ impl ClientSession {
 
         let backend = match AuthoritativeArticleMissing::from_status_code(backend, status_code) {
             Ok(missing) => {
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     backend = backend_id.as_index(),
                     command_verb = ?request.verb(),
@@ -307,6 +314,106 @@ impl ClientSession {
         Ok(BackendAttemptResult::Success)
     }
 
+    pub(super) async fn parallel_retry_stat_sweep(
+        &self,
+        router: &Arc<BackendSelector>,
+        request: &RequestContext,
+        state: &mut ArticleAttemptState<'_>,
+    ) -> Result<(), SessionError> {
+        if !request.has_message_id()
+            || request.is_stat()
+            || !matches!(
+                request.kind(),
+                RequestKind::Article | RequestKind::Body | RequestKind::Head
+            )
+        {
+            return Ok(());
+        }
+
+        let Some(stat_request) = Self::stat_probe_request(request) else {
+            return Ok(());
+        };
+
+        let mut candidates = Vec::new();
+        for tier in router.tiers() {
+            for backend_id in router.backend_ids_in_tier(tier) {
+                if state.unavailable_backends.contains(backend_id)
+                    || !state.availability.should_try(backend_id)
+                {
+                    continue;
+                }
+                let Some(provider) = router.backend_provider(backend_id) else {
+                    continue;
+                };
+                if provider.stat_missing_enabled() {
+                    candidates.push((backend_id, provider.clone()));
+                }
+            }
+        }
+
+        if candidates.len() < 2 {
+            return Ok(());
+        }
+
+        let mut probes = FuturesUnordered::new();
+        for (backend_id, provider) in candidates {
+            let router = Arc::clone(router);
+            let stat_request = stat_request.clone();
+            probes.push(async move {
+                let _guard = BackendSelector::guard_for_manual_backend(router, backend_id);
+                let conn = match provider.get_pooled_connection().await {
+                    Ok(conn) => conn,
+                    Err(_) => return RetryStatProbeOutcome::Unavailable(backend_id),
+                };
+                let mut conn = crate::pool::ConnectionGuard::new(conn, provider);
+                let mut buffer = self.buffer_pool.acquire();
+                let read =
+                    backend::send_request(&mut **conn.get_mut(), &stat_request, &mut buffer).await;
+                let status_code = match read {
+                    Ok(read) => read.status_code(),
+                    Err(_) => {
+                        conn.retire_with_cooldown();
+                        return RetryStatProbeOutcome::Unavailable(backend_id);
+                    }
+                };
+
+                if self
+                    .capture_suppressed_430_response(&mut conn, backend_id, &stat_request, buffer)
+                    .await
+                    .is_err()
+                {
+                    conn.retire_with_cooldown();
+                    return RetryStatProbeOutcome::Unavailable(backend_id);
+                }
+                let _ = conn.release();
+
+                if status_code.is_some_and(|status| status.as_u16() == 430) {
+                    RetryStatProbeOutcome::Missing(backend_id)
+                } else {
+                    RetryStatProbeOutcome::Present
+                }
+            });
+        }
+
+        while let Some(outcome) = probes.next().await {
+            match outcome {
+                RetryStatProbeOutcome::Missing(backend_id) => {
+                    let missing = AuthoritativeArticleMissing { backend_id };
+                    self.record_authoritative_article_missing(&missing, state.availability);
+                    if let Some(msg_id) = request.message_id_value() {
+                        self.cache.record_backend_missing(msg_id, backend_id).await;
+                    }
+                }
+                RetryStatProbeOutcome::Present => {}
+                RetryStatProbeOutcome::Unavailable(backend_id) => {
+                    state.unavailable_backends.suppress(backend_id);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     async fn write_successful_retry_response(
         &self,
         conn: crate::pool::ConnectionGuard,
@@ -338,7 +445,7 @@ impl ClientSession {
     ) -> Result<PreparedBackendAttempt, SessionError> {
         let backend_id = backend.backend_id();
         let request_wire_len = request.request_wire_len().get();
-        debug!(
+        trace!(
             client = %self.client_addr,
             backend = backend_id.as_index(),
             command_verb = ?request.verb(),
@@ -383,7 +490,7 @@ impl ClientSession {
             Some(status_code) => status_code,
             None => {
                 read_status.log_warnings(&buffer, self.client_addr, backend_id);
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     backend = backend_id.as_index(),
                     command_verb = ?request.verb(),
@@ -404,7 +511,7 @@ impl ClientSession {
             }
         };
 
-        debug!(
+        trace!(
             client = %self.client_addr,
             backend = backend_id.as_index(),
             command_verb = ?request.verb(),
@@ -680,7 +787,7 @@ impl ClientSession {
             }
             Some(cached) => {
                 let (cached_backend_id, cached_conn) = cached;
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     cached_backend = cached_backend_id.as_index(),
                     backend = backend_id.as_index(),
@@ -692,7 +799,7 @@ impl ClientSession {
                 );
                 let _ = cached_conn.release();
                 let checkout_status = provider.status_counts();
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     backend = backend_id.as_index(),
                     command_verb = ?request.verb(),
@@ -706,7 +813,7 @@ impl ClientSession {
                 );
                 let conn = provider.get_pooled_connection().await?;
                 let checkout_status = provider.status_counts();
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     backend = backend_id.as_index(),
                     command_verb = ?request.verb(),
@@ -724,7 +831,7 @@ impl ClientSession {
             }
             None => {
                 let checkout_status = provider.status_counts();
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     backend = backend_id.as_index(),
                     command_verb = ?request.verb(),
@@ -738,7 +845,7 @@ impl ClientSession {
                 );
                 let conn = provider.get_pooled_connection().await?;
                 let checkout_status = provider.status_counts();
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     backend = backend_id.as_index(),
                     command_verb = ?request.verb(),
@@ -774,7 +881,7 @@ impl ClientSession {
         let mut guard = self
             .checkout_direct_backend_connection(provider, backend_id, request, backend_connection)
             .await?;
-        debug!(
+        trace!(
             client = %self.client_addr,
             backend = backend_id.as_index(),
             command_verb = ?request.verb(),
@@ -1723,6 +1830,112 @@ mod tests {
             body_commands.load(Ordering::SeqCst),
             1,
             "first attempt should go directly to BODY/ARTICLE/HEAD without STAT probe"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_stat_sweep_marks_missing_across_multiple_backends() {
+        let session = test_session();
+        let (port0, stat0, body0) = spawn_stat_missing_probe_server().await;
+        let (port1, stat1, body1) = spawn_stat_missing_probe_server().await;
+        let router = router_with_tiered_backends([
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port0)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                0,
+            ),
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port1)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                1,
+            ),
+        ]);
+
+        let request = request_context(b"BODY <missing@example.com>\r\n");
+        let mut availability = ArticleAvailability::new();
+        let mut client_to_backend_bytes = ClientToBackendBytes::zero();
+        let mut backend_connection = None;
+        let mut unavailable_backends = SuppressedBackends::empty();
+        let mut state = ArticleAttemptState {
+            availability: &mut availability,
+            client_to_backend_bytes: &mut client_to_backend_bytes,
+            backend_connection: &mut backend_connection,
+            unavailable_backends: &mut unavailable_backends,
+        };
+
+        session
+            .parallel_retry_stat_sweep(&router, &request, &mut state)
+            .await
+            .expect("parallel retry STAT sweep should succeed");
+
+        assert!(availability.is_missing(BackendId::from_index(0)));
+        assert!(availability.is_missing(BackendId::from_index(1)));
+        assert_eq!(stat0.load(Ordering::SeqCst), 1);
+        assert_eq!(stat1.load(Ordering::SeqCst), 1);
+        assert_eq!(body0.load(Ordering::SeqCst), 0);
+        assert_eq!(body1.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn retry_stat_sweep_leaves_pending_counts_balanced() {
+        let session = test_session();
+        let (port0, _stat0, _body0) = spawn_stat_missing_probe_server().await;
+        let (port1, _stat1, _body1) = spawn_stat_missing_probe_server().await;
+        let router = router_with_tiered_backends([
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port0)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                0,
+            ),
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port1)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                1,
+            ),
+        ]);
+
+        let request = request_context(b"BODY <missing@example.com>\r\n");
+        let mut availability = ArticleAvailability::new();
+        let mut client_to_backend_bytes = ClientToBackendBytes::zero();
+        let mut backend_connection = None;
+        let mut unavailable_backends = SuppressedBackends::empty();
+        let mut state = ArticleAttemptState {
+            availability: &mut availability,
+            client_to_backend_bytes: &mut client_to_backend_bytes,
+            backend_connection: &mut backend_connection,
+            unavailable_backends: &mut unavailable_backends,
+        };
+
+        session
+            .parallel_retry_stat_sweep(&router, &request, &mut state)
+            .await
+            .expect("parallel retry STAT sweep should succeed");
+
+        assert_eq!(
+            router
+                .backend_load(BackendId::from_index(0))
+                .expect("backend 0 should exist")
+                .get(),
+            0
+        );
+        assert_eq!(
+            router
+                .backend_load(BackendId::from_index(1))
+                .expect("backend 1 should exist")
+                .get(),
+            0
         );
     }
 

--- a/src/session/handlers/hybrid.rs
+++ b/src/session/handlers/hybrid.rs
@@ -179,7 +179,8 @@ impl ClientSession {
 
         // Guard pending_count immediately — if get_pooled_connection fails,
         // the guard drops and decrements automatically
-        let pending_guard = crate::router::CommandGuard::new(router.clone(), backend_id);
+        let pending_guard =
+            crate::router::BackendSelector::guard_for_routed_backend(router.clone(), backend_id);
 
         let provider = router
             .backend_provider(backend_id)

--- a/src/session/handlers/per_command.rs
+++ b/src/session/handlers/per_command.rs
@@ -29,6 +29,10 @@ use crate::session::SessionError;
 use crate::session::handlers::article_retry::OrderedPipelineGate;
 use crate::types::{BackendId, BackendToClientBytes, ClientToBackendBytes, TransferMetrics};
 
+/// Ordered large-transfer pipelining is disabled due to sustained throughput regressions
+/// from long-lived regular buffer holds in the write path.
+const ORDERED_LARGE_TRANSFER_PIPELINE_ENABLED: bool = false;
+
 fn safe_command_log_label(request: &RequestContext) -> &str {
     std::str::from_utf8(request.verb()).unwrap_or("<non-utf8-command>")
 }
@@ -674,6 +678,10 @@ impl ClientSession {
         batch: &crate::session::handlers::pipeline::RequestBatch,
         state: &PerCommandLoopState,
     ) -> bool {
+        if !ORDERED_LARGE_TRANSFER_PIPELINE_ENABLED {
+            return false;
+        }
+
         if router.backend_count() <= 1
             || batch.len() <= 1
             || self.cache_articles
@@ -933,5 +941,10 @@ mod tests {
             ),
             "Other errors should NOT be classified as client disconnect"
         );
+    }
+
+    #[test]
+    fn ordered_large_transfer_pipeline_is_disabled() {
+        assert!(!super::ORDERED_LARGE_TRANSFER_PIPELINE_ENABLED);
     }
 }

--- a/src/session/handlers/per_command.rs
+++ b/src/session/handlers/per_command.rs
@@ -31,7 +31,12 @@ use crate::types::{BackendId, BackendToClientBytes, ClientToBackendBytes, Transf
 
 /// Ordered large-transfer pipelining is disabled due to sustained throughput regressions
 /// from long-lived regular buffer holds in the write path.
-const ORDERED_LARGE_TRANSFER_PIPELINE_ENABLED: bool = false;
+enum OrderedLargeTransferPipelineState {
+    Disabled,
+}
+
+const ORDERED_LARGE_TRANSFER_PIPELINE_STATE: OrderedLargeTransferPipelineState =
+    OrderedLargeTransferPipelineState::Disabled;
 
 fn safe_command_log_label(request: &RequestContext) -> &str {
     std::str::from_utf8(request.verb()).unwrap_or("<non-utf8-command>")
@@ -678,7 +683,10 @@ impl ClientSession {
         batch: &crate::session::handlers::pipeline::RequestBatch,
         state: &PerCommandLoopState,
     ) -> bool {
-        if !ORDERED_LARGE_TRANSFER_PIPELINE_ENABLED {
+        if matches!(
+            ORDERED_LARGE_TRANSFER_PIPELINE_STATE,
+            OrderedLargeTransferPipelineState::Disabled
+        ) {
             return false;
         }
 
@@ -945,6 +953,9 @@ mod tests {
 
     #[test]
     fn ordered_large_transfer_pipeline_is_disabled() {
-        assert!(!super::ORDERED_LARGE_TRANSFER_PIPELINE_ENABLED);
+        assert!(matches!(
+            super::ORDERED_LARGE_TRANSFER_PIPELINE_STATE,
+            super::OrderedLargeTransferPipelineState::Disabled
+        ));
     }
 }

--- a/src/session/shared_client_writer.rs
+++ b/src/session/shared_client_writer.rs
@@ -99,8 +99,18 @@ impl SharedClientWriter {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Mutex, OnceLock};
+
+    fn metrics_flag_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
     #[test]
     fn writer_lock_metrics_flag_is_runtime_configurable() {
+        let _guard = metrics_flag_test_lock()
+            .lock()
+            .expect("metrics flag test lock should not be poisoned");
         let was_enabled = super::client_writer_lock_metrics_enabled();
         super::set_client_writer_lock_metrics_enabled(!was_enabled);
         assert_eq!(super::client_writer_lock_metrics_enabled(), !was_enabled);

--- a/src/session/shared_client_writer.rs
+++ b/src/session/shared_client_writer.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 use std::sync::OnceLock;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 
 #[derive(Debug, Default)]
 struct ClientWriterLockMetrics {
@@ -21,9 +21,16 @@ pub(crate) struct ClientWriterLockMetricsSnapshot {
 }
 
 fn client_writer_lock_metrics_enabled() -> bool {
-    static ENABLED: OnceLock<bool> = OnceLock::new();
-    *ENABLED
-        .get_or_init(|| std::env::var_os("NNTP_PROXY_CLIENT_WRITER_LOCK_METRICS_SECS").is_some())
+    client_writer_lock_metrics_enabled_flag().load(Ordering::Relaxed)
+}
+
+pub(crate) fn set_client_writer_lock_metrics_enabled(enabled: bool) {
+    client_writer_lock_metrics_enabled_flag().store(enabled, Ordering::Relaxed);
+}
+
+fn client_writer_lock_metrics_enabled_flag() -> &'static AtomicBool {
+    static ENABLED: OnceLock<AtomicBool> = OnceLock::new();
+    ENABLED.get_or_init(|| AtomicBool::new(false))
 }
 
 fn client_writer_lock_metrics() -> &'static ClientWriterLockMetrics {
@@ -87,5 +94,16 @@ impl SharedClientWriter {
             Ok(mutex) => Ok(mutex.into_inner()),
             Err(inner) => Err(Self { inner }),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn writer_lock_metrics_flag_is_runtime_configurable() {
+        let was_enabled = super::client_writer_lock_metrics_enabled();
+        super::set_client_writer_lock_metrics_enabled(!was_enabled);
+        assert_eq!(super::client_writer_lock_metrics_enabled(), !was_enabled);
+        super::set_client_writer_lock_metrics_enabled(was_enabled);
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -50,6 +50,14 @@ pub struct StartupTuiSession {
     terminal: Option<TuiTerminal>,
 }
 
+fn notify_shutdown(tx: &mpsc::Sender<()>) {
+    match tx.try_send(()) {
+        Ok(()) => {}
+        Err(tokio::sync::mpsc::error::TrySendError::Full(_)) => {}
+        Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {}
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum RemoteDashboardStatus {
     Connecting {
@@ -251,7 +259,7 @@ impl StartupTuiSession {
         let result = run_app(&mut terminal, &mut app, &mut shutdown_rx).await;
         restore_terminal(&mut terminal)?;
 
-        let _ = shutdown_tx.send(()).await;
+        notify_shutdown(&shutdown_tx);
         result
     }
 }
@@ -292,7 +300,7 @@ pub async fn run_tui(
     .await;
 
     // Signal shutdown when TUI exits
-    let _ = shutdown_tx.send(()).await;
+    notify_shutdown(&shutdown_tx);
 
     result
 }


### PR DESCRIPTION
## Summary
Moves non-primary-tier STAT prefetch dispatch earlier so probes launch before routing and checkout work, while still respecting availability gating and stat_missing enablement.

Keeps prefetch focused on updating availability from authoritative 430 miss facts.

## Why
For miss-heavy workloads, earlier dispatch increases overlap between tier0 fetch attempts and tier greater than zero miss discovery, improving retry efficiency.

## Stack position
Depends on #79, which depends on #80.

## Testing
Added and updated behavior-focused coverage that prefetch probes only eligible non-primary backends, skips already-known-missing backends via availability gating, and preserves retry sweep and pending-balance integrity.