### PR TITLE
Prefetch non-primary STAT probes on first attempt

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -35,6 +35,8 @@ username = "your_username"
 password = "your_password"
 max_connections = 20
 tier = 0
+# Probe misses with STAT before ARTICLE/BODY/HEAD on this backend (0=off, non-zero=on)
+stat_missing = 1
 use_tls = false
 tls_verify_cert = true
 
@@ -48,6 +50,8 @@ username = "your_username"
 password = "your_password"
 max_connections = 10
 tier = 1
+# Enable STAT miss probes on non-primary tiers to prefill availability while tier 0 fetch runs.
+stat_missing = 1
 connection_keepalive = 60
 use_tls = true
 tls_verify_cert = true

--- a/config.full.toml
+++ b/config.full.toml
@@ -100,6 +100,9 @@ name = "Example News Server 1"
 max_connections = 20
 # Lower tier numbers are tried first. Higher tiers are fallback/archive servers.
 tier = 0
+# Probe misses with STAT before ARTICLE/BODY/HEAD (0 = disabled, non-zero = enabled).
+# Default is 0; this example enables it on all tiers.
+stat_missing = 1
 # Optional keep-alive interval in seconds
 # connection_keepalive = 60
 use_tls = false
@@ -123,6 +126,8 @@ username = "testuser"
 password = "testpass"
 max_connections = 10
 tier = 1
+# Common setup: enable STAT miss probes on fallback tiers.
+stat_missing = 1
 connection_keepalive = 60
 use_tls = false
 tls_verify_cert = true
@@ -135,6 +140,7 @@ username = "premium_user"
 password = "secure_password"
 max_connections = 15
 tier = 5
+stat_missing = 1
 connection_keepalive = 120
 use_tls = true
 tls_verify_cert = true
@@ -149,6 +155,7 @@ username = "archive_user"
 password = "archive_pass"
 max_connections = 2
 tier = 10
+stat_missing = 1
 connection_keepalive = 120
 use_tls = true
 tls_verify_cert = true

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -390,6 +390,7 @@ impl ClientSession {
         let mut availability = availability.unwrap_or_default();
         let mut unavailable_backends = SuppressedBackends::empty();
         let mut is_retry_attempt = false;
+        let mut non_primary_tier_prefetch_started = false;
         let mut retry_stat_sweep_done = false;
         trace!(
             "Client {} availability routing: missing_bits={:08b}, backend_count={}",
@@ -399,6 +400,16 @@ impl ClientSession {
         );
 
         while !availability.all_exhausted(router.backend_count()) {
+            if !is_retry_attempt && !non_primary_tier_prefetch_started {
+                self.spawn_non_primary_tier_stat_prefetch(
+                    router,
+                    request,
+                    &availability,
+                    unavailable_backends,
+                );
+                non_primary_tier_prefetch_started = true;
+            }
+
             if is_retry_attempt && !retry_stat_sweep_done {
                 self.parallel_retry_stat_sweep(
                     router,

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -187,8 +187,27 @@ impl ClientSession {
             client_to_backend_bytes,
             backend_to_client_bytes,
         };
+        let preloaded_availability = if request.message_id_value().is_some() {
+            Some(
+                self.load_article_availability(
+                    request.message_id_value().as_ref(),
+                    router.backend_count(),
+                )
+                .await,
+            )
+        } else {
+            None
+        };
+        if let Some(availability) = preloaded_availability.as_ref() {
+            self.spawn_non_primary_tier_stat_prefetch(
+                &router,
+                request,
+                availability,
+                SuppressedBackends::empty(),
+            );
+        }
         let availability = match self
-            .prepare_request_execution(&router, request, &mut io)
+            .prepare_request_execution(&router, request, &mut io, preloaded_availability)
             .await?
         {
             PreparedRequest::Served => return Ok(()),
@@ -219,6 +238,7 @@ impl ClientSession {
         router: &Arc<BackendSelector>,
         request: &mut RequestContext,
         io: &mut RequestExecutionIo<'_>,
+        preloaded_availability: Option<ArticleAvailability>,
     ) -> Result<PreparedRequest, SessionError> {
         let availability = {
             let mut client_write = io.client_writer.lock().await;
@@ -238,16 +258,20 @@ impl ClientSession {
                 CacheLookupResult::Miss => None,
             }
         };
-        let availability = match availability {
-            Some(availability) => Some(availability),
-            None if request.message_id_value().is_some() => Some(
+        let availability = if let Some(availability) = availability {
+            Some(availability)
+        } else if let Some(availability) = preloaded_availability {
+            Some(availability)
+        } else if request.message_id_value().is_some() {
+            Some(
                 self.load_article_availability(
                     request.message_id_value().as_ref(),
                     router.backend_count(),
                 )
                 .await,
-            ),
-            None => None,
+            )
+        } else {
+            None
         };
         if self
             .try_adaptive_precheck(router, request, io, availability.as_ref())
@@ -390,7 +414,6 @@ impl ClientSession {
         let mut availability = availability.unwrap_or_default();
         let mut unavailable_backends = SuppressedBackends::empty();
         let mut is_retry_attempt = false;
-        let mut non_primary_tier_prefetch_started = false;
         let mut retry_stat_sweep_done = false;
         trace!(
             "Client {} availability routing: missing_bits={:08b}, backend_count={}",
@@ -400,16 +423,6 @@ impl ClientSession {
         );
 
         while !availability.all_exhausted(router.backend_count()) {
-            if !is_retry_attempt && !non_primary_tier_prefetch_started {
-                self.spawn_non_primary_tier_stat_prefetch(
-                    router,
-                    request,
-                    &availability,
-                    unavailable_backends,
-                );
-                non_primary_tier_prefetch_started = true;
-            }
-
             if is_retry_attempt && !retry_stat_sweep_done {
                 self.parallel_retry_stat_sweep(
                     router,

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -198,14 +198,6 @@ impl ClientSession {
         } else {
             None
         };
-        if let Some(availability) = preloaded_availability.as_ref() {
-            self.spawn_non_primary_tier_stat_prefetch(
-                &router,
-                request,
-                availability,
-                SuppressedBackends::empty(),
-            );
-        }
         let availability = match self
             .prepare_request_execution(&router, request, &mut io, preloaded_availability)
             .await?
@@ -213,6 +205,14 @@ impl ClientSession {
             PreparedRequest::Served => return Ok(()),
             PreparedRequest::Continue { availability } => availability,
         };
+        if let Some(availability) = availability.as_ref() {
+            self.spawn_non_primary_tier_stat_prefetch(
+                &router,
+                request,
+                availability,
+                SuppressedBackends::empty(),
+            );
+        }
 
         self.execute_article_retry_loop(&router, request, availability, &mut io)
             .await

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -2173,6 +2173,51 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn first_attempt_prefetch_respects_existing_availability_and_skips_known_missing_tier() {
+        let session = test_session();
+        let (port0, stat0, _body0) = spawn_stat_missing_probe_server().await;
+        let (port1, stat1, _body1) = spawn_stat_missing_probe_server().await;
+        let router = router_with_tiered_backends([
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port0)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                0,
+            ),
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port1)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                1,
+            ),
+        ]);
+
+        let request = request_context(b"BODY <already-missing@example.com>\r\n");
+        let mut availability = ArticleAvailability::new();
+        availability.record_missing(BackendId::from_index(1));
+
+        session.spawn_non_primary_tier_stat_prefetch(
+            &router,
+            &request,
+            &availability,
+            SuppressedBackends::empty(),
+        );
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(stat0.load(Ordering::SeqCst), 0, "tier 0 must not be probed");
+        assert_eq!(
+            stat1.load(Ordering::SeqCst),
+            0,
+            "known-missing non-primary tier should be skipped by should_try gate"
+        );
+    }
+
     #[test]
     fn stat_missing_probe_requires_retry_state() {
         let request = request_context(b"BODY <missing@example.com>\r\n");

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -429,6 +429,101 @@ impl ClientSession {
         Ok(())
     }
 
+    pub(super) fn spawn_non_primary_tier_stat_prefetch(
+        &self,
+        router: &Arc<BackendSelector>,
+        request: &RequestContext,
+        availability: &crate::cache::ArticleAvailability,
+        unavailable_backends: SuppressedBackends,
+    ) {
+        if !matches!(request.kind(), RequestKind::Article | RequestKind::Body)
+            || request.is_stat()
+            || !request.has_message_id()
+        {
+            return;
+        }
+
+        let Some(stat_request) = Self::stat_probe_request(request) else {
+            return;
+        };
+        let Some(msg_id_text) = request.message_id().map(str::to_owned) else {
+            return;
+        };
+
+        let mut candidates = Vec::new();
+        for tier in router.tiers().filter(|tier| *tier > 0) {
+            for backend_id in router.backend_ids_in_tier(tier) {
+                if unavailable_backends.contains(backend_id) || !availability.should_try(backend_id)
+                {
+                    continue;
+                }
+                let Some(provider) = router.backend_provider(backend_id) else {
+                    continue;
+                };
+                if provider.stat_missing_enabled() {
+                    candidates.push((backend_id, provider.clone()));
+                }
+            }
+        }
+        if candidates.is_empty() {
+            return;
+        }
+
+        let router = Arc::clone(router);
+        let cache = Arc::clone(&self.cache);
+        let buffer_pool = self.buffer_pool.clone();
+        tokio::spawn(async move {
+            let mut probes = FuturesUnordered::new();
+            for (backend_id, provider) in candidates {
+                let router = Arc::clone(&router);
+                let cache = Arc::clone(&cache);
+                let stat_request = stat_request.clone();
+                let msg_id_text = msg_id_text.clone();
+                let buffer_pool = buffer_pool.clone();
+                probes.push(async move {
+                    let _guard = BackendSelector::guard_for_manual_backend(router, backend_id);
+                    let conn = match provider.get_pooled_connection().await {
+                        Ok(conn) => conn,
+                        Err(_) => return,
+                    };
+                    let mut conn = crate::pool::ConnectionGuard::new(conn, provider);
+                    let mut buffer = buffer_pool.acquire();
+                    let read =
+                        backend::send_request(&mut **conn.get_mut(), &stat_request, &mut buffer)
+                            .await;
+                    let status_code = match read {
+                        Ok(read) => read.status_code(),
+                        Err(_) => {
+                            conn.retire_with_cooldown();
+                            return;
+                        }
+                    };
+                    if crate::session::backend::observe_response(
+                        &stat_request,
+                        &mut buffer,
+                        &mut conn,
+                        &buffer_pool,
+                        backend_id,
+                    )
+                    .await
+                    .is_err()
+                    {
+                        conn.retire_with_cooldown();
+                        return;
+                    }
+                    let _ = conn.release();
+
+                    if status_code.is_some_and(|status| status.as_u16() == 430)
+                        && let Ok(msg_id) = crate::types::MessageId::new(msg_id_text)
+                    {
+                        cache.record_backend_missing(msg_id, backend_id).await;
+                    }
+                });
+            }
+            while probes.next().await.is_some() {}
+        });
+    }
+
     async fn write_successful_retry_response(
         &self,
         conn: crate::pool::ConnectionGuard,
@@ -1990,6 +2085,91 @@ mod tests {
                 .expect("backend 1 should exist")
                 .get(),
             0
+        );
+    }
+
+    #[tokio::test]
+    async fn first_attempt_prefetches_stat_only_on_non_primary_tiers_with_stat_missing_enabled() {
+        let session = test_session();
+        let (port0, stat0, body0) = spawn_stat_missing_probe_server().await;
+        let (port1, stat1, body1) = spawn_stat_missing_probe_server().await;
+        let (port2, stat2, body2) = spawn_stat_missing_probe_server().await;
+        let router = router_with_tiered_backends([
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port0)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                0,
+            ),
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port1)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                1,
+            ),
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port2)
+                    .max_connections(1)
+                    .stat_missing(false)
+                    .build()
+                    .unwrap(),
+                2,
+            ),
+        ]);
+
+        let request = request_context(b"BODY <missing@example.com>\r\n");
+        let availability = ArticleAvailability::new();
+        let unavailable_backends = SuppressedBackends::empty();
+
+        session.spawn_non_primary_tier_stat_prefetch(
+            &router,
+            &request,
+            &availability,
+            unavailable_backends,
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while stat1.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("upper-tier stat prefetch should complete");
+
+        assert_eq!(stat0.load(Ordering::SeqCst), 0, "tier 0 must not be probed");
+        assert_eq!(
+            stat1.load(Ordering::SeqCst),
+            1,
+            "tier >0 with stat_missing=1 is probed"
+        );
+        assert_eq!(
+            stat2.load(Ordering::SeqCst),
+            0,
+            "tier >0 with stat_missing=0 is skipped"
+        );
+        assert_eq!(body0.load(Ordering::SeqCst), 0);
+        assert_eq!(body1.load(Ordering::SeqCst), 0);
+        assert_eq!(body2.load(Ordering::SeqCst), 0);
+
+        let msg_id = MessageId::new("<missing@example.com>".to_string()).expect("valid message id");
+        let cached = tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if let Some(cached) = session.cache.get(&msg_id).await {
+                    break cached;
+                }
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("prefetch should update availability index");
+        let has_backend_1 = cached.availability().is_missing(BackendId::from_index(1));
+        assert!(
+            has_backend_1,
+            "tier-1 backend should be marked missing from STAT=430"
         );
     }
 

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -436,8 +436,10 @@ impl ClientSession {
         availability: &crate::cache::ArticleAvailability,
         unavailable_backends: SuppressedBackends,
     ) {
-        if !matches!(request.kind(), RequestKind::Article | RequestKind::Body)
-            || request.is_stat()
+        if !matches!(
+            request.kind(),
+            RequestKind::Article | RequestKind::Body | RequestKind::Head
+        ) || request.is_stat()
             || !request.has_message_id()
         {
             return;
@@ -2166,9 +2168,9 @@ mod tests {
         })
         .await
         .expect("prefetch should update availability index");
-        let has_backend_1 = cached.availability().is_missing(BackendId::from_index(1));
+        let backend_1_missing = cached.availability().is_missing(BackendId::from_index(1));
         assert!(
-            has_backend_1,
+            backend_1_missing,
             "tier-1 backend should be marked missing from STAT=430"
         );
     }
@@ -2216,6 +2218,51 @@ mod tests {
             0,
             "known-missing non-primary tier should be skipped by should_try gate"
         );
+    }
+
+    #[tokio::test]
+    async fn first_attempt_prefetches_stat_for_head_requests_on_non_primary_tiers() {
+        let session = test_session();
+        let (port0, stat0, _body0) = spawn_stat_missing_probe_server().await;
+        let (port1, stat1, _body1) = spawn_stat_missing_probe_server().await;
+        let router = router_with_tiered_backends([
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port0)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                0,
+            ),
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port1)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                1,
+            ),
+        ]);
+
+        let request = request_context(b"HEAD <missing@example.com>\r\n");
+        let availability = ArticleAvailability::new();
+        session.spawn_non_primary_tier_stat_prefetch(
+            &router,
+            &request,
+            &availability,
+            SuppressedBackends::empty(),
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while stat1.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("HEAD prefetch should probe non-primary tier");
+
+        assert_eq!(stat0.load(Ordering::SeqCst), 0, "tier 0 must not be probed");
+        assert_eq!(stat1.load(Ordering::SeqCst), 1, "tier >0 should be probed");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
This PR keeps the early STAT prefetch behavior separate from the retry-only base merge.

- starts non-primary-tier STAT probes for first ARTICLE/BODY/HEAD attempts
- keeps direct fetch flow unblocked while background probes update availability
- covers eligibility and timing behavior in command execution tests

## Testing
Added coverage for first-attempt prefetch launch timing and non-primary eligibility behavior so retry-only behavior on main remains unchanged while prefetch logic is validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented STAT miss probing to pre-check article availability on backend servers before attempting to retrieve content.

* **Configuration**
  * Added `stat_missing` setting to enable availability probing on primary and fallback backend tiers in both example and production configuration files.

* **Tests**
  * Added test coverage for STAT miss probing behavior verification across backend tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->