### PR TITLE
Clarify backend cleanup and guardrails

### DIFF
--- a/GUARDRAILS-TODO.md
+++ b/GUARDRAILS-TODO.md
@@ -1,0 +1,23 @@
+# Guardrails TODO (state-constrained connection fate)
+
+Goal: make connection lifecycle misuse impossible inside the crate, not just less visible.
+
+## Planned guardrails
+
+1. Add finalize enforcement for guard-owning operations:
+   - drop-bomb / finalize token in debug+tests
+   - panic/fail fast if a guard-owning flow exits without explicit finalize.
+
+2. Encode pool-fate decisions with typed outcomes:
+   - `BackendHealthy`
+   - `BackendDirty`
+   - `BackendFailed`
+   so connection fate is derived from outcome type, not ad-hoc branching.
+
+3. Ban low-level calls outside the chokepoint module:
+   - deny lint(s) for direct `release/retire/remove_*` usage
+   - allowlist only the designated lifecycle module.
+
+4. Add regression tests for lifecycle invariants:
+   - no implicit guard-drop on timeout/cancel paths
+   - client-side write/flush failures do not trigger backend cooldown retirement unless backend is dirty/failed.

--- a/GUARDRAILS-TODO.md
+++ b/GUARDRAILS-TODO.md
@@ -1,14 +1,3 @@
 # Guardrails TODO (state-constrained connection fate)
 
-Goal: make connection lifecycle misuse impossible inside the crate, not just less visible.
-
-## Planned guardrails
-
-1. Encode pool-fate decisions with typed outcomes:
-   - `BackendHealthy`
-   - `BackendDirty`
-   - `BackendFailed`
-   so connection fate is derived from outcome type, not ad-hoc branching.
-
-2. Add regression tests for lifecycle invariants:
-   - no implicit guard-drop on timeout/cancel paths
+All planned guardrails implemented.

--- a/GUARDRAILS-TODO.md
+++ b/GUARDRAILS-TODO.md
@@ -10,10 +10,5 @@ Goal: make connection lifecycle misuse impossible inside the crate, not just les
    - `BackendFailed`
    so connection fate is derived from outcome type, not ad-hoc branching.
 
-2. Ban low-level calls outside the chokepoint module:
-   - deny lint(s) for direct `release/retire/remove_*` usage
-   - allowlist only the designated lifecycle module.
-
-3. Add regression tests for lifecycle invariants:
+2. Add regression tests for lifecycle invariants:
    - no implicit guard-drop on timeout/cancel paths
-   - client-side write/flush failures do not trigger backend cooldown retirement unless backend is dirty/failed.

--- a/GUARDRAILS-TODO.md
+++ b/GUARDRAILS-TODO.md
@@ -4,20 +4,16 @@ Goal: make connection lifecycle misuse impossible inside the crate, not just les
 
 ## Planned guardrails
 
-1. Add finalize enforcement for guard-owning operations:
-   - drop-bomb / finalize token in debug+tests
-   - panic/fail fast if a guard-owning flow exits without explicit finalize.
-
-2. Encode pool-fate decisions with typed outcomes:
+1. Encode pool-fate decisions with typed outcomes:
    - `BackendHealthy`
    - `BackendDirty`
    - `BackendFailed`
    so connection fate is derived from outcome type, not ad-hoc branching.
 
-3. Ban low-level calls outside the chokepoint module:
+2. Ban low-level calls outside the chokepoint module:
    - deny lint(s) for direct `release/retire/remove_*` usage
    - allowlist only the designated lifecycle module.
 
-4. Add regression tests for lifecycle invariants:
+3. Add regression tests for lifecycle invariants:
    - no implicit guard-drop on timeout/cancel paths
    - client-side write/flush failures do not trigger backend cooldown retirement unless backend is dirty/failed.

--- a/clippy.toml
+++ b/clippy.toml
@@ -3,5 +3,7 @@ disallowed-methods = [
   { path = "tokio::io::AsyncReadExt::read_to_string", reason = "Session response paths must keep protocol framing byte-accurate; read_to_string bypasses framer boundaries." },
   { path = "std::io::Read::read_to_end", reason = "Session response paths must stream through framer entrypoints instead of buffering whole responses." },
   { path = "std::io::Read::read_to_string", reason = "Session response paths must not decode unframed bytes directly into strings." },
+  { path = "crate::pool::ChunkedResponse::write_all_to_recording", reason = "Only multiline_framing may use the recorded write helper; response write accounting must stay centralized." },
+  { path = "crate::pool::buffer::record_response_write_metrics_internal", reason = "Only multiline_framing may record response-write metrics; callers must not recreate the split accounting path." },
   { path = "crate::session::response_transfer::ResponseTransferError::ClientDisconnect", reason = "Only multiline_framing may construct ClientDisconnect; response-write paths must use ClientWrite to force connection retirement." },
 ]

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+disallowed-methods = [
+  { path = "tokio::io::AsyncReadExt::read_to_end", reason = "Session response paths must use MultilineFramer-backed operations; read_to_end bypasses framing boundaries." },
+  { path = "tokio::io::AsyncReadExt::read_to_string", reason = "Session response paths must keep protocol framing byte-accurate; read_to_string bypasses framer boundaries." },
+  { path = "std::io::Read::read_to_end", reason = "Session response paths must stream through framer entrypoints instead of buffering whole responses." },
+  { path = "std::io::Read::read_to_string", reason = "Session response paths must not decode unframed bytes directly into strings." },
+  { path = "crate::session::response_transfer::ResponseTransferError::ClientDisconnect", reason = "Only multiline_framing may construct ClientDisconnect; response-write paths must use ClientWrite to force connection retirement." },
+]

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -205,10 +205,10 @@ impl NntpClient {
         )
         .await
         {
-            conn.retire_with_cooldown();
+            conn.fail_backend();
             return Err(err);
         }
-        let _ = conn.release();
+        let _ = conn.complete_success();
         Ok(capture)
     }
 

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -37,13 +37,10 @@
 //! # fn process(_: &[u8]) {}
 //! ```
 
-use anyhow::{Context, Result};
-use deadpool::managed::Object;
-
-use crate::pool::deadpool_connection::TcpManager;
-use crate::pool::{BufferPool, DeadpoolConnectionProvider, PooledBuffer};
+use crate::pool::{BufferPool, ConnectionGuard, DeadpoolConnectionProvider, PooledBuffer};
 use crate::protocol::{RequestContext, article_request, body_request, head_request, stat_request};
-use crate::session::backend::send_request;
+use crate::session::backend::execute_request_classified;
+use anyhow::{Context, Result};
 
 /// Standalone NNTP client for fetching articles
 ///
@@ -140,12 +137,12 @@ impl NntpClient {
         let request = stat_request(message_id);
         let mut conn = self
             .conn_pool
-            .get_pooled_connection()
+            .checkout_connection_guard()
             .await
             .context("Failed to get connection from pool")?;
         let mut buffer = self.buffer_pool.acquire();
 
-        let response = send_request(&mut *conn, &request, &mut buffer).await?;
+        let response = execute_request_classified(&mut **conn, &request, &mut buffer).await?;
         let Some(status_code) = response.status_code() else {
             anyhow::bail!("Invalid STAT response");
         };
@@ -171,12 +168,12 @@ impl NntpClient {
     async fn fetch_response(&self, request: RequestContext) -> Result<PooledBuffer> {
         let mut conn = self
             .conn_pool
-            .get_pooled_connection()
+            .checkout_connection_guard()
             .await
             .context("Failed to get connection from pool")?;
         let mut io_buffer = self.buffer_pool.acquire();
 
-        let response = send_request(&mut *conn, &request, &mut io_buffer).await?;
+        let response = execute_request_classified(&mut **conn, &request, &mut io_buffer).await?;
         let Some(status_code) = response.status_code() else {
             anyhow::bail!("Invalid response from server");
         };
@@ -194,7 +191,7 @@ impl NntpClient {
 
     async fn fetch_captured_multiline_response(
         &self,
-        mut conn: Object<TcpManager>,
+        mut conn: ConnectionGuard,
         mut io_buffer: PooledBuffer,
     ) -> Result<PooledBuffer> {
         // This client helper is intentionally only an owner of the destination
@@ -208,9 +205,10 @@ impl NntpClient {
         )
         .await
         {
-            self.conn_pool.remove_with_cooldown(conn);
+            conn.retire_with_cooldown();
             return Err(err);
         }
+        let _ = conn.release();
         Ok(capture)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,8 @@
 //! - **Per-command routing mode**: Each command is routed to a backend (round-robin),
 //!   but commands are still processed serially (NNTP is synchronous)
 
+#![allow(clippy::disallowed_methods)]
+
 // Module declarations
 pub mod args;
 pub mod auth;

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -561,7 +561,7 @@ pub(crate) fn reset_response_write_metrics() {
     metrics.max_chunks_per_response.store(0, Ordering::Relaxed);
 }
 
-pub(crate) fn record_response_write_metrics(
+pub(crate) fn record_response_write_metrics_internal(
     chunk_count: usize,
     bytes_written: usize,
     tiny_chunks: usize,
@@ -838,7 +838,7 @@ impl ChunkedResponse {
     ///
     /// # Errors
     /// Returns any write error produced by the underlying async sink.
-    pub async fn write_all_to<W>(&self, writer: &mut W) -> std::io::Result<()>
+    pub async fn write_all_to_recording<W>(&self, writer: &mut W) -> std::io::Result<()>
     where
         W: AsyncWriteExt + Unpin,
     {

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -325,8 +325,6 @@ struct HotPathAllocationMetrics {
     capture_pool_fallback_allocations: AtomicUsize,
     chunked_response_metadata_spills: AtomicUsize,
     pending_backend_byte_heap_fallbacks: AtomicUsize,
-    non_owned_response_write_chunks: AtomicUsize,
-    non_owned_response_write_bytes: AtomicUsize,
     regular_pool_buffer_holds: AtomicUsize,
     regular_pool_buffer_hold_micros_total: AtomicU64,
     regular_pool_buffer_hold_micros_max: AtomicU64,
@@ -335,7 +333,7 @@ struct HotPathAllocationMetrics {
     capture_pool_buffer_hold_micros_max: AtomicU64,
 }
 
-/// Snapshot of direct client write-path activity from `ChunkedResponse::write_all_to`.
+/// Snapshot of logical response writes emitted to clients.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct ResponseWriteMetricsSnapshot {
     pub responses: usize,
@@ -358,8 +356,6 @@ pub struct HotPathAllocationMetricsSnapshot {
     pub capture_pool_fallback_allocations: usize,
     pub chunked_response_metadata_spills: usize,
     pub pending_backend_byte_heap_fallbacks: usize,
-    pub non_owned_response_write_chunks: usize,
-    pub non_owned_response_write_bytes: usize,
     pub regular_pool_buffer_holds: usize,
     pub regular_pool_buffer_hold_micros_total: u64,
     pub regular_pool_buffer_hold_micros_max: u64,
@@ -468,14 +464,17 @@ pub(crate) fn record_pending_backend_byte_heap_fallback() {
         .fetch_add(1, Ordering::Relaxed);
 }
 
-pub(crate) fn record_non_owned_response_write_chunk(bytes: usize) {
-    let metrics = hot_path_allocation_metrics();
-    metrics
-        .non_owned_response_write_chunks
-        .fetch_add(1, Ordering::Relaxed);
-    metrics
-        .non_owned_response_write_bytes
-        .fetch_add(bytes, Ordering::Relaxed);
+pub(crate) fn classify_response_write_chunk(bytes: usize) -> (usize, usize, usize, usize) {
+    let tiny_chunks = if bytes <= 256 { 1 } else { 0 };
+    let tiny_chunk_bytes = if bytes <= 256 { bytes } else { 0 };
+    let small_chunks = if bytes <= 4096 { 1 } else { 0 };
+    let small_chunk_bytes = if bytes <= 4096 { bytes } else { 0 };
+    (
+        tiny_chunks,
+        tiny_chunk_bytes,
+        small_chunks,
+        small_chunk_bytes,
+    )
 }
 
 #[must_use]
@@ -494,12 +493,6 @@ pub fn hot_path_allocation_metrics_snapshot() -> HotPathAllocationMetricsSnapsho
             .load(Ordering::Relaxed),
         pending_backend_byte_heap_fallbacks: metrics
             .pending_backend_byte_heap_fallbacks
-            .load(Ordering::Relaxed),
-        non_owned_response_write_chunks: metrics
-            .non_owned_response_write_chunks
-            .load(Ordering::Relaxed),
-        non_owned_response_write_bytes: metrics
-            .non_owned_response_write_bytes
             .load(Ordering::Relaxed),
         regular_pool_buffer_holds: metrics.regular_pool_buffer_holds.load(Ordering::Relaxed),
         regular_pool_buffer_hold_micros_total: metrics
@@ -534,12 +527,6 @@ pub fn reset_hot_path_allocation_metrics() {
         .pending_backend_byte_heap_fallbacks
         .store(0, Ordering::Relaxed);
     metrics
-        .non_owned_response_write_chunks
-        .store(0, Ordering::Relaxed);
-    metrics
-        .non_owned_response_write_bytes
-        .store(0, Ordering::Relaxed);
-    metrics
         .regular_pool_buffer_holds
         .store(0, Ordering::Relaxed);
     metrics
@@ -559,7 +546,22 @@ pub fn reset_hot_path_allocation_metrics() {
         .store(0, Ordering::Relaxed);
 }
 
-fn record_response_write_metrics(
+#[cfg(test)]
+pub(crate) fn reset_response_write_metrics() {
+    let metrics = response_write_metrics();
+    metrics.responses.store(0, Ordering::Relaxed);
+    metrics.single_chunk_responses.store(0, Ordering::Relaxed);
+    metrics.multi_chunk_responses.store(0, Ordering::Relaxed);
+    metrics.chunks_written.store(0, Ordering::Relaxed);
+    metrics.bytes_written.store(0, Ordering::Relaxed);
+    metrics.tiny_chunks.store(0, Ordering::Relaxed);
+    metrics.tiny_chunk_bytes.store(0, Ordering::Relaxed);
+    metrics.small_chunks.store(0, Ordering::Relaxed);
+    metrics.small_chunk_bytes.store(0, Ordering::Relaxed);
+    metrics.max_chunks_per_response.store(0, Ordering::Relaxed);
+}
+
+pub(crate) fn record_response_write_metrics(
     chunk_count: usize,
     bytes_written: usize,
     tiny_chunks: usize,
@@ -603,6 +605,16 @@ fn record_response_write_metrics(
             .multi_chunk_responses
             .fetch_add(1, Ordering::Relaxed);
     }
+}
+
+#[cfg(test)]
+pub(crate) fn response_write_metrics_test_guard() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::Mutex;
+
+    static GUARD: Mutex<()> = Mutex::new(());
+    GUARD
+        .lock()
+        .expect("response-write metrics test guard poisoned")
 }
 
 #[must_use]
@@ -830,34 +842,6 @@ impl ChunkedResponse {
     where
         W: AsyncWriteExt + Unpin,
     {
-        if response_write_metrics_enabled() {
-            let mut chunk_count = 0usize;
-            let mut tiny_chunks = 0usize;
-            let mut tiny_chunk_bytes = 0usize;
-            let mut small_chunks = 0usize;
-            let mut small_chunk_bytes = 0usize;
-            for chunk in self.iter_chunks() {
-                chunk_count += 1;
-                let len = chunk.len();
-                if len <= 256 {
-                    tiny_chunks += 1;
-                    tiny_chunk_bytes += len;
-                }
-                if len <= 4096 {
-                    small_chunks += 1;
-                    small_chunk_bytes += len;
-                }
-            }
-            record_response_write_metrics(
-                chunk_count,
-                self.len,
-                tiny_chunks,
-                tiny_chunk_bytes,
-                small_chunks,
-                small_chunk_bytes,
-            );
-        }
-
         for chunk in self.iter_chunks() {
             writer.write_all(chunk).await?;
         }
@@ -1217,10 +1201,7 @@ mod tests {
     }
 
     fn response_write_metrics_test_guard() -> MutexGuard<'static, ()> {
-        static GUARD: Mutex<()> = Mutex::new(());
-        GUARD
-            .lock()
-            .expect("response-write metrics test guard poisoned")
+        super::response_write_metrics_test_guard()
     }
     use tokio::io::AsyncWriteExt;
 

--- a/src/pool/connection_guard.rs
+++ b/src/pool/connection_guard.rs
@@ -95,7 +95,7 @@ impl ConnectionGuard {
         }
     }
 
-    /// Return connection to pool (healthy).
+    /// Return connection to pool after a successful exchange.
     ///
     /// Connection will be returned to the pool normally when the returned
     /// `Object` is dropped. The guard is consumed — no cleanup happens.
@@ -103,11 +103,11 @@ impl ConnectionGuard {
     /// # Panics
     ///
     /// Panics if the guard has already been consumed (double-release).
-    pub(crate) fn release(mut self) -> Object<TcpManager> {
+    pub(crate) fn complete_success(mut self) -> Object<TcpManager> {
         self.released = true;
         self.conn
             .take()
-            .expect("ConnectionGuard::release() called on consumed guard")
+            .expect("ConnectionGuard::complete_success() called on consumed guard")
     }
 
     /// Close and remove the connection without applying replacement cooldown.
@@ -118,12 +118,12 @@ impl ConnectionGuard {
     /// # Panics
     ///
     /// Panics if the guard has already been consumed.
-    pub(crate) fn retire_without_cooldown(mut self) {
+    pub(crate) fn fail_client(mut self) {
         self.released = true;
         let conn = self
             .conn
             .take()
-            .expect("ConnectionGuard::retire_without_cooldown() called on consumed guard");
+            .expect("ConnectionGuard::fail_client() called on consumed guard");
         self.provider.remove_without_cooldown(conn);
     }
 
@@ -136,12 +136,12 @@ impl ConnectionGuard {
     /// # Panics
     ///
     /// Panics if the guard has already been consumed.
-    pub(crate) fn retire_with_cooldown(mut self) {
+    pub(crate) fn fail_backend(mut self) {
         self.released = true;
         let conn = self
             .conn
             .take()
-            .expect("ConnectionGuard::retire_with_cooldown() called on consumed guard");
+            .expect("ConnectionGuard::fail_backend() called on consumed guard");
         self.provider.remove_with_cooldown(conn);
     }
 
@@ -258,19 +258,19 @@ mod tests {
     //
     // These tests verify two invariants that callers must rely on:
     //
-    //   1. `release()` returns the connection to pool — pool can reuse it without
+    //   1. `complete_success()` returns the connection to pool — pool can reuse it without
     //      creating a new TCP connection to the backend.
     //
-    //   2. drop without `release()` removes the connection — pool creates a fresh
+    //   2. drop without `complete_success()` removes the connection — pool creates a fresh
     //      TCP connection on the next `get()`.
     //
     // These invariants protect the A2 refactor: any call site that uses
-    // `ConnectionGuard` must call `release()` on "clean" paths (e.g. `ClientDisconnect`
+    // `ConnectionGuard` must call `complete_success()` on "clean" paths (e.g. `ClientDisconnect`
     // where the backend was drained successfully) and let the guard drop on
     // "dirty" paths (backend errors, unknown state).
     //
     // A buggy A2 that drops the guard on `ClientDisconnect` without calling
-    // `release()` would cause release_reuses_pool_connection to fail — the pool
+    // `complete_success()` would cause release_reuses_pool_connection to fail — the pool
     // would create a new TCP connection instead of reusing the existing one.
 
     use super::ConnectionGuard;
@@ -358,7 +358,7 @@ mod tests {
 
         // release() returns conn to pool (no shutdown)
         let guard = ConnectionGuard::new(conn, provider.clone());
-        drop(guard.release());
+        drop(guard.complete_success());
 
         // Second get — pool recycles the existing connection (no new TCP handshake)
         let _conn2 = provider.get_pooled_connection().await.unwrap();

--- a/src/pool/connection_guard.rs
+++ b/src/pool/connection_guard.rs
@@ -84,7 +84,10 @@ pub struct ConnectionGuard {
 
 impl ConnectionGuard {
     /// Create a new guard (removes from pool on drop unless released).
-    pub const fn new(conn: Object<TcpManager>, provider: DeadpoolConnectionProvider) -> Self {
+    pub(crate) const fn new(
+        conn: Object<TcpManager>,
+        provider: DeadpoolConnectionProvider,
+    ) -> Self {
         Self {
             conn: Some(conn),
             provider,
@@ -100,7 +103,7 @@ impl ConnectionGuard {
     /// # Panics
     ///
     /// Panics if the guard has already been consumed (double-release).
-    pub fn release(mut self) -> Object<TcpManager> {
+    pub(crate) fn release(mut self) -> Object<TcpManager> {
         self.released = true;
         self.conn
             .take()
@@ -115,7 +118,7 @@ impl ConnectionGuard {
     /// # Panics
     ///
     /// Panics if the guard has already been consumed.
-    pub fn retire_without_cooldown(mut self) {
+    pub(crate) fn retire_without_cooldown(mut self) {
         self.released = true;
         let conn = self
             .conn
@@ -133,7 +136,7 @@ impl ConnectionGuard {
     /// # Panics
     ///
     /// Panics if the guard has already been consumed.
-    pub fn retire_with_cooldown(mut self) {
+    pub(crate) fn retire_with_cooldown(mut self) {
         self.released = true;
         let conn = self
             .conn
@@ -147,7 +150,7 @@ impl ConnectionGuard {
     /// # Panics
     ///
     /// Panics if the guard has already been consumed.
-    pub const fn get_mut(&mut self) -> &mut Object<TcpManager> {
+    pub(crate) const fn get_mut(&mut self) -> &mut Object<TcpManager> {
         self.conn
             .as_mut()
             .expect("ConnectionGuard already consumed")
@@ -158,29 +161,29 @@ impl ConnectionGuard {
     /// # Panics
     ///
     /// Panics if the guard has already been consumed.
-    pub const fn get(&self) -> &Object<TcpManager> {
+    pub(crate) const fn get(&self) -> &Object<TcpManager> {
         self.conn
             .as_ref()
             .expect("ConnectionGuard already consumed")
     }
 
     #[must_use]
-    pub fn connection_type(&self) -> &'static str {
+    pub(crate) fn connection_type(&self) -> &'static str {
         self.get().connection_type()
     }
 
     #[must_use]
-    pub fn pending_bytes_len(&self) -> usize {
+    pub(crate) fn pending_bytes_len(&self) -> usize {
         self.get().pending_bytes_len()
     }
 
     #[must_use]
-    pub fn provider_status_counts(&self) -> crate::pool::provider::DeadpoolStatusCounts {
+    pub(crate) fn provider_status_counts(&self) -> crate::pool::provider::DeadpoolStatusCounts {
         self.provider.status_counts()
     }
 
     #[must_use]
-    pub fn provider_name(&self) -> &str {
+    pub(crate) fn provider_name(&self) -> &str {
         self.provider.name()
     }
 }
@@ -229,7 +232,7 @@ impl std::ops::DerefMut for ConnectionGuard {
 /// # Arguments
 /// * `conn` - Pooled connection to verify
 /// * `provider` - Connection provider (used for `remove_with_cooldown` on failure)
-pub async fn salvage_with_health_check(
+pub(crate) async fn salvage_with_health_check(
     mut conn: Object<TcpManager>,
     provider: DeadpoolConnectionProvider,
 ) {

--- a/src/pool/connection_guard.rs
+++ b/src/pool/connection_guard.rs
@@ -103,7 +103,7 @@ impl ConnectionGuard {
     /// # Panics
     ///
     /// Panics if the guard has already been consumed (double-release).
-    pub(crate) fn complete_success(mut self) -> Object<TcpManager> {
+    pub fn complete_success(mut self) -> Object<TcpManager> {
         self.released = true;
         self.conn
             .take()
@@ -190,6 +190,10 @@ impl ConnectionGuard {
 
 impl Drop for ConnectionGuard {
     fn drop(&mut self) {
+        debug_assert!(
+            self.released,
+            "ConnectionGuard dropped without explicit finalize"
+        );
         if !self.released
             && let Some(conn) = self.conn.take()
         {
@@ -342,7 +346,7 @@ mod tests {
             .unwrap()
     }
 
-    /// Invariant: `release()` returns the connection to the pool.
+    /// Invariant: `complete_success()` returns the connection to the pool.
     ///
     /// Pool must reuse the connection without creating a new TCP connection.
     /// This is the path taken on success and on `ClientDisconnect` (backend was
@@ -356,7 +360,7 @@ mod tests {
         let conn = provider.get_pooled_connection().await.unwrap();
         assert_eq!(accept_count.load(Ordering::SeqCst), 1);
 
-        // release() returns conn to pool (no shutdown)
+        // complete_success() returns conn to pool (no shutdown)
         let guard = ConnectionGuard::new(conn, provider.clone());
         drop(guard.complete_success());
 
@@ -365,16 +369,17 @@ mod tests {
         assert_eq!(
             accept_count.load(Ordering::SeqCst),
             1,
-            "release() must return connection to pool; next get() must reuse it without \
+            "complete_success() must return connection to pool; next get() must reuse it without \
              creating a new TCP connection"
         );
     }
 
-    /// Invariant: drop without `release()` removes the connection from the pool.
+    /// Invariant: drop without `complete_success()` removes the connection from the pool.
     ///
     /// The guard shuts down the socket; pool recycle detects EOF
     /// and discards it; next `get()` creates a fresh TCP connection.
     /// Unknown/backend-error drop paths apply replacement cooldown.
+    #[cfg(not(debug_assertions))]
     #[tokio::test]
     async fn drop_without_release_forces_new_connection() {
         let (port, accept_count) = spawn_greeting_server().await;
@@ -403,9 +408,19 @@ mod tests {
         assert_eq!(
             accept_count.load(Ordering::SeqCst),
             2,
-            "drop without release() must remove connection; next get() must create \
+            "drop without complete_success() must remove connection; next get() must create \
              a new TCP connection"
         );
+    }
+
+    #[cfg(debug_assertions)]
+    #[tokio::test]
+    #[should_panic(expected = "ConnectionGuard dropped without explicit finalize")]
+    async fn drop_without_complete_success_panics_in_debug() {
+        let (port, _accept_count) = spawn_greeting_server().await;
+        let provider = make_provider(port);
+        let conn = provider.get_pooled_connection().await.unwrap();
+        let _guard = ConnectionGuard::new(conn, provider.clone());
     }
 
     // ─── salvage_with_health_check notes ────────────────────────────────────

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -14,7 +14,8 @@ pub use buffer::{
     BufferPool, ChunkedResponse, HotPathAllocationMetricsSnapshot, PooledBuffer,
     hot_path_allocation_metrics_snapshot, reset_hot_path_allocation_metrics,
 };
-pub use connection_guard::{ConnectionGuard, salvage_with_health_check};
+pub(crate) use connection_guard::ConnectionGuard;
+pub(crate) use connection_guard::salvage_with_health_check;
 pub use connection_trait::{ConnectionProvider, PoolStatus};
 pub use health_check::{HealthCheckError, HealthCheckMetrics};
 pub use prewarming::prewarm_pools;

--- a/src/pool/provider.rs
+++ b/src/pool/provider.rs
@@ -495,7 +495,7 @@ impl DeadpoolConnectionProvider {
     /// # Errors
     /// Returns [`crate::connection_error::ConnectionError`] if deadpool cannot
     /// provide a healthy backend connection.
-    pub async fn get_pooled_connection(
+    pub(in crate::pool) async fn get_pooled_connection(
         &self,
     ) -> Result<managed::Object<TcpManager>, crate::connection_error::ConnectionError> {
         use crate::connection_error::ConnectionError;
@@ -519,6 +519,21 @@ impl DeadpoolConnectionProvider {
             );
             err
         })
+    }
+
+    /// Checkout a pooled connection wrapped in a `ConnectionGuard`.
+    ///
+    /// Callers outside `crate::pool` should use this entrypoint instead of accessing
+    /// raw pooled objects directly.
+    ///
+    /// # Errors
+    /// Returns [`crate::connection_error::ConnectionError`] when no healthy backend
+    /// connection can be acquired.
+    pub async fn checkout_connection_guard(
+        &self,
+    ) -> Result<crate::pool::ConnectionGuard, crate::connection_error::ConnectionError> {
+        let conn = self.get_pooled_connection().await?;
+        Ok(crate::pool::ConnectionGuard::new(conn, self.clone()))
     }
 
     #[must_use]
@@ -560,7 +575,7 @@ impl DeadpoolConnectionProvider {
     /// the backend did not fail. For example, a client disconnect can leave
     /// unread backend response bytes in flight, making the socket dirty without
     /// implying that replacement connections should be throttled.
-    pub fn remove_without_cooldown(&self, conn: managed::Object<TcpManager>) {
+    pub(crate) fn remove_without_cooldown(&self, conn: managed::Object<TcpManager>) {
         shutdown_and_drop(conn);
     }
 
@@ -582,7 +597,7 @@ impl DeadpoolConnectionProvider {
     /// either [`shutdown_and_drop`] or [`resize_then_drop`], so the caller cannot
     /// accidentally `drop(conn)` before `pool.resize()`. Any attempt to reorder
     /// would be a use-after-move error.
-    pub fn remove_with_cooldown(&self, conn: managed::Object<TcpManager>) {
+    pub(crate) fn remove_with_cooldown(&self, conn: managed::Object<TcpManager>) {
         if self.is_shutting_down.load(Ordering::Acquire) {
             shutdown_and_drop(conn);
             return;

--- a/src/pool/provider.rs
+++ b/src/pool/provider.rs
@@ -575,7 +575,7 @@ impl DeadpoolConnectionProvider {
     /// the backend did not fail. For example, a client disconnect can leave
     /// unread backend response bytes in flight, making the socket dirty without
     /// implying that replacement connections should be throttled.
-    pub(crate) fn remove_without_cooldown(&self, conn: managed::Object<TcpManager>) {
+    pub(super) fn remove_without_cooldown(&self, conn: managed::Object<TcpManager>) {
         shutdown_and_drop(conn);
     }
 
@@ -597,7 +597,7 @@ impl DeadpoolConnectionProvider {
     /// either [`shutdown_and_drop`] or [`resize_then_drop`], so the caller cannot
     /// accidentally `drop(conn)` before `pool.resize()`. Any attempt to reorder
     /// would be a use-after-move error.
-    pub(crate) fn remove_with_cooldown(&self, conn: managed::Object<TcpManager>) {
+    pub(super) fn remove_with_cooldown(&self, conn: managed::Object<TcpManager>) {
         if self.is_shutting_down.load(Ordering::Acquire) {
             shutdown_and_drop(conn);
             return;

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -369,12 +369,6 @@ pub fn spawn_response_write_metrics_logger(period: Option<std::time::Duration>) 
                 pending_backend_byte_heap_fallbacks_delta = current_alloc
                     .pending_backend_byte_heap_fallbacks
                     .saturating_sub(previous_alloc.pending_backend_byte_heap_fallbacks),
-                non_owned_response_write_chunks_delta = current_alloc
-                    .non_owned_response_write_chunks
-                    .saturating_sub(previous_alloc.non_owned_response_write_chunks),
-                non_owned_response_write_bytes_delta = current_alloc
-                    .non_owned_response_write_bytes
-                    .saturating_sub(previous_alloc.non_owned_response_write_bytes),
                 regular_pool_buffer_holds_delta = current_alloc
                     .regular_pool_buffer_holds
                     .saturating_sub(previous_alloc.regular_pool_buffer_holds),

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -299,7 +299,7 @@ pub fn spawn_cache_stats_logger(proxy: &std::sync::Arc<crate::NntpProxy>) {
 ///
 /// Enable this via `proxy.response_write_metrics_secs` in config.
 pub fn spawn_response_write_metrics_logger(period: Option<std::time::Duration>) {
-    use tracing::{debug, info};
+    use tracing::debug;
 
     let Some(period) = period else {
         return;
@@ -333,7 +333,7 @@ pub fn spawn_response_write_metrics_logger(period: Option<std::time::Duration>) 
                 .checked_div(responses_delta)
                 .unwrap_or(0);
 
-            info!(
+            debug!(
                 responses_delta = responses_delta,
                 single_chunk_delta = current
                     .single_chunk_responses

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -299,7 +299,7 @@ pub fn spawn_cache_stats_logger(proxy: &std::sync::Arc<crate::NntpProxy>) {
 ///
 /// Enable this via `proxy.response_write_metrics_secs` in config.
 pub fn spawn_response_write_metrics_logger(period: Option<std::time::Duration>) {
-    use tracing::info;
+    use tracing::{debug, info};
 
     let Some(period) = period else {
         return;
@@ -353,7 +353,7 @@ pub fn spawn_response_write_metrics_logger(period: Option<std::time::Duration>) 
             );
 
             let current_alloc = crate::pool::buffer::hot_path_allocation_metrics_snapshot();
-            info!(
+            debug!(
                 regular_pool_fallback_allocations_delta = current_alloc
                     .regular_pool_fallback_allocations
                     .saturating_sub(previous_alloc.regular_pool_fallback_allocations),
@@ -404,7 +404,7 @@ pub fn spawn_response_write_metrics_logger(period: Option<std::time::Duration>) 
 ///
 /// Enable this via `proxy.client_writer_lock_metrics_secs` in config.
 pub fn spawn_client_writer_lock_metrics_logger(period: Option<std::time::Duration>) {
-    use tracing::info;
+    use tracing::debug;
 
     let Some(period) = period else {
         crate::session::shared_client_writer::set_client_writer_lock_metrics_enabled(false);
@@ -437,7 +437,7 @@ pub fn spawn_client_writer_lock_metrics_logger(period: Option<std::time::Duratio
                         .saturating_sub(previous.contended_locks) as u64)
             };
 
-            info!(
+            debug!(
                 requests_delta = requests_delta,
                 immediate_delta = current
                     .immediate_locks

--- a/src/session/backend.rs
+++ b/src/session/backend.rs
@@ -215,8 +215,7 @@ pub fn format_hex_preview(data: &[u8], max_bytes: usize) -> String {
 
 // ─── Command execution ──────────────────────────────────────────────────────
 
-/// Send a typed request and read enough bytes for backend response classification.
-pub(crate) async fn send_request<C>(
+pub(crate) async fn execute_request_classified<C>(
     conn: &mut C,
     request: &RequestContext,
     buffer: &mut PooledBuffer,
@@ -234,8 +233,7 @@ where
     read_until_backend_reply(conn, request, buffer).await
 }
 
-/// Send a typed request with timing measurements.
-pub(crate) async fn send_request_timed<C>(
+pub(crate) async fn execute_request_classified_timed<C>(
     conn: &mut C,
     request: &RequestContext,
     buffer: &mut PooledBuffer,
@@ -414,7 +412,7 @@ mod tests {
         let mut buffer = pool.acquire();
 
         let request = RequestContext::from_verb_args(b"DATE", b"");
-        let response = send_request(&mut stream, &request, &mut buffer)
+        let response = execute_request_classified(&mut stream, &request, &mut buffer)
             .await
             .expect("send_request should handle partial reads");
         let status_code = response
@@ -435,7 +433,7 @@ mod tests {
         let mut buffer = pool.acquire();
 
         let request = RequestContext::from_verb_args(b"DATE", b"");
-        let response = send_request(&mut stream, &request, &mut buffer)
+        let response = execute_request_classified(&mut stream, &request, &mut buffer)
             .await
             .expect("send_request should read through complete backend response");
         let status_code = response
@@ -457,7 +455,7 @@ mod tests {
         let mut buffer = pool.acquire();
 
         let request = RequestContext::from_verb_args(b"GROUP", b"alt.test");
-        let response = send_request(&mut stream, &request, &mut buffer)
+        let response = execute_request_classified(&mut stream, &request, &mut buffer)
             .await
             .expect("send_request should handle single-byte reads");
         let status_code = response

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -393,7 +393,7 @@ impl ClientSession {
         backend_connection: &mut Option<(crate::types::BackendId, crate::pool::ConnectionGuard)>,
     ) {
         if let Some((_backend_id, conn)) = backend_connection.take() {
-            let _ = conn.release();
+            let _ = conn.complete_success();
         }
     }
 

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -623,9 +623,16 @@ impl ClientSession {
                     if let Some(msg_id) = request.message_id_value() {
                         self.cache.record_backend_missing(msg_id, backend_id).await;
                     }
-                    if let Err(err) = self
-                        .capture_suppressed_430_response(&mut conn, backend_id, request, buffer)
-                        .await
+                    let mut buffer = buffer;
+                    if let Err(err) = crate::session::backend::observe_response(
+                        request,
+                        &mut buffer,
+                        &mut conn,
+                        &self.buffer_pool,
+                        backend_id,
+                    )
+                    .await
+                    .map_err(SessionError::from)
                     {
                         Self::release_cached_backend_connection(&mut backend_connection);
                         let turn = order.wait_turn(order_index).await;

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -25,7 +25,7 @@ const BACKEND_TIMING_SAMPLE_MASK: u64 = 0x0f;
 static BACKEND_TIMING_SAMPLE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[inline]
-pub fn should_sample_backend_timing() -> bool {
+pub(crate) fn should_sample_backend_timing() -> bool {
     BACKEND_TIMING_SAMPLE_COUNTER.fetch_add(1, Ordering::Relaxed) & BACKEND_TIMING_SAMPLE_MASK == 0
 }
 
@@ -133,19 +133,24 @@ enum BackendReadAttemptError {
     Backend(anyhow::Error),
 }
 
+impl From<SessionError> for BackendReadAttemptError {
+    fn from(err: SessionError) -> Self {
+        Self::Backend(anyhow::Error::new(err))
+    }
+}
+
 enum RetryStatProbeOutcome {
     Missing(BackendId),
     Present,
     Unavailable(BackendId),
 }
 
-/// Any client write failure after the full backend response is already owned is terminal.
+/// Any client write failure after response ownership is established is terminal.
 ///
-/// The backend connection is already clean at this point, but the client may have received a
-/// partial prefix of the response. Retrying another backend on the same client socket would
-/// splice responses together and corrupt NNTP response ordering.
+/// This must retire the backend connection to prevent protocol desync from
+/// partially-written client responses.
 const fn classify_response_write_err(e: std::io::Error) -> ResponseTransferError {
-    ResponseTransferError::ClientDisconnect(e)
+    ResponseTransferError::ClientWrite(e)
 }
 
 const fn can_discard_response_after_write(
@@ -177,9 +182,28 @@ impl ResponseRetention {
 }
 
 impl ClientSession {
-    #[inline]
-    const fn should_reuse_cached_batch_connection() -> bool {
-        true
+    fn cached_batch_connection_is_healthy(
+        &self,
+        guard: &mut crate::pool::ConnectionGuard,
+        backend_id: BackendId,
+        request: &RequestContext,
+    ) -> bool {
+        match crate::pool::health_check::check_tcp_alive(guard) {
+            Ok(()) => true,
+            Err(err) => {
+                warn!(
+                    client = %self.client_addr,
+                    backend = backend_id.as_index(),
+                    command_verb = ?request.verb(),
+                    msg_id = ?request.message_id_value(),
+                    connection_type = guard.connection_type(),
+                    pending_bytes = guard.pending_bytes_len(),
+                    error = %err,
+                    "Cached batch connection failed pre-reuse health check; retiring it"
+                );
+                false
+            }
+        }
     }
 
     pub(super) fn retry_backend_provider<'a>(
@@ -251,7 +275,7 @@ impl ClientSession {
             return Ok(BackendAttemptResult::BackendUnavailable);
         };
 
-        let Some((mut conn, status_code, buffer)) = self
+        let Some((mut conn, status_code, mut buffer)) = self
             .prepare_backend_attempt(provider, &backend, request, state, is_retry_attempt)
             .await?
         else {
@@ -271,8 +295,15 @@ impl ClientSession {
                 if let Some(msg_id) = request.message_id_value() {
                     self.cache.record_backend_missing(msg_id, backend_id).await;
                 }
-                self.capture_suppressed_430_response(&mut conn, backend_id, request, buffer)
-                    .await?;
+                crate::session::backend::observe_response(
+                    request,
+                    &mut buffer,
+                    &mut conn,
+                    &self.buffer_pool,
+                    backend_id,
+                )
+                .await
+                .map_err(SessionError::from)?;
                 self.release_or_reuse_connection(
                     conn,
                     backend_id,
@@ -361,14 +392,17 @@ impl ClientSession {
             let stat_request = stat_request.clone();
             probes.push(async move {
                 let _guard = BackendSelector::guard_for_manual_backend(router, backend_id);
-                let conn = match provider.get_pooled_connection().await {
+                let mut conn = match provider.checkout_connection_guard().await {
                     Ok(conn) => conn,
                     Err(_) => return RetryStatProbeOutcome::Unavailable(backend_id),
                 };
-                let mut conn = crate::pool::ConnectionGuard::new(conn, provider);
                 let mut buffer = self.buffer_pool.acquire();
-                let read =
-                    backend::send_request(&mut **conn.get_mut(), &stat_request, &mut buffer).await;
+                let read = backend::execute_request_classified(
+                    &mut **conn,
+                    &stat_request,
+                    &mut buffer,
+                )
+                .await;
                 let status_code = match read {
                     Ok(read) => read.status_code(),
                     Err(_) => {
@@ -376,6 +410,20 @@ impl ClientSession {
                         return RetryStatProbeOutcome::Unavailable(backend_id);
                     }
                 };
+
+                if crate::session::backend::observe_response(
+                    &stat_request,
+                    &mut buffer,
+                    &mut conn,
+                    &self.buffer_pool,
+                    backend_id,
+                )
+                .await
+                .is_err()
+                {
+                    conn.retire_with_cooldown();
+                    return RetryStatProbeOutcome::Unavailable(backend_id);
+                }
 
                 if self
                     .capture_suppressed_430_response(&mut conn, backend_id, &stat_request, buffer)
@@ -467,15 +515,17 @@ impl ClientSession {
                 let buffer_pool = buffer_pool.clone();
                 probes.push(async move {
                     let _guard = BackendSelector::guard_for_manual_backend(router, backend_id);
-                    let conn = match provider.get_pooled_connection().await {
+                    let mut conn = match provider.checkout_connection_guard().await {
                         Ok(conn) => conn,
                         Err(_) => return,
                     };
-                    let mut conn = crate::pool::ConnectionGuard::new(conn, provider);
                     let mut buffer = buffer_pool.acquire();
-                    let read =
-                        backend::send_request(&mut **conn.get_mut(), &stat_request, &mut buffer)
-                            .await;
+                    let read = backend::execute_request_classified(
+                        &mut **conn,
+                        &stat_request,
+                        &mut buffer,
+                    )
+                    .await;
                     let status_code = match read {
                         Ok(read) => read.status_code(),
                         Err(_) => {
@@ -618,24 +668,6 @@ impl ClientSession {
         );
 
         Ok(Some((conn, status_code, buffer)))
-    }
-
-    pub(super) async fn capture_suppressed_430_response(
-        &self,
-        conn: &mut crate::pool::ConnectionGuard,
-        backend_id: BackendId,
-        request: &RequestContext,
-        mut buffer: crate::pool::PooledBuffer,
-    ) -> Result<(), SessionError> {
-        crate::session::backend::observe_response(
-            request,
-            &mut buffer,
-            conn,
-            &self.buffer_pool,
-            backend_id,
-        )
-        .await
-        .map_err(SessionError::from)
     }
 
     fn handle_invalid_backend_response(
@@ -845,6 +877,8 @@ impl ClientSession {
         backend_connection: &mut Option<(BackendId, crate::pool::ConnectionGuard)>,
     ) -> Result<crate::pool::ConnectionGuard> {
         let checkout_status = provider.status_counts();
+        let can_expand_or_use_idle =
+            checkout_status.available > 0 || checkout_status.size < checkout_status.max_size;
         debug!(
             client = %self.client_addr,
             backend = backend_id.as_index(),
@@ -858,8 +892,57 @@ impl ClientSession {
             "Starting pool checkout for direct backend attempt"
         );
         let guard = match backend_connection.take() {
-            Some((cached_backend_id, guard)) if cached_backend_id == backend_id => {
-                if Self::should_reuse_cached_batch_connection() {
+            Some((cached_backend_id, mut guard)) if cached_backend_id == backend_id => {
+                if !self.cached_batch_connection_is_healthy(&mut guard, backend_id, request) {
+                    guard.retire_with_cooldown();
+                    let checkout_status = provider.status_counts();
+                    trace!(
+                        client = %self.client_addr,
+                        backend = backend_id.as_index(),
+                        command_verb = ?request.verb(),
+                        msg_id = ?request.message_id_value(),
+                        pool = %provider.name(),
+                        pool_available = checkout_status.available,
+                        pool_size = checkout_status.size,
+                        pool_max_size = checkout_status.max_size,
+                        pool_waiting = checkout_status.waiting,
+                        "Requesting pooled connection after retiring unhealthy cached batch connection"
+                    );
+                    provider.checkout_connection_guard().await?
+                } else if can_expand_or_use_idle {
+                    debug!(
+                        client = %self.client_addr,
+                        backend = backend_id.as_index(),
+                        command_verb = ?request.verb(),
+                        msg_id = ?request.message_id_value(),
+                        pool = %provider.name(),
+                        pool_available = checkout_status.available,
+                        pool_size = checkout_status.size,
+                        pool_max_size = checkout_status.max_size,
+                        pool_waiting = checkout_status.waiting,
+                        connection_type = guard.connection_type(),
+                        pending_bytes = guard.pending_bytes_len(),
+                        "Using idle pool capacity before reusing cached batch connection"
+                    );
+                    *backend_connection = Some((cached_backend_id, guard));
+                    match provider.checkout_connection_guard().await {
+                        Ok(conn) => conn,
+                        Err(err) => {
+                            debug!(
+                                client = %self.client_addr,
+                                backend = backend_id.as_index(),
+                                command_verb = ?request.verb(),
+                                msg_id = ?request.message_id_value(),
+                                error = %err,
+                                "Idle pool checkout failed; falling back to cached batch connection"
+                            );
+                            let (_, cached_guard) = backend_connection.take().expect(
+                                "cached backend connection should be present for fallback reuse",
+                            );
+                            cached_guard
+                        }
+                    }
+                } else {
                     let checkout_status = provider.status_counts();
                     debug!(
                         client = %self.client_addr,
@@ -876,8 +959,6 @@ impl ClientSession {
                         "Reusing cached batch connection for direct backend attempt"
                     );
                     guard
-                } else {
-                    unreachable!("cached batch connection reuse should remain enabled");
                 }
             }
             Some(cached) => {
@@ -906,7 +987,7 @@ impl ClientSession {
                     pool_waiting = checkout_status.waiting,
                     "Requesting pooled connection after backend switch"
                 );
-                let conn = provider.get_pooled_connection().await?;
+                let conn = provider.checkout_connection_guard().await?;
                 let checkout_status = provider.status_counts();
                 trace!(
                     client = %self.client_addr,
@@ -922,7 +1003,7 @@ impl ClientSession {
                     pending_bytes = conn.pending_bytes_len(),
                     "Pool checkout succeeded for direct backend attempt"
                 );
-                crate::pool::ConnectionGuard::new(conn, provider.clone())
+                conn
             }
             None => {
                 let checkout_status = provider.status_counts();
@@ -938,7 +1019,7 @@ impl ClientSession {
                     pool_waiting = checkout_status.waiting,
                     "Requesting pooled connection"
                 );
-                let conn = provider.get_pooled_connection().await?;
+                let conn = provider.checkout_connection_guard().await?;
                 let checkout_status = provider.status_counts();
                 trace!(
                     client = %self.client_addr,
@@ -954,7 +1035,7 @@ impl ClientSession {
                     pending_bytes = conn.pending_bytes_len(),
                     "Pool checkout succeeded for direct backend attempt"
                 );
-                crate::pool::ConnectionGuard::new(conn, provider.clone())
+                conn
             }
         };
         Ok(guard)
@@ -985,15 +1066,55 @@ impl ClientSession {
             pending_bytes = guard.pending_bytes_len(),
             "Sending request to backend and waiting for classifiable response bytes"
         );
-        let result = self
-            .execute_and_read_response_with_optional_stat_probe(
-                &mut guard,
-                provider,
-                backend,
-                request,
-                stat_probe_retry_only,
-            )
-            .await;
+        let result =
+            if Self::should_use_stat_missing_probe(provider, request, stat_probe_retry_only) {
+                if let Some(stat_request) = Self::stat_probe_request(request) {
+                    debug!(
+                        client = %self.client_addr,
+                        backend = backend.backend_id().as_index(),
+                        command_verb = ?request.verb(),
+                        msg_id = ?request.message_id_value(),
+                        "Running STAT miss probe before backend article fetch"
+                    );
+
+                    let (probe_response, mut probe_buffer, probe_timings) = self
+                        .execute_and_read_response(&mut guard, backend, &stat_request)
+                        .await
+                        .map_err(|BackendReadAttemptError::Backend(e)| e)?;
+                    if probe_response
+                        .status_code()
+                        .is_some_and(|status| status.as_u16() == 430)
+                    {
+                        debug!(
+                            client = %self.client_addr,
+                            backend = backend.backend_id().as_index(),
+                            command_verb = ?request.verb(),
+                            msg_id = ?request.message_id_value(),
+                            "STAT miss probe returned 430; skipping backend article fetch"
+                        );
+                        Ok((probe_response, probe_buffer, probe_timings))
+                    } else {
+                        crate::session::backend::observe_response(
+                            &stat_request,
+                            &mut probe_buffer,
+                            &mut guard,
+                            &self.buffer_pool,
+                            backend.backend_id(),
+                        )
+                        .await
+                        .map_err(SessionError::from)?;
+                        let _ = probe_timings;
+                        self.execute_and_read_response(&mut guard, backend, request)
+                            .await
+                    }
+                } else {
+                    self.execute_and_read_response(&mut guard, backend, request)
+                        .await
+                }
+            } else {
+                self.execute_and_read_response(&mut guard, backend, request)
+                    .await
+            };
 
         match result {
             Ok((read_status, buffer, timings)) => Ok((guard, read_status, buffer, timings)),
@@ -1028,12 +1149,12 @@ impl ClientSession {
         let mut buffer = self.buffer_pool.acquire();
         let (response, timings) = if should_sample_backend_timing() {
             let (response, ttfb, send, recv) =
-                backend::send_request_timed(conn, request, &mut buffer)
+                backend::execute_request_classified_timed(conn, request, &mut buffer)
                     .await
                     .map_err(BackendReadAttemptError::Backend)?;
             (response, Some((ttfb, send, recv)))
         } else {
-            let response = backend::send_request(conn, request, &mut buffer)
+            let response = backend::execute_request_classified(conn, request, &mut buffer)
                 .await
                 .map_err(BackendReadAttemptError::Backend)?;
             (response, None)
@@ -1114,7 +1235,6 @@ impl ClientSession {
 
         self.execute_and_read_response(conn, backend, request).await
     }
-
     /// Write response from backend to client and handle caching.
     ///
     /// Returns `ResponseTransferError` so callers can decide the connection's pool fate
@@ -1412,7 +1532,7 @@ mod tests {
     use crate::auth::AuthHandler;
     use crate::cache::{ArticleAvailability, UnifiedCache};
     use crate::metrics::MetricsCollector;
-    use crate::pool::{BufferPool, ConnectionGuard, DeadpoolConnectionProvider};
+    use crate::pool::{BufferPool, DeadpoolConnectionProvider};
     use crate::protocol::{RequestContext, StatusCode};
     use crate::router::{ArticleBackend, BackendSelector, SuppressedBackends};
     use crate::session::SessionError;
@@ -1616,6 +1736,62 @@ mod tests {
         (port, stat_commands, body_commands)
     }
 
+    async fn spawn_delayed_stat_missing_probe_server(
+        delay: Duration,
+    ) -> (u16, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let stat_commands = Arc::new(AtomicUsize::new(0));
+        let body_commands = Arc::new(AtomicUsize::new(0));
+        let stat_count = Arc::clone(&stat_commands);
+        let body_count = Arc::clone(&body_commands);
+
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let stat_count = Arc::clone(&stat_count);
+                let body_count = Arc::clone(&body_count);
+                tokio::spawn(async move {
+                    let (read_half, mut write_half) = stream.into_split();
+                    let mut reader = BufReader::new(read_half);
+
+                    if write_half.write_all(b"200 Ready\r\n").await.is_err() {
+                        return;
+                    }
+
+                    let mut line = String::new();
+                    loop {
+                        line.clear();
+                        match reader.read_line(&mut line).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(_) => {
+                                let cmd = line.trim().to_ascii_uppercase();
+                                if cmd.starts_with("MODE") {
+                                    let _ = write_half.write_all(b"200 Posting allowed\r\n").await;
+                                } else if cmd.starts_with("STAT ") {
+                                    stat_count.fetch_add(1, Ordering::SeqCst);
+                                    tokio::time::sleep(delay).await;
+                                    let _ = write_half.write_all(b"430 Missing\r\n").await;
+                                } else if cmd.starts_with("BODY") || cmd.starts_with("ARTICLE") {
+                                    body_count.fetch_add(1, Ordering::SeqCst);
+                                    let _ = write_half.write_all(
+                                        b"222 0 <found@example.com> body follows\r\npayload\r\n.\r\n",
+                                    ).await;
+                                } else if cmd.starts_with("QUIT") {
+                                    let _ = write_half.write_all(b"205 Goodbye\r\n").await;
+                                    break;
+                                } else {
+                                    let _ = write_half.write_all(b"200 OK\r\n").await;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        (port, stat_commands, body_commands)
+    }
+
     async fn spawn_article_response_then_close_server(
         response: &'static [u8],
     ) -> (u16, Arc<AtomicUsize>) {
@@ -1768,7 +1944,7 @@ mod tests {
         let classified = classify_response_write_err(err);
         assert!(matches!(
             classified,
-            crate::session::response_transfer::ResponseTransferError::ClientDisconnect(_)
+            crate::session::response_transfer::ResponseTransferError::ClientWrite(_)
         ));
     }
 
@@ -1778,7 +1954,7 @@ mod tests {
         let classified = classify_response_write_err(err);
         assert!(matches!(
             classified,
-            crate::session::response_transfer::ResponseTransferError::ClientDisconnect(_)
+            crate::session::response_transfer::ResponseTransferError::ClientWrite(_)
         ));
     }
 
@@ -2035,6 +2211,70 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn retry_stat_sweep_marks_slow_430_backends_missing() {
+        let session = test_session();
+        let (slow_port, slow_stat, slow_body) =
+            spawn_delayed_stat_missing_probe_server(Duration::from_millis(350)).await;
+        let (fast_port, fast_stat, fast_body) = spawn_stat_missing_probe_server().await;
+        let router = router_with_tiered_backends([
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", slow_port)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                0,
+            ),
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", fast_port)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                1,
+            ),
+        ]);
+
+        let request = request_context(b"BODY <missing@example.com>\r\n");
+        let mut availability = ArticleAvailability::new();
+        let mut client_to_backend_bytes = ClientToBackendBytes::zero();
+        let mut backend_connection = None;
+        let mut unavailable_backends = SuppressedBackends::empty();
+        let mut state = ArticleAttemptState {
+            availability: &mut availability,
+            client_to_backend_bytes: &mut client_to_backend_bytes,
+            backend_connection: &mut backend_connection,
+            unavailable_backends: &mut unavailable_backends,
+        };
+
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            session.parallel_retry_stat_sweep(&router, &request, &mut state),
+        )
+        .await
+        .expect("parallel retry STAT sweep should not hang")
+        .expect("parallel retry STAT sweep should succeed");
+
+        assert!(
+            state.availability.is_missing(BackendId::from_index(0)),
+            "slow STAT=430 backend should still be classified as missing"
+        );
+        assert!(
+            state.availability.is_missing(BackendId::from_index(1)),
+            "fast STAT=430 backend should be classified as missing"
+        );
+        assert_eq!(
+            state.unavailable_backends.bits(),
+            0,
+            "authoritative 430 probes should not suppress backends as unavailable"
+        );
+        assert_eq!(slow_stat.load(Ordering::SeqCst), 1);
+        assert_eq!(fast_stat.load(Ordering::SeqCst), 1);
+        assert_eq!(slow_body.load(Ordering::SeqCst), 0);
+        assert_eq!(fast_body.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
     async fn first_attempt_prefetches_stat_only_on_non_primary_tiers_with_stat_missing_enabled() {
         let session = test_session();
         let (port0, stat0, body0) = spawn_stat_missing_probe_server().await;
@@ -2135,9 +2375,45 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn direct_checkout_prefers_cached_batch_connection() {
-        assert!(super::ClientSession::should_reuse_cached_batch_connection());
+    #[tokio::test]
+    async fn checkout_retires_unhealthy_cached_batch_connection_before_reuse() {
+        let session = test_session();
+        let (port, accept_count) = spawn_greeting_server().await;
+        let provider = DeadpoolConnectionProvider::builder("127.0.0.1", port)
+            .max_connections(2)
+            .build()
+            .unwrap();
+
+        let request = request_context(b"BODY <cached-health@example.com>\r\n");
+        let backend_id = BackendId::from_index(0);
+        let conn = provider
+            .checkout_connection_guard()
+            .await
+            .expect("initial pooled connection should be created");
+        let mut backend_connection = Some((backend_id, conn));
+        if let Some((_, cached_guard)) = backend_connection.as_mut() {
+            cached_guard
+                .get_mut()
+                .queue_pending_bytes(b"stale")
+                .expect("test should be able to inject queued bytes");
+        }
+
+        let guard = session
+            .checkout_direct_backend_connection(
+                &provider,
+                backend_id,
+                &request,
+                &mut backend_connection,
+            )
+            .await
+            .expect("checkout should recover with a fresh pooled connection");
+        drop(guard.release());
+
+        assert_eq!(
+            accept_count.load(Ordering::SeqCst),
+            2,
+            "checkout should discard the dead cached connection and open a fresh one"
+        );
     }
 
     #[tokio::test]
@@ -2592,10 +2868,10 @@ mod tests {
             .max_connections(5)
             .build()
             .unwrap();
-        let conn = provider.get_pooled_connection().await.unwrap();
+        let conn = provider.checkout_connection_guard().await.unwrap();
         assert_eq!(accept_count.load(Ordering::SeqCst), 1);
 
-        let guard = ConnectionGuard::new(conn, provider.clone());
+        let guard = conn;
         let request = request_context(b"STAT <test@example.com>\r\n");
         let mut client_write = FlushFailWriter::new();
         let mut backend_bytes = BufferPool::new(BufferSize::try_new(8192).unwrap(), 1).acquire();
@@ -2623,7 +2899,7 @@ mod tests {
         ));
         assert_eq!(client_write.writes, b"223 0 <test@example.com> status\r\n");
 
-        let _reused = provider.get_pooled_connection().await.unwrap();
+        let _reused = provider.checkout_connection_guard().await.unwrap();
         assert_eq!(
             accept_count.load(Ordering::SeqCst),
             1,
@@ -2639,10 +2915,10 @@ mod tests {
             .max_connections(5)
             .build()
             .unwrap();
-        let conn = provider.get_pooled_connection().await.unwrap();
+        let conn = provider.checkout_connection_guard().await.unwrap();
         assert_eq!(accept_count.load(Ordering::SeqCst), 1);
 
-        let guard = ConnectionGuard::new(conn, provider.clone());
+        let guard = conn;
         let request = request_context(b"ARTICLE <test@example.com>\r\n");
         let mut client_write = WriteFailWriter;
         let mut backend_bytes = BufferPool::new(BufferSize::try_new(8192).unwrap(), 1).acquire();
@@ -2669,11 +2945,59 @@ mod tests {
             crate::session::SessionError::ClientDisconnect(_)
         ));
 
-        let _reused = provider.get_pooled_connection().await.unwrap();
+        let _reused = provider.checkout_connection_guard().await.unwrap();
         assert_eq!(
             accept_count.load(Ordering::SeqCst),
             1,
             "client write failure after a complete framed response must not retire the backend connection"
+        );
+    }
+
+    #[tokio::test]
+    async fn write_disconnect_with_packed_trailing_bytes_retires_backend_connection() {
+        let session = test_session();
+        let (port, accept_count) = spawn_greeting_server().await;
+        let provider = DeadpoolConnectionProvider::builder("127.0.0.1", port)
+            .max_connections(5)
+            .build()
+            .unwrap();
+        let conn = provider.checkout_connection_guard().await.unwrap();
+        assert_eq!(accept_count.load(Ordering::SeqCst), 1);
+
+        let guard = conn;
+        let request = request_context(b"ARTICLE <test@example.com>\r\n");
+        let mut client_write = WriteFailWriter;
+        let mut backend_bytes = BufferPool::new(BufferSize::try_new(8192).unwrap(), 1).acquire();
+        backend_bytes.copy_from_slice(
+            b"220 Article follows\r\nbody\r\n.\r\n223 0 <next@example.com> status\r\n",
+        );
+
+        let err = session
+            .write_successful_backend_response(
+                guard,
+                &mut client_write,
+                &eligible(BackendId::from_index(0)),
+                backend_bytes,
+                ResponseWriteParams {
+                    request: &request,
+                    msg_id: None,
+                    status_code: StatusCode::new(220),
+                },
+                None,
+            )
+            .await
+            .expect_err("packed trailing bytes plus client write failure must be terminal");
+
+        assert!(matches!(
+            err,
+            crate::session::SessionError::ClientDisconnect(_)
+        ));
+
+        let _replacement = provider.checkout_connection_guard().await.unwrap();
+        assert_eq!(
+            accept_count.load(Ordering::SeqCst),
+            2,
+            "client write failure with queued backend bytes must retire the connection"
         );
     }
 }

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -406,7 +406,7 @@ impl ClientSession {
                 let status_code = match read {
                     Ok(read) => read.status_code(),
                     Err(_) => {
-                        conn.retire_with_cooldown();
+                        conn.fail_backend();
                         return RetryStatProbeOutcome::Unavailable(backend_id);
                     }
                 };
@@ -421,7 +421,7 @@ impl ClientSession {
                 .await
                 .is_err()
                 {
-                    conn.retire_with_cooldown();
+                    conn.fail_backend();
                     return RetryStatProbeOutcome::Unavailable(backend_id);
                 }
 
@@ -430,10 +430,10 @@ impl ClientSession {
                     .await
                     .is_err()
                 {
-                    conn.retire_with_cooldown();
+                    conn.fail_backend();
                     return RetryStatProbeOutcome::Unavailable(backend_id);
                 }
-                let _ = conn.release();
+                let _ = conn.complete_success();
 
                 if status_code.is_some_and(|status| status.as_u16() == 430) {
                     RetryStatProbeOutcome::Missing(backend_id)
@@ -529,7 +529,7 @@ impl ClientSession {
                     let status_code = match read {
                         Ok(read) => read.status_code(),
                         Err(_) => {
-                            conn.retire_with_cooldown();
+                            conn.fail_backend();
                             return;
                         }
                     };
@@ -543,10 +543,10 @@ impl ClientSession {
                     .await
                     .is_err()
                     {
-                        conn.retire_with_cooldown();
+                        conn.fail_backend();
                         return;
                     }
-                    let _ = conn.release();
+                    let _ = conn.complete_success();
 
                     if status_code.is_some_and(|status| status.as_u16() == 430)
                         && let Ok(msg_id) = crate::types::MessageId::new(msg_id_text)
@@ -693,7 +693,7 @@ impl ClientSession {
         );
         let request_kind = request.kind();
         let provider_for_salvage = provider.clone();
-        let conn_for_salvage = conn.release();
+        let conn_for_salvage = conn.complete_success();
         tokio::spawn(async move {
             tracing::debug!(
                 backend = ?backend_id,
@@ -790,7 +790,7 @@ impl ClientSession {
             );
             self.metrics.record_error(backend_id);
             self.metrics.user_error(self.username());
-            conn.retire_with_cooldown();
+            conn.fail_backend();
         } else if let ResponseConnectionReuse::QueuedBytes { len } =
             crate::session::response_transfer::connection_reuse_after_response(&conn)
         {
@@ -801,7 +801,7 @@ impl ClientSession {
                 queued_bytes = len,
                 "Response write left queued backend bytes; retiring connection"
             );
-            conn.retire_without_cooldown();
+            conn.fail_client();
         } else {
             debug!(
                 client = %self.client_addr,
@@ -809,7 +809,7 @@ impl ClientSession {
                 command_verb = ?request.verb(),
                 "Response write error left backend connection reusable; releasing it back to pool"
             );
-            let _ = conn.release();
+            let _ = conn.complete_success();
         }
 
         SessionError::from(error)
@@ -835,7 +835,7 @@ impl ClientSession {
                 queued_bytes = len,
                 "Direct per-command response left queued backend bytes; retiring connection"
             );
-            conn.retire_without_cooldown();
+            conn.fail_client();
         } else if let Some(slot) = backend_connection
             && slot.is_none()
         {
@@ -865,7 +865,7 @@ impl ClientSession {
                 pending_bytes = conn.pending_bytes_len(),
                 "Direct per-command response finished cleanly; releasing backend connection"
             );
-            let _ = conn.release();
+            let _ = conn.complete_success();
         }
     }
 
@@ -894,7 +894,7 @@ impl ClientSession {
         let guard = match backend_connection.take() {
             Some((cached_backend_id, mut guard)) if cached_backend_id == backend_id => {
                 if !self.cached_batch_connection_is_healthy(&mut guard, backend_id, request) {
-                    guard.retire_with_cooldown();
+                    guard.fail_backend();
                     let checkout_status = provider.status_counts();
                     trace!(
                         client = %self.client_addr,
@@ -973,7 +973,7 @@ impl ClientSession {
                     pending_bytes = cached_conn.pending_bytes_len(),
                     "Releasing cached backend connection before switching backend"
                 );
-                let _ = cached_conn.release();
+                let _ = cached_conn.complete_success();
                 let checkout_status = provider.status_counts();
                 trace!(
                     client = %self.client_addr,
@@ -1126,7 +1126,7 @@ impl ClientSession {
                     error = %e,
                     "Backend attempt failed before response completed; dropping pooled connection"
                 );
-                guard.retire_with_cooldown();
+                guard.fail_backend();
                 Err(e)
             }
         }
@@ -2407,7 +2407,7 @@ mod tests {
             )
             .await
             .expect("checkout should recover with a fresh pooled connection");
-        drop(guard.release());
+        drop(guard.complete_success());
 
         assert_eq!(
             accept_count.load(Ordering::SeqCst),

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -1559,6 +1559,14 @@ mod tests {
         RequestContext::parse(line).expect("valid request line")
     }
 
+    fn finalize_backend_connection(
+        backend_connection: &mut Option<(BackendId, crate::pool::ConnectionGuard)>,
+    ) {
+        if let Some((_backend_id, conn)) = backend_connection.take() {
+            let _ = conn.complete_success();
+        }
+    }
+
     fn test_session() -> crate::session::ClientSession {
         let addr: std::net::SocketAddr = "127.0.0.1:9999".parse().unwrap();
         let buffer_pool = BufferPool::new(BufferSize::try_new(8192).unwrap(), 4);
@@ -2062,6 +2070,7 @@ mod tests {
         ));
         assert!(availability.is_missing(BackendId::from_index(0)));
         assert_eq!(article_commands.load(Ordering::SeqCst), 1);
+        finalize_backend_connection(&mut backend_connection);
 
         drop(held_writer);
     }
@@ -2102,6 +2111,7 @@ mod tests {
             1,
             "first attempt should go directly to BODY/ARTICLE/HEAD without STAT probe"
         );
+        finalize_backend_connection(&mut backend_connection);
     }
 
     #[tokio::test]
@@ -2417,6 +2427,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn first_attempt_skips_stat_missing_probe() {
+        let session = test_session();
+        let (port, stat_commands, body_commands) = spawn_stat_missing_probe_server().await;
+        let provider = DeadpoolConnectionProvider::builder("127.0.0.1", port)
+            .max_connections(1)
+            .stat_missing(true)
+            .build()
+            .unwrap();
+        let router = router_with_backend(provider);
+        let (client_writer, _client_read, _client_write) = shared_client_writer_pair().await;
+
+        let mut request = request_context(b"BODY <missing@example.com>\r\n");
+        let mut availability = ArticleAvailability::new();
+        let mut client_to_backend_bytes = ClientToBackendBytes::zero();
+        let mut backend_connection = None;
+        let mut unavailable_backends = SuppressedBackends::empty();
+        let mut state = ArticleAttemptState {
+            availability: &mut availability,
+            client_to_backend_bytes: &mut client_to_backend_bytes,
+            backend_connection: &mut backend_connection,
+            unavailable_backends: &mut unavailable_backends,
+        };
+
+        let result = session
+            .try_backend_for_article(&router, &mut request, &client_writer, &mut state, false)
+            .await
+            .expect("first BODY attempt should complete without transport error");
+
+        assert!(matches!(result, BackendAttemptResult::Success));
+        assert_eq!(
+            stat_commands.load(Ordering::SeqCst),
+            0,
+            "STAT probe is retry-only and should not run on first attempt"
+        );
+        assert_eq!(body_commands.load(Ordering::SeqCst), 1);
+        assert!(!availability.is_missing(BackendId::from_index(0)));
+        finalize_backend_connection(&mut backend_connection);
+    }
+
+    #[tokio::test]
     async fn track_stat_records_availability_when_article_cache_disabled() {
         let cache = Arc::new(UnifiedCache::memory(1024, Duration::from_secs(60)));
         let session = test_session_with_cache(cache.clone(), false);
@@ -2596,6 +2646,7 @@ mod tests {
         assert_eq!(availability.missing_bits(), 0);
         assert_eq!(availability.missing_bits(), 0);
         assert_eq!(request.backend_id(), Some(BackendId::from_index(1)));
+        finalize_backend_connection(&mut backend_connection);
 
         let mut written = vec![0; good_response.len()];
         tokio::time::timeout(Duration::from_secs(1), client_read.read_exact(&mut written))
@@ -2660,6 +2711,7 @@ mod tests {
         assert_eq!(bad_article_commands.load(Ordering::SeqCst), 1);
         assert_eq!(good_article_commands.load(Ordering::SeqCst), 1);
         assert_eq!(request.backend_id(), Some(BackendId::from_index(1)));
+        finalize_backend_connection(&mut backend_connection);
     }
 
     #[tokio::test]
@@ -2787,6 +2839,7 @@ mod tests {
         assert_eq!(backup_article_commands.load(Ordering::SeqCst), 0);
         assert_eq!(availability.missing_bits(), 0);
         assert_eq!(availability.missing_bits(), 0);
+        finalize_backend_connection(&mut backend_connection);
     }
 
     #[tokio::test]
@@ -2858,6 +2911,7 @@ mod tests {
             .expect("client response should be readable")
             .expect("client read should succeed");
         assert_eq!(written, response);
+        finalize_backend_connection(&mut backend_connection);
     }
 
     #[tokio::test]
@@ -2899,7 +2953,8 @@ mod tests {
         ));
         assert_eq!(client_write.writes, b"223 0 <test@example.com> status\r\n");
 
-        let _reused = provider.checkout_connection_guard().await.unwrap();
+        let reused = provider.checkout_connection_guard().await.unwrap();
+        drop(reused.complete_success());
         assert_eq!(
             accept_count.load(Ordering::SeqCst),
             1,
@@ -2945,7 +3000,8 @@ mod tests {
             crate::session::SessionError::ClientDisconnect(_)
         ));
 
-        let _reused = provider.checkout_connection_guard().await.unwrap();
+        let reused = provider.checkout_connection_guard().await.unwrap();
+        drop(reused.complete_success());
         assert_eq!(
             accept_count.load(Ordering::SeqCst),
             1,
@@ -2993,7 +3049,8 @@ mod tests {
             crate::session::SessionError::ClientDisconnect(_)
         ));
 
-        let _replacement = provider.checkout_connection_guard().await.unwrap();
+        let replacement = provider.checkout_connection_guard().await.unwrap();
+        drop(replacement.complete_success());
         assert_eq!(
             accept_count.load(Ordering::SeqCst),
             2,

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -6,7 +6,9 @@
 use crate::protocol::{RequestContext, RequestKind, RequestResponseMetadata, StatusCode};
 use crate::router::{ArticleBackend, BackendSelector, SuppressedBackends};
 use crate::session::SessionError;
-use crate::session::response_transfer::{ResponseConnectionReuse, ResponseTransferError};
+use crate::session::response_transfer::{
+    BackendConnectionOutcome, ResponseConnectionReuse, ResponseTransferError,
+};
 use crate::session::retry::retry_once;
 use crate::session::routing::{
     CacheAction, MetricsAction, determine_cache_action_for_request,
@@ -780,36 +782,42 @@ impl ClientSession {
         request: &RequestContext,
         error: ResponseTransferError,
     ) -> SessionError {
-        if error.must_remove_connection() {
-            warn!(
-                client = %self.client_addr,
-                backend = backend_id.as_index(),
-                command_verb = ?request.verb(),
-                error = %error,
-                "Response write error, removing connection from pool"
-            );
-            self.metrics.record_error(backend_id);
-            self.metrics.user_error(self.username());
-            conn.fail_backend();
-        } else if let ResponseConnectionReuse::QueuedBytes { len } =
-            crate::session::response_transfer::connection_reuse_after_response(&conn)
-        {
-            warn!(
-                client = %self.client_addr,
-                backend = backend_id.as_index(),
-                command_verb = ?request.verb(),
-                queued_bytes = len,
-                "Response write left queued backend bytes; retiring connection"
-            );
-            conn.fail_client();
-        } else {
-            debug!(
-                client = %self.client_addr,
-                backend = backend_id.as_index(),
-                command_verb = ?request.verb(),
-                "Response write error left backend connection reusable; releasing it back to pool"
-            );
-            let _ = conn.complete_success();
+        let reuse = crate::session::response_transfer::connection_reuse_after_response(&conn);
+        match error.pool_fate(reuse) {
+            BackendConnectionOutcome::BackendFailed => {
+                warn!(
+                    client = %self.client_addr,
+                    backend = backend_id.as_index(),
+                    command_verb = ?request.verb(),
+                    error = %error,
+                    "Response write error, removing connection from pool"
+                );
+                self.metrics.record_error(backend_id);
+                self.metrics.user_error(self.username());
+                conn.fail_backend();
+            }
+            BackendConnectionOutcome::BackendDirty => {
+                let ResponseConnectionReuse::QueuedBytes { len } = reuse else {
+                    unreachable!("dirty backend fate requires queued bytes");
+                };
+                warn!(
+                    client = %self.client_addr,
+                    backend = backend_id.as_index(),
+                    command_verb = ?request.verb(),
+                    queued_bytes = len,
+                    "Response write left queued backend bytes; retiring connection"
+                );
+                conn.fail_client();
+            }
+            BackendConnectionOutcome::BackendHealthy => {
+                debug!(
+                    client = %self.client_addr,
+                    backend = backend_id.as_index(),
+                    command_verb = ?request.verb(),
+                    "Response write error left backend connection reusable; releasing it back to pool"
+                );
+                let _ = conn.complete_success();
+            }
         }
 
         SessionError::from(error)
@@ -822,50 +830,62 @@ impl ClientSession {
         request: &RequestContext,
         backend_connection: Option<&mut Option<(BackendId, crate::pool::ConnectionGuard)>>,
     ) {
-        if let ResponseConnectionReuse::QueuedBytes { len } =
-            crate::session::response_transfer::connection_reuse_after_response(&conn)
+        match crate::session::response_transfer::connection_reuse_after_response(&conn).pool_fate()
         {
-            warn!(
-                client = %self.client_addr,
-                backend = backend_id.as_index(),
-                command_verb = ?request.verb(),
-                msg_id = ?request.message_id_value(),
-                connection_type = conn.connection_type(),
-                pending_bytes = conn.pending_bytes_len(),
-                queued_bytes = len,
-                "Direct per-command response left queued backend bytes; retiring connection"
-            );
-            conn.fail_client();
-        } else if let Some(slot) = backend_connection
-            && slot.is_none()
-        {
-            let status = conn.provider_status_counts();
-            debug!(
-                client = %self.client_addr,
-                backend = backend_id.as_index(),
-                command_verb = ?request.verb(),
-                msg_id = ?request.message_id_value(),
-                connection_type = conn.connection_type(),
-                pending_bytes = conn.pending_bytes_len(),
-                pool = %conn.provider_name(),
-                pool_available = status.available,
-                pool_size = status.size,
-                pool_max_size = status.max_size,
-                pool_waiting = status.waiting,
-                "Direct per-command response finished cleanly; keeping backend connection for this client batch"
-            );
-            *slot = Some((backend_id, conn));
-        } else {
-            debug!(
-                client = %self.client_addr,
-                backend = backend_id.as_index(),
-                command_verb = ?request.verb(),
-                msg_id = ?request.message_id_value(),
-                connection_type = conn.connection_type(),
-                pending_bytes = conn.pending_bytes_len(),
-                "Direct per-command response finished cleanly; releasing backend connection"
-            );
-            let _ = conn.complete_success();
+            BackendConnectionOutcome::BackendDirty => {
+                let ResponseConnectionReuse::QueuedBytes { len } =
+                    crate::session::response_transfer::connection_reuse_after_response(&conn)
+                else {
+                    unreachable!("dirty backend fate requires queued bytes");
+                };
+                warn!(
+                    client = %self.client_addr,
+                    backend = backend_id.as_index(),
+                    command_verb = ?request.verb(),
+                    msg_id = ?request.message_id_value(),
+                    connection_type = conn.connection_type(),
+                    pending_bytes = conn.pending_bytes_len(),
+                    queued_bytes = len,
+                    "Direct per-command response left queued backend bytes; retiring connection"
+                );
+                conn.fail_client();
+            }
+            BackendConnectionOutcome::BackendHealthy => {
+                if let Some(slot) = backend_connection
+                    && slot.is_none()
+                {
+                    let status = conn.provider_status_counts();
+                    debug!(
+                        client = %self.client_addr,
+                        backend = backend_id.as_index(),
+                        command_verb = ?request.verb(),
+                        msg_id = ?request.message_id_value(),
+                        connection_type = conn.connection_type(),
+                        pending_bytes = conn.pending_bytes_len(),
+                        pool = %conn.provider_name(),
+                        pool_available = status.available,
+                        pool_size = status.size,
+                        pool_max_size = status.max_size,
+                        pool_waiting = status.waiting,
+                        "Direct per-command response finished cleanly; keeping backend connection for this client batch"
+                    );
+                    *slot = Some((backend_id, conn));
+                } else {
+                    debug!(
+                        client = %self.client_addr,
+                        backend = backend_id.as_index(),
+                        command_verb = ?request.verb(),
+                        msg_id = ?request.message_id_value(),
+                        connection_type = conn.connection_type(),
+                        pending_bytes = conn.pending_bytes_len(),
+                        "Direct per-command response finished cleanly; releasing backend connection"
+                    );
+                    let _ = conn.complete_success();
+                }
+            }
+            BackendConnectionOutcome::BackendFailed => unreachable!(
+                "successful per-command response reuse cannot produce failed backend fate"
+            ),
         }
     }
 

--- a/src/session/handlers/hybrid.rs
+++ b/src/session/handlers/hybrid.rs
@@ -97,13 +97,10 @@ impl ClientSession {
         self.mode_state.switch_to_stateful();
 
         // Acquire backend connection (returns CommandGuard to track pending_count)
-        let (pooled_conn, backend_id, _pending_guard, provider) = self
+        let (mut conn_guard, backend_id, _pending_guard) = self
             .acquire_stateful_backend()
             .await
             .context("Failed to acquire backend for stateful mode")?;
-
-        // Wrap connection in guard — unreleased connections are removed from the pool.
-        let mut conn_guard = crate::pool::ConnectionGuard::new(pooled_conn, provider);
 
         // Start stateful session metrics tracking
         let _session_guard = StatefulSessionGuard::start(&self.metrics);
@@ -165,10 +162,9 @@ impl ClientSession {
     async fn acquire_stateful_backend(
         &self,
     ) -> Result<(
-        deadpool::managed::Object<crate::pool::deadpool_connection::TcpManager>,
+        crate::pool::ConnectionGuard,
         crate::types::BackendId,
         crate::router::CommandGuard,
-        crate::pool::DeadpoolConnectionProvider,
     )> {
         let router = self
             .router
@@ -187,9 +183,9 @@ impl ClientSession {
             .ok_or_else(|| anyhow::anyhow!("{}: {:?}", error::BACKEND_NOT_FOUND, backend_id))?;
 
         let provider = provider.clone();
-        let conn = provider.get_pooled_connection().await?;
+        let conn_guard = provider.checkout_connection_guard().await?;
 
-        Ok((conn, backend_id, pending_guard, provider))
+        Ok((conn_guard, backend_id, pending_guard))
     }
 }
 

--- a/src/session/handlers/hybrid.rs
+++ b/src/session/handlers/hybrid.rs
@@ -145,7 +145,7 @@ impl ClientSession {
 
         // H1: Only return connection to pool on success
         if result.is_ok() {
-            let _conn = conn_guard.release();
+            let _conn = conn_guard.complete_success();
         } // else: guard drops -> removes connection with replacement cooldown
 
         // Metrics guard automatically ends session via Drop

--- a/src/session/handlers/per_command.rs
+++ b/src/session/handlers/per_command.rs
@@ -100,16 +100,16 @@ impl BatchBackendConnection {
         &mut self.conn
     }
 
-    fn release(&mut self) {
+    fn complete_success(&mut self) {
         if let Some((_backend_id, conn)) = self.conn.take() {
-            let _ = conn.release();
+            let _ = conn.complete_success();
         }
     }
 }
 
 impl Drop for BatchBackendConnection {
     fn drop(&mut self) {
-        self.release();
+        self.complete_success();
     }
 }
 

--- a/src/session/handlers/per_command.rs
+++ b/src/session/handlers/per_command.rs
@@ -109,7 +109,9 @@ impl BatchBackendConnection {
 
 impl Drop for BatchBackendConnection {
     fn drop(&mut self) {
-        self.complete_success();
+        if let Some((_backend_id, conn)) = self.conn.take() {
+            conn.fail_backend();
+        }
     }
 }
 
@@ -520,7 +522,7 @@ impl ClientSession {
             return Ok(action);
         }
 
-        match self
+        let action = match self
             .process_pipelineable_batch(
                 router,
                 client_writer,
@@ -538,10 +540,12 @@ impl ClientSession {
                     batch,
                     &mut backend_connection,
                 )
-                .await
+                .await?
             }
-            action => Ok(action),
-        }
+            action => action,
+        };
+        backend_connection.complete_success();
+        Ok(action)
     }
 
     async fn handle_batch_rejections(
@@ -876,7 +880,67 @@ impl ClientSession {
 
 #[cfg(test)]
 mod tests {
+    use crate::pool::DeadpoolConnectionProvider;
     use crate::protocol::{RequestContext, ResponseWireLen, StatusCode};
+    use crate::types::BackendId;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+    use tokio::net::TcpListener;
+    use tokio::time::Duration;
+
+    async fn spawn_greeting_server() -> (u16, Arc<AtomicUsize>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let accept_count = Arc::new(AtomicUsize::new(0));
+        let count = Arc::clone(&accept_count);
+
+        tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                count.fetch_add(1, Ordering::SeqCst);
+                tokio::spawn(async move {
+                    let (read_half, mut write_half) = stream.into_split();
+                    let mut reader = BufReader::new(read_half);
+
+                    if write_half.write_all(b"200 Ready\r\n").await.is_err() {
+                        return;
+                    }
+
+                    let mut line = String::new();
+                    loop {
+                        line.clear();
+                        match reader.read_line(&mut line).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(_) => {
+                                let cmd = line.trim().to_ascii_uppercase();
+                                if cmd == "COMPRESS DEFLATE" {
+                                    let _ = write_half.write_all(b"500 Not supported\r\n").await;
+                                } else if cmd.starts_with("MODE") {
+                                    let _ = write_half.write_all(b"200 Posting allowed\r\n").await;
+                                } else if cmd.starts_with("QUIT") {
+                                    let _ = write_half.write_all(b"205 Goodbye\r\n").await;
+                                    break;
+                                } else if cmd.starts_with("DATE") {
+                                    let _ = write_half.write_all(b"111 20240101000000\r\n").await;
+                                } else {
+                                    let _ = write_half.write_all(b"200 OK\r\n").await;
+                                }
+                            }
+                        }
+                    }
+                });
+            }
+        });
+
+        (port, accept_count)
+    }
+
+    fn make_provider(port: u16) -> DeadpoolConnectionProvider {
+        DeadpoolConnectionProvider::builder("127.0.0.1", port)
+            .max_connections(5)
+            .build()
+            .unwrap()
+    }
 
     #[test]
     fn local_response_records_typed_status_and_wire_len() {
@@ -903,6 +967,35 @@ mod tests {
         let request = RequestContext::parse(b"GROUP alt.test\r\n").expect("valid request");
 
         assert_eq!(super::safe_command_log_label(&request), "GROUP");
+    }
+
+    #[tokio::test]
+    async fn batch_connection_cancel_retirees_connection_on_drop() {
+        let (port, accept_count) = spawn_greeting_server().await;
+        let provider = make_provider(port);
+        let conn = provider.checkout_connection_guard().await.unwrap();
+        assert_eq!(accept_count.load(Ordering::SeqCst), 1);
+
+        let handle = tokio::spawn(async move {
+            let _batch = super::BatchBackendConnection {
+                conn: Some((BackendId::from_index(0), conn)),
+            };
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            drop(_batch);
+        });
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        handle.abort();
+        let _ = handle.await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let next = provider.checkout_connection_guard().await.unwrap();
+        drop(next.complete_success());
+        assert_eq!(
+            accept_count.load(Ordering::SeqCst),
+            2,
+            "timeout/cancel cleanup must retire the batch connection instead of returning it to the pool"
+        );
     }
 
     #[test]

--- a/src/session/handlers/stateful.rs
+++ b/src/session/handlers/stateful.rs
@@ -230,10 +230,10 @@ impl ClientSession {
         use crate::protocol::BACKEND_UNAVAILABLE;
 
         // Acquire backend connection
-        let backend_conn = match provider.get_pooled_connection().await {
-            Ok(conn) => {
+        let mut conn_guard = match provider.checkout_connection_guard().await {
+            Ok(conn_guard) => {
                 debug!(server = server_name, "Got pooled connection");
-                conn
+                conn_guard
             }
             Err(e) => {
                 error!(server = server_name, client = %self.client_addr, error = %e, "Failed to get pooled connection");
@@ -246,9 +246,6 @@ impl ClientSession {
                 )));
             }
         };
-
-        // Wrap in guard — unreleased connections are removed from the pool.
-        let mut conn_guard = crate::pool::ConnectionGuard::new(backend_conn, provider.clone());
 
         // Split streams
         let (client_read, client_write) = client_stream.split();

--- a/src/session/handlers/stateful.rs
+++ b/src/session/handlers/stateful.rs
@@ -266,7 +266,7 @@ impl ClientSession {
 
         // H2: Only return connection to pool on success
         if result.is_ok() {
-            let _conn = conn_guard.release();
+            let _conn = conn_guard.complete_success();
         } // else: guard drops -> removes connection with replacement cooldown
 
         result.map_err(crate::session::SessionError::from)

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -47,6 +47,7 @@
 //! # fn example() -> anyhow::Result<()> {
 //! let addr: SocketAddr = "127.0.0.1:50000".parse()?;
 //! let buffer_pool = BufferPool::new(BufferSize::try_new(8192)?, 10);
+
 //! let router = Arc::new(BackendSelector::new());
 //! let auth = Arc::new(AuthHandler::new(None, None)?);
 //! let metrics = MetricsCollector::new(1);
@@ -163,6 +164,8 @@
 //!   - Routes command to backend
 //!   - Handles connection pool management
 //!   - Distinguishes backend errors from client disconnects
+
+#![deny(clippy::disallowed_methods)]
 
 pub mod auth_state;
 pub(crate) mod backend;

--- a/src/session/multiline_framing.rs
+++ b/src/session/multiline_framing.rs
@@ -60,7 +60,7 @@ impl ResponseWriteStats {
     }
 
     fn record(self) {
-        crate::pool::buffer::record_response_write_metrics(
+        crate::pool::buffer::record_response_write_metrics_internal(
             self.chunk_count,
             self.bytes_written,
             self.tiny_chunks,
@@ -1396,7 +1396,7 @@ where
         let mut stats = ResponseWriteStats::default();
         stats.add_buffered_response(response);
         response
-            .write_all_to(writer)
+            .write_all_to_recording(writer)
             .await
             .map_err(crate::session::response_transfer::ResponseTransferError::ClientDisconnect)?;
         response.clear();
@@ -1490,7 +1490,7 @@ where
             framed.push_from_buffer(io_buffer, conn, response, pool)?;
             let mut stats = ResponseWriteStats::default();
             stats.add_buffered_response(response);
-            response.write_all_to(writer).await.map_err(
+            response.write_all_to_recording(writer).await.map_err(
                 crate::session::response_transfer::ResponseTransferError::ClientDisconnect,
             )?;
             stats.record();
@@ -1520,7 +1520,7 @@ where
                 framed.push_from_buffer(io_buffer, conn, response, pool, initial_len)?;
                 let mut stats = ResponseWriteStats::default();
                 stats.add_buffered_response(response);
-                response.write_all_to(writer).await.map_err(
+                response.write_all_to_recording(writer).await.map_err(
                     crate::session::response_transfer::ResponseTransferError::ClientDisconnect,
                 )?;
                 stats.record();
@@ -1596,7 +1596,7 @@ where
                     framed.push_from_buffer(io_buffer, conn, response, pool, n)?;
                     let mut stats = ResponseWriteStats::default();
                     stats.add_buffered_response(response);
-                    response.write_all_to(writer).await.map_err(
+                    response.write_all_to_recording(writer).await.map_err(
                         crate::session::response_transfer::ResponseTransferError::ClientDisconnect,
                     )?;
                     stats.record();

--- a/src/session/multiline_framing.rs
+++ b/src/session/multiline_framing.rs
@@ -31,6 +31,61 @@ pub(crate) const CAPABILITIES_WITHOUT_AUTHINFO_RESPONSE: &[u8] =
 pub(crate) const CAPABILITIES_WITH_AUTHINFO_RESPONSE: &[u8] =
     b"101 Capability list:\r\nVERSION 2\r\nREADER\r\nAUTHINFO USER PASS\r\nOVER\r\nHDR\r\n.\r\n";
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct ResponseWriteStats {
+    chunk_count: usize,
+    bytes_written: usize,
+    tiny_chunks: usize,
+    tiny_chunk_bytes: usize,
+    small_chunks: usize,
+    small_chunk_bytes: usize,
+}
+
+impl ResponseWriteStats {
+    fn add_chunk(&mut self, bytes: usize) {
+        let (tiny_chunks, tiny_chunk_bytes, small_chunks, small_chunk_bytes) =
+            crate::pool::buffer::classify_response_write_chunk(bytes);
+        self.chunk_count += 1;
+        self.bytes_written += bytes;
+        self.tiny_chunks += tiny_chunks;
+        self.tiny_chunk_bytes += tiny_chunk_bytes;
+        self.small_chunks += small_chunks;
+        self.small_chunk_bytes += small_chunk_bytes;
+    }
+
+    fn add_buffered_response(&mut self, response: &crate::pool::ChunkedResponse) {
+        for chunk in response.iter_chunks() {
+            self.add_chunk(chunk.len());
+        }
+    }
+
+    fn record(self) {
+        crate::pool::buffer::record_response_write_metrics(
+            self.chunk_count,
+            self.bytes_written,
+            self.tiny_chunks,
+            self.tiny_chunk_bytes,
+            self.small_chunks,
+            self.small_chunk_bytes,
+        );
+    }
+
+    const fn bytes_written_u64(self) -> u64 {
+        self.bytes_written as u64
+    }
+}
+
+impl std::ops::AddAssign for ResponseWriteStats {
+    fn add_assign(&mut self, rhs: Self) {
+        self.chunk_count += rhs.chunk_count;
+        self.bytes_written += rhs.bytes_written;
+        self.tiny_chunks += rhs.tiny_chunks;
+        self.tiny_chunk_bytes += rhs.tiny_chunk_bytes;
+        self.small_chunks += rhs.small_chunks;
+        self.small_chunk_bytes += rhs.small_chunk_bytes;
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum PackedPendingBytesPolicy {
     Reject,
@@ -105,7 +160,7 @@ impl CompleteMultilineWireChunk {
         conn: &mut crate::stream::ConnectionStream,
         pool: &crate::pool::BufferPool,
         total_len: usize,
-    ) -> Result<u64, crate::session::response_transfer::ResponseTransferError>
+    ) -> Result<ResponseWriteStats, crate::session::response_transfer::ResponseTransferError>
     where
         W: AsyncWrite + Unpin,
     {
@@ -178,7 +233,7 @@ async fn write_response_chunk_preserving_suffix_on_error<W>(
     total_len: usize,
     response: &Range<usize>,
     next_response_input: &Range<usize>,
-) -> Result<u64, crate::session::response_transfer::ResponseTransferError>
+) -> Result<ResponseWriteStats, crate::session::response_transfer::ResponseTransferError>
 where
     W: AsyncWrite + Unpin,
 {
@@ -189,10 +244,10 @@ where
             crate::session::response_transfer::ResponseTransferError::ClientDisconnect(err),
         );
     }
-    crate::pool::buffer::record_non_owned_response_write_chunk(chunk.len());
-    let chunk_len = chunk.len() as u64;
+    let mut stats = ResponseWriteStats::default();
+    stats.add_chunk(chunk.len());
     queue_packed_next_response_input(io_buffer, conn, pool, next_response_input, total_len)?;
-    Ok(chunk_len)
+    Ok(stats)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -211,12 +266,12 @@ impl IncompleteMultilineWireChunk {
         conn: &mut crate::stream::ConnectionStream,
         pool: &crate::pool::BufferPool,
         backend_id: crate::types::BackendId,
-    ) -> Result<u64, crate::session::response_transfer::ResponseTransferError>
+    ) -> Result<ResponseWriteStats, crate::session::response_transfer::ResponseTransferError>
     where
         W: AsyncWrite + Unpin,
     {
         let mut bytes_received = 0;
-        let bytes_written = {
+        let mut stats = {
             let response = &io_buffer[..current_len][self.response.clone()];
             bytes_received += response.len() as u64;
             if let Err(e) = writer.write_all(response).await {
@@ -233,11 +288,11 @@ impl IncompleteMultilineWireChunk {
                     crate::session::response_transfer::ResponseTransferError::ClientDisconnect(e),
                 );
             }
-            crate::pool::buffer::record_non_owned_response_write_chunk(response.len());
-            response.len() as u64
+            let mut stats = ResponseWriteStats::default();
+            stats.add_chunk(response.len());
+            stats
         };
 
-        let mut bytes_written = bytes_written;
         let mut continuation = Some(self);
         loop {
             let n = io_buffer.read_from(conn).await.map_err(|e| {
@@ -261,7 +316,10 @@ impl IncompleteMultilineWireChunk {
                     return complete
                         .write_from(writer, io_buffer, conn, pool, n)
                         .await
-                        .map(|bytes| bytes_written + bytes);
+                        .map(|next| {
+                            stats += next;
+                            stats
+                        });
                 }
                 FramedMultilineChunk::Incomplete(incomplete) => {
                     let response = &io_buffer[incomplete.response.clone()];
@@ -282,8 +340,7 @@ impl IncompleteMultilineWireChunk {
                             ),
                         );
                     }
-                    crate::pool::buffer::record_non_owned_response_write_chunk(response.len());
-                    bytes_written += response.len() as u64;
+                    stats.add_chunk(response.len());
                     continuation = Some(incomplete);
                 }
             }
@@ -300,9 +357,9 @@ impl IncompleteMultilineWireChunk {
         conn: &mut crate::stream::ConnectionStream,
         pool: &crate::pool::BufferPool,
         backend_id: crate::types::BackendId,
-        mut bytes_written: u64,
+        mut stats: ResponseWriteStats,
         mut bytes_received: u64,
-    ) -> Result<u64, crate::session::response_transfer::ResponseTransferError>
+    ) -> Result<ResponseWriteStats, crate::session::response_transfer::ResponseTransferError>
     where
         W: AsyncWrite + Unpin,
     {
@@ -322,8 +379,7 @@ impl IncompleteMultilineWireChunk {
                 crate::session::response_transfer::ResponseTransferError::ClientDisconnect(e),
             );
         }
-        crate::pool::buffer::record_non_owned_response_write_chunk(response.len());
-        bytes_written += response.len() as u64;
+        stats.add_chunk(response.len());
         self.write_after_current_chunk(
             writer,
             framer,
@@ -331,7 +387,7 @@ impl IncompleteMultilineWireChunk {
             conn,
             pool,
             backend_id,
-            bytes_written,
+            stats,
             bytes_received,
         )
         .await
@@ -346,9 +402,9 @@ impl IncompleteMultilineWireChunk {
         conn: &mut crate::stream::ConnectionStream,
         pool: &crate::pool::BufferPool,
         backend_id: crate::types::BackendId,
-        mut bytes_written: u64,
+        mut stats: ResponseWriteStats,
         mut bytes_received: u64,
-    ) -> Result<u64, crate::session::response_transfer::ResponseTransferError>
+    ) -> Result<ResponseWriteStats, crate::session::response_transfer::ResponseTransferError>
     where
         W: AsyncWrite + Unpin,
     {
@@ -375,7 +431,10 @@ impl IncompleteMultilineWireChunk {
                     return complete
                         .write_from(writer, io_buffer, conn, pool, n)
                         .await
-                        .map(|bytes| bytes_written + bytes);
+                        .map(|next| {
+                            stats += next;
+                            stats
+                        });
                 }
                 FramedMultilineChunk::Incomplete(incomplete) => {
                     let response = &io_buffer[incomplete.response.clone()];
@@ -396,8 +455,7 @@ impl IncompleteMultilineWireChunk {
                             ),
                         );
                     }
-                    crate::pool::buffer::record_non_owned_response_write_chunk(response.len());
-                    bytes_written += response.len() as u64;
+                    stats.add_chunk(response.len());
                     continuation = Some(incomplete);
                 }
             }
@@ -439,7 +497,7 @@ impl FramedSingleLineChunk {
         conn: &mut crate::stream::ConnectionStream,
         pool: &crate::pool::BufferPool,
         total_len: usize,
-    ) -> Result<u64, crate::session::response_transfer::ResponseTransferError>
+    ) -> Result<ResponseWriteStats, crate::session::response_transfer::ResponseTransferError>
     where
         W: AsyncWrite + Unpin,
     {
@@ -1176,16 +1234,18 @@ where
     })?;
 
     if let ResponseFrame::SingleLine { framed, .. } = &frame {
-        return framed
+        let stats = framed
             .write_from(writer, io_buffer, conn, pool, initial_len)
-            .await;
+            .await?;
+        stats.record();
+        return Ok(stats.bytes_written_u64());
     }
 
-    match framer.frame_initial_multiline_chunk(&io_buffer[..initial_len]) {
+    let stats = match framer.frame_initial_multiline_chunk(&io_buffer[..initial_len]) {
         FramedMultilineChunk::Complete(complete) => {
             complete
                 .write_from(writer, io_buffer, conn, pool, initial_len)
-                .await
+                .await?
         }
         FramedMultilineChunk::Incomplete(incomplete) => {
             incomplete
@@ -1198,9 +1258,11 @@ where
                     pool,
                     backend_id,
                 )
-                .await
+                .await?
         }
-    }
+    };
+    stats.record();
+    Ok(stats.bytes_written_u64())
 }
 
 async fn consume_remaining_multiline_response(
@@ -1330,14 +1392,15 @@ where
     async fn flush_unretained_prefix(
         writer: &mut W,
         response: &mut crate::pool::ChunkedResponse,
-    ) -> Result<u64, crate::session::response_transfer::ResponseTransferError> {
-        let bytes = response.len() as u64;
+    ) -> Result<ResponseWriteStats, crate::session::response_transfer::ResponseTransferError> {
+        let mut stats = ResponseWriteStats::default();
+        stats.add_buffered_response(response);
         response
             .write_all_to(writer)
             .await
             .map_err(crate::session::response_transfer::ResponseTransferError::ClientDisconnect)?;
         response.clear();
-        Ok(bytes)
+        Ok(stats)
     }
 
     async fn flush_unretained_prefix_before_complete(
@@ -1348,9 +1411,9 @@ where
         conn: &mut crate::stream::ConnectionStream,
         pool: &crate::pool::BufferPool,
         total_len: usize,
-    ) -> Result<u64, crate::session::response_transfer::ResponseTransferError> {
+    ) -> Result<ResponseWriteStats, crate::session::response_transfer::ResponseTransferError> {
         match Self::flush_unretained_prefix(writer, response).await {
-            Ok(bytes_written) => Ok(bytes_written),
+            Ok(stats) => Ok(stats),
             Err(crate::session::response_transfer::ResponseTransferError::ClientDisconnect(e)) => {
                 framed.observe_from_buffer(io_buffer, conn, pool, total_len)?;
                 Err(crate::session::response_transfer::ResponseTransferError::ClientDisconnect(e))
@@ -1369,12 +1432,12 @@ where
         conn: &mut crate::stream::ConnectionStream,
         backend_id: crate::types::BackendId,
     ) -> Result<
-        (u64, IncompleteMultilineWireChunk),
+        (ResponseWriteStats, IncompleteMultilineWireChunk),
         crate::session::response_transfer::ResponseTransferError,
     > {
         let bytes_received = response.len() as u64;
         match Self::flush_unretained_prefix(writer, response).await {
-            Ok(bytes_written) => Ok((bytes_written, incomplete)),
+            Ok(stats) => Ok((stats, incomplete)),
             Err(crate::session::response_transfer::ResponseTransferError::ClientDisconnect(e)) => {
                 consume_remaining_multiline_response(
                     framer,
@@ -1425,18 +1488,20 @@ where
         response.clear();
         if let ResponseFrame::SingleLine { framed, .. } = &frame {
             framed.push_from_buffer(io_buffer, conn, response, pool)?;
-            let bytes = response.len() as u64;
+            let mut stats = ResponseWriteStats::default();
+            stats.add_buffered_response(response);
             response.write_all_to(writer).await.map_err(
                 crate::session::response_transfer::ResponseTransferError::ClientDisconnect,
             )?;
-            return Ok((bytes, true));
+            stats.record();
+            return Ok((stats.bytes_written_u64(), true));
         }
 
         let mut continuation = match framer.frame_initial_multiline_chunk(&io_buffer[..initial_len])
         {
             FramedMultilineChunk::Complete(framed) => {
                 if Self::would_exceed_retention(response, framed.response.len(), retention_limit) {
-                    let bytes_written = Self::flush_unretained_prefix_before_complete(
+                    let mut stats = Self::flush_unretained_prefix_before_complete(
                         writer,
                         response,
                         &framed,
@@ -1446,17 +1511,20 @@ where
                         initial_len,
                     )
                     .await?;
-                    let current = framed
+                    stats += framed
                         .write_from(writer, io_buffer, conn, pool, initial_len)
                         .await?;
-                    return Ok((bytes_written + current, false));
+                    stats.record();
+                    return Ok((stats.bytes_written_u64(), false));
                 }
                 framed.push_from_buffer(io_buffer, conn, response, pool, initial_len)?;
-                let bytes = response.len() as u64;
+                let mut stats = ResponseWriteStats::default();
+                stats.add_buffered_response(response);
                 response.write_all_to(writer).await.map_err(
                     crate::session::response_transfer::ResponseTransferError::ClientDisconnect,
                 )?;
-                return Ok((bytes, true));
+                stats.record();
+                return Ok((stats.bytes_written_u64(), true));
             }
             FramedMultilineChunk::Incomplete(incomplete) => {
                 if Self::would_exceed_retention(
@@ -1464,7 +1532,7 @@ where
                     incomplete.response.len(),
                     retention_limit,
                 ) {
-                    let (bytes_written, incomplete) = Self::flush_unretained_prefix_or_drain(
+                    let (stats, incomplete) = Self::flush_unretained_prefix_or_drain(
                         writer,
                         response,
                         &mut framer,
@@ -1474,8 +1542,8 @@ where
                         backend_id,
                     )
                     .await?;
-                    let bytes_received = bytes_written;
-                    let total = incomplete
+                    let bytes_received = stats.bytes_written_u64();
+                    let stats = incomplete
                         .write_current_and_after(
                             writer,
                             initial_len,
@@ -1484,11 +1552,12 @@ where
                             conn,
                             pool,
                             backend_id,
-                            bytes_written,
+                            stats,
                             bytes_received,
                         )
                         .await?;
-                    return Ok((total, false));
+                    stats.record();
+                    return Ok((stats.bytes_written_u64(), false));
                 }
                 incomplete.push_buffer_to(response, pool, io_buffer);
                 Some(incomplete)
@@ -1516,19 +1585,22 @@ where
                         framed.response.len(),
                         retention_limit,
                     ) {
-                        let bytes_written = Self::flush_unretained_prefix_before_complete(
+                        let mut stats = Self::flush_unretained_prefix_before_complete(
                             writer, response, &framed, io_buffer, conn, pool, n,
                         )
                         .await?;
-                        let current = framed.write_from(writer, io_buffer, conn, pool, n).await?;
-                        return Ok((bytes_written + current, false));
+                        stats += framed.write_from(writer, io_buffer, conn, pool, n).await?;
+                        stats.record();
+                        return Ok((stats.bytes_written_u64(), false));
                     }
                     framed.push_from_buffer(io_buffer, conn, response, pool, n)?;
-                    let bytes = response.len() as u64;
+                    let mut stats = ResponseWriteStats::default();
+                    stats.add_buffered_response(response);
                     response.write_all_to(writer).await.map_err(
                         crate::session::response_transfer::ResponseTransferError::ClientDisconnect,
                     )?;
-                    return Ok((bytes, true));
+                    stats.record();
+                    return Ok((stats.bytes_written_u64(), true));
                 }
                 FramedMultilineChunk::Incomplete(incomplete) => {
                     if Self::would_exceed_retention(
@@ -1536,7 +1608,7 @@ where
                         incomplete.response.len(),
                         retention_limit,
                     ) {
-                        let (bytes_written, incomplete) = Self::flush_unretained_prefix_or_drain(
+                        let (stats, incomplete) = Self::flush_unretained_prefix_or_drain(
                             writer,
                             response,
                             &mut framer,
@@ -1546,8 +1618,8 @@ where
                             backend_id,
                         )
                         .await?;
-                        let bytes_received = bytes_written;
-                        let total = incomplete
+                        let bytes_received = stats.bytes_written_u64();
+                        let stats = incomplete
                             .write_current_and_after(
                                 writer,
                                 n,
@@ -1556,11 +1628,12 @@ where
                                 conn,
                                 pool,
                                 backend_id,
-                                bytes_written,
+                                stats,
                                 bytes_received,
                             )
                             .await?;
-                        return Ok((total, false));
+                        stats.record();
+                        return Ok((stats.bytes_written_u64(), false));
                     }
                     incomplete.push_buffer_to(response, pool, io_buffer);
                     Some(incomplete)
@@ -1568,7 +1641,10 @@ where
             };
         }
 
-        Ok((response.len() as u64, true))
+        let mut stats = ResponseWriteStats::default();
+        stats.add_buffered_response(response);
+        stats.record();
+        Ok((stats.bytes_written_u64(), true))
     }
 }
 
@@ -2619,7 +2695,7 @@ mod tests {
             .await
             .expect("complete response should write");
 
-        assert_eq!(written, response_len as u64);
+        assert_eq!(written.bytes_written_u64(), response_len as u64);
         assert_eq!(writer, &chunk[..response_len]);
         assert_eq!(conn.pending_bytes_len(), b"223 0 <next>\r\n".len());
         let metrics = crate::pool::buffer::hot_path_allocation_metrics_snapshot();
@@ -2646,7 +2722,7 @@ mod tests {
             .await
             .expect("single-line response should write");
 
-        assert_eq!(written, response_len as u64);
+        assert_eq!(written.bytes_written_u64(), response_len as u64);
         assert_eq!(writer, &chunk[..response_len]);
         assert_eq!(conn.pending_bytes_len(), b"223 0 <next>\r\n".len());
         let metrics = crate::pool::buffer::hot_path_allocation_metrics_snapshot();
@@ -2840,6 +2916,95 @@ mod tests {
             1,
             "draining pooled pending input should return the original buffer"
         );
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn write_response_single_line_records_response_write_metrics() {
+        let _guard = crate::pool::buffer::response_write_metrics_test_guard();
+        crate::pool::buffer::reset_response_write_metrics();
+        crate::pool::buffer::set_response_write_metrics_enabled(true);
+
+        let response = b"223 0 <first>\r\n";
+        let request = crate::protocol::RequestContext::parse(b"STAT <test@example>\r\n")
+            .expect("valid request");
+        let pool = make_pool();
+        let mut io_buffer = pool.acquire();
+        io_buffer.copy_from_slice(response);
+        let mut conn = loopback_connection_stream().await;
+        let mut writer = Vec::new();
+
+        let written = write_response(
+            &request,
+            &mut io_buffer,
+            &mut conn,
+            &mut writer,
+            &pool,
+            crate::types::BackendId::from_index(1),
+        )
+        .await
+        .expect("single-line response should write");
+
+        let metrics = crate::pool::buffer::response_write_metrics_snapshot();
+        assert_eq!(written, response.len() as u64);
+        assert_eq!(metrics.responses, 1);
+        assert_eq!(metrics.single_chunk_responses, 1);
+        assert_eq!(metrics.multi_chunk_responses, 0);
+        assert_eq!(metrics.chunks_written, 1);
+        assert_eq!(metrics.bytes_written, response.len());
+        assert_eq!(metrics.tiny_chunks, 1);
+        assert_eq!(metrics.tiny_chunk_bytes, response.len());
+        assert_eq!(metrics.small_chunks, 1);
+        assert_eq!(metrics.small_chunk_bytes, response.len());
+        assert_eq!(metrics.max_chunks_per_response, 1);
+
+        crate::pool::buffer::set_response_write_metrics_enabled(false);
+        crate::pool::buffer::reset_response_write_metrics();
+    }
+
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)]
+    async fn write_response_multiline_records_multi_chunk_response_write_metrics() {
+        let _guard = crate::pool::buffer::response_write_metrics_test_guard();
+        crate::pool::buffer::reset_response_write_metrics();
+        crate::pool::buffer::set_response_write_metrics_enabled(true);
+
+        let request = crate::protocol::RequestContext::parse(b"ARTICLE <test@example>\r\n")
+            .expect("valid request");
+        let pool = make_pool();
+        let mut io_buffer = pool.acquire();
+        io_buffer.copy_from_slice(b"220 article\r\n");
+        let mut conn = mock_backend_conn(vec![b"body\r\n.\r\n".to_vec()]).await;
+        let mut writer = Vec::new();
+
+        let written = write_response(
+            &request,
+            &mut io_buffer,
+            &mut conn,
+            &mut writer,
+            &pool,
+            crate::types::BackendId::from_index(1),
+        )
+        .await
+        .expect("multiline response should write");
+
+        let metrics = crate::pool::buffer::response_write_metrics_snapshot();
+        let expected = b"220 article\r\nbody\r\n.\r\n";
+        assert_eq!(written, expected.len() as u64);
+        assert_eq!(writer, expected);
+        assert_eq!(metrics.responses, 1);
+        assert_eq!(metrics.single_chunk_responses, 0);
+        assert_eq!(metrics.multi_chunk_responses, 1);
+        assert_eq!(metrics.chunks_written, 2);
+        assert_eq!(metrics.bytes_written, expected.len());
+        assert_eq!(metrics.tiny_chunks, 2);
+        assert_eq!(metrics.tiny_chunk_bytes, expected.len());
+        assert_eq!(metrics.small_chunks, 2);
+        assert_eq!(metrics.small_chunk_bytes, expected.len());
+        assert_eq!(metrics.max_chunks_per_response, 2);
+
+        crate::pool::buffer::set_response_write_metrics_enabled(false);
+        crate::pool::buffer::reset_response_write_metrics();
     }
 
     #[tokio::test]

--- a/src/session/multiline_framing.rs
+++ b/src/session/multiline_framing.rs
@@ -6,6 +6,8 @@
 //! If a response is incomplete, the same framer state is fed the next backend
 //! buffer until it can produce a typed complete or incomplete response chunk.
 
+#![allow(clippy::disallowed_methods)]
+
 use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::ops::Range;
@@ -107,19 +109,16 @@ impl CompleteMultilineWireChunk {
     where
         W: AsyncWrite + Unpin,
     {
-        let response = &io_buffer[..total_len][self.response.clone()];
-        writer
-            .write_all(response)
-            .await
-            .map_err(crate::session::response_transfer::ResponseTransferError::ClientDisconnect)?;
-        crate::pool::buffer::record_non_owned_response_write_chunk(response.len());
-        let response_len = response.len() as u64;
-        if self.next_response_input.start < total_len {
-            let old = std::mem::replace(io_buffer, pool.acquire());
-            conn.queue_pooled_pending_bytes_first(old, self.next_response_input.clone())
-                .map_err(crate::session::response_transfer::ResponseTransferError::Io)?;
-        }
-        Ok(response_len)
+        write_response_chunk_preserving_suffix_on_error(
+            writer,
+            io_buffer,
+            conn,
+            pool,
+            total_len,
+            &self.response,
+            &self.next_response_input,
+        )
+        .await
     }
 
     fn push_from_buffer(
@@ -135,6 +134,7 @@ impl CompleteMultilineWireChunk {
             conn.queue_pending_bytes_first(&old[self.next_response_input.clone()])
                 .map_err(crate::session::response_transfer::ResponseTransferError::Io)?;
         }
+
         response.push_buffer_range(old, self.response.clone());
         Ok(())
     }
@@ -153,6 +153,46 @@ impl CompleteMultilineWireChunk {
         }
         Ok(())
     }
+}
+
+fn queue_packed_next_response_input(
+    io_buffer: &mut crate::pool::PooledBuffer,
+    conn: &mut crate::stream::ConnectionStream,
+    pool: &crate::pool::BufferPool,
+    next_response_input: &Range<usize>,
+    total_len: usize,
+) -> Result<(), crate::session::response_transfer::ResponseTransferError> {
+    if next_response_input.start < total_len {
+        let old = std::mem::replace(io_buffer, pool.acquire());
+        conn.queue_pooled_pending_bytes_first(old, next_response_input.clone())
+            .map_err(crate::session::response_transfer::ResponseTransferError::Io)?;
+    }
+    Ok(())
+}
+
+async fn write_response_chunk_preserving_suffix_on_error<W>(
+    writer: &mut W,
+    io_buffer: &mut crate::pool::PooledBuffer,
+    conn: &mut crate::stream::ConnectionStream,
+    pool: &crate::pool::BufferPool,
+    total_len: usize,
+    response: &Range<usize>,
+    next_response_input: &Range<usize>,
+) -> Result<u64, crate::session::response_transfer::ResponseTransferError>
+where
+    W: AsyncWrite + Unpin,
+{
+    let chunk = &io_buffer[..total_len][response.clone()];
+    if let Err(err) = writer.write_all(chunk).await {
+        queue_packed_next_response_input(io_buffer, conn, pool, next_response_input, total_len)?;
+        return Err(
+            crate::session::response_transfer::ResponseTransferError::ClientDisconnect(err),
+        );
+    }
+    crate::pool::buffer::record_non_owned_response_write_chunk(chunk.len());
+    let chunk_len = chunk.len() as u64;
+    queue_packed_next_response_input(io_buffer, conn, pool, next_response_input, total_len)?;
+    Ok(chunk_len)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -403,19 +443,16 @@ impl FramedSingleLineChunk {
     where
         W: AsyncWrite + Unpin,
     {
-        let response = &io_buffer[..total_len][self.response.clone()];
-        writer
-            .write_all(response)
-            .await
-            .map_err(crate::session::response_transfer::ResponseTransferError::ClientDisconnect)?;
-        crate::pool::buffer::record_non_owned_response_write_chunk(response.len());
-        let response_len = response.len() as u64;
-        if self.next_response_input.start < total_len {
-            let old = std::mem::replace(io_buffer, pool.acquire());
-            conn.queue_pooled_pending_bytes_first(old, self.next_response_input.clone())
-                .map_err(crate::session::response_transfer::ResponseTransferError::Io)?;
-        }
-        Ok(response_len)
+        write_response_chunk_preserving_suffix_on_error(
+            writer,
+            io_buffer,
+            conn,
+            pool,
+            total_len,
+            &self.response,
+            &self.next_response_input,
+        )
+        .await
     }
 
     fn push_from_buffer(
@@ -1026,7 +1063,7 @@ impl<'a> IsolatedMultilineResponse<'a> {
 }
 
 #[cfg(test)]
-pub(crate) async fn capture_response(
+async fn capture_response(
     request: &crate::protocol::RequestContext,
     io_buffer: &mut crate::pool::PooledBuffer,
     conn: &mut crate::stream::ConnectionStream,
@@ -2617,6 +2654,105 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn complete_multiline_write_client_error_preserves_packed_suffix() {
+        let chunk = b"220 article\r\nbody\r\n.\r\n223 0 <next>\r\n";
+        let response_len = b"220 article\r\nbody\r\n.\r\n".len();
+        let framed = CompleteMultilineWireChunk {
+            response: 0..response_len,
+            next_response_input: response_len..chunk.len(),
+        };
+        let pool = make_pool();
+        let mut io_buffer = pool.acquire();
+        io_buffer.copy_from_slice(chunk);
+        let mut conn = loopback_connection_stream().await;
+        let mut writer = FailingWriter;
+
+        let err = framed
+            .write_from(&mut writer, &mut io_buffer, &mut conn, &pool, chunk.len())
+            .await;
+
+        assert!(matches!(
+            err,
+            Err(ResponseTransferError::ClientDisconnect(_))
+        ));
+        assert_eq!(conn.pending_bytes_len(), b"223 0 <next>\r\n".len());
+    }
+
+    #[tokio::test]
+    async fn single_line_write_client_error_preserves_packed_suffix() {
+        let chunk = b"223 0 <first>\r\n223 0 <next>\r\n";
+        let response_len = b"223 0 <first>\r\n".len();
+        let framed = FramedSingleLineChunk {
+            response: 0..response_len,
+            next_response_input: response_len..chunk.len(),
+        };
+        let pool = make_pool();
+        let mut io_buffer = pool.acquire();
+        io_buffer.copy_from_slice(chunk);
+        let mut conn = loopback_connection_stream().await;
+        let mut writer = FailingWriter;
+
+        let err = framed
+            .write_from(&mut writer, &mut io_buffer, &mut conn, &pool, chunk.len())
+            .await;
+
+        assert!(matches!(
+            err,
+            Err(ResponseTransferError::ClientDisconnect(_))
+        ));
+        assert_eq!(conn.pending_bytes_len(), b"223 0 <next>\r\n".len());
+    }
+
+    #[tokio::test]
+    async fn complete_multiline_split_boundaries_preserve_packed_suffix_on_write_error() {
+        let first_response = b"220 article\r\nbody\r\n.\r\n";
+        let next_response = b"223 0 <next>\r\n";
+        let pool = make_pool();
+
+        for split in 1..first_response.len() {
+            let initial = &first_response[..split];
+            let mut continuation = Vec::from(&first_response[split..]);
+            continuation.extend_from_slice(next_response);
+            let mut framer = MultilineFramer::default();
+            let prior = match framer.frame_initial_multiline_chunk(initial) {
+                FramedMultilineChunk::Incomplete(prior) => prior,
+                FramedMultilineChunk::Complete(_) => panic!("split={split} unexpectedly complete"),
+            };
+            let complete = match framer.frame_next_multiline_chunk(prior, &continuation) {
+                FramedMultilineChunk::Complete(complete) => complete,
+                FramedMultilineChunk::Incomplete(_) => {
+                    panic!("split={split} did not complete on continuation")
+                }
+            };
+
+            let mut io_buffer = pool.acquire();
+            io_buffer.copy_from_slice(&continuation);
+            let mut conn = loopback_connection_stream().await;
+            let mut writer = FailingWriter;
+
+            let err = complete
+                .write_from(
+                    &mut writer,
+                    &mut io_buffer,
+                    &mut conn,
+                    &pool,
+                    continuation.len(),
+                )
+                .await;
+
+            assert!(matches!(
+                err,
+                Err(ResponseTransferError::ClientDisconnect(_))
+            ));
+            assert_eq!(
+                conn.pending_bytes_len(),
+                next_response.len(),
+                "split={split}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn write_response_complete_multiline_queues_packed_suffix_as_pooled_input() {
         let first_response = b"220 article\r\nbody\r\n.\r\n";
         let next_response = b"223 0 <next>\r\n";
@@ -2941,6 +3077,22 @@ mod tests {
             violations.is_empty(),
             "raw multiline boundary scanner shapes escaped multiline_framing.rs:\n{}",
             violations.join("\n")
+        );
+    }
+
+    #[test]
+    fn framed_write_paths_use_shared_suffix_preservation_chokepoint() {
+        let source_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("src")
+            .join("session")
+            .join("multiline_framing.rs");
+        let source = std::fs::read_to_string(source_path).expect("read multiline_framing source");
+        let delegations = source
+            .match_indices("write_response_chunk_preserving_suffix_on_error(")
+            .count();
+        assert!(
+            delegations >= 3,
+            "single-line and complete-multiline write paths must delegate through the shared suffix-preservation helper"
         );
     }
 

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -214,19 +214,18 @@ async fn execute_backend_query(
     request: &RequestContext,
 ) -> Result<QueryAttemptResult, ()> {
     let backend_id = backend.backend_id();
-    let Ok(conn_raw) = provider.get_pooled_connection().await else {
+    let Ok(mut conn) = provider.checkout_connection_guard().await else {
         return Ok(QueryAttemptResult::Error);
     };
-    let mut conn = crate::pool::ConnectionGuard::new(conn_raw, provider.clone());
 
     let mut buffer = deps.buffer_pool.acquire();
 
     let response = if should_sample_backend_timing() {
-        backend::send_request_timed(&mut **conn, request, &mut buffer)
+        backend::execute_request_classified_timed(&mut **conn, request, &mut buffer)
             .await
             .map(|(response, ttfb, send, recv)| (response, Some((ttfb, send, recv))))
     } else {
-        backend::send_request(&mut **conn, request, &mut buffer)
+        backend::execute_request_classified(&mut **conn, request, &mut buffer)
             .await
             .map(|response| (response, None))
     };

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -235,7 +235,7 @@ async fn execute_backend_query(
         Ok((response, timings)) => {
             let Some(status_code) = response.status_code() else {
                 response.log_warnings(&buffer, "adaptive-precheck", backend_id);
-                conn.retire_with_cooldown();
+                conn.fail_backend();
                 return Err(());
             };
             let single_line_payload = response
@@ -254,11 +254,11 @@ async fn execute_backend_query(
 
             let result = classify_precheck_result(deps, backend, status_code, timings, response);
 
-            let _ = conn.release(); // response received; connection healthy, return to pool
+            let _ = conn.complete_success(); // response received; connection healthy, return to pool
             Ok(result)
         }
         Err(_) => {
-            conn.retire_with_cooldown();
+            conn.fail_backend();
             Err(())
         }
     }

--- a/src/session/response_transfer.rs
+++ b/src/session/response_transfer.rs
@@ -12,6 +12,13 @@ pub(crate) enum ResponseTransferError {
     /// backend response and started writing it locally.
     ClientDisconnect(std::io::Error),
 
+    /// Client write failed after backend response ownership was already established.
+    ///
+    /// This is treated as terminal for backend-connection reuse to prevent
+    /// protocol desync when a partially-written client response races with
+    /// subsequent backend reuse.
+    ClientWrite(std::io::Error),
+
     /// Backend closed connection before sending a complete multiline response.
     BackendEof {
         backend_id: crate::types::BackendId,
@@ -28,15 +35,16 @@ impl ResponseTransferError {
     /// A plain client disconnect after a complete response has been captured is
     /// safe for connection reuse. Backend EOF and other I/O errors may leave
     /// unread bytes in flight and must retire it.
-    pub(crate) const fn must_remove_connection(&self) -> bool {
+    pub(super) const fn must_remove_connection(&self) -> bool {
         !matches!(self, Self::ClientDisconnect(_))
     }
 
     /// Convert the transfer outcome into an `anyhow` error for older call sites
     /// that still bubble untyped errors.
-    pub(crate) fn into_anyhow(self) -> anyhow::Error {
+    pub(super) fn into_anyhow(self) -> anyhow::Error {
         match self {
             Self::ClientDisconnect(io_err) => anyhow::Error::from(io_err),
+            Self::ClientWrite(io_err) => anyhow::Error::from(io_err),
             Self::Io(e) => e,
             Self::BackendEof {
                 backend_id,
@@ -53,6 +61,7 @@ impl std::fmt::Display for ResponseTransferError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::ClientDisconnect(e) => write!(f, "client disconnected: {e}"),
+            Self::ClientWrite(e) => write!(f, "client write failed: {e}"),
             Self::BackendEof {
                 backend_id,
                 bytes_received,
@@ -70,6 +79,7 @@ impl std::error::Error for ResponseTransferError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::ClientDisconnect(e) => Some(e),
+            Self::ClientWrite(e) => Some(e),
             Self::BackendEof { .. } => None,
             Self::Io(e) => e.source(),
         }
@@ -77,7 +87,7 @@ impl std::error::Error for ResponseTransferError {
 }
 
 /// Reuse decision after a response transfer completed successfully.
-pub(crate) enum ResponseConnectionReuse {
+pub(super) enum ResponseConnectionReuse {
     /// No queued bytes remain on the connection.
     Reusable,
     /// Bytes are queued for the next response and the connection must stay on
@@ -88,7 +98,7 @@ pub(crate) enum ResponseConnectionReuse {
 /// Inspect a connection after response transfer without exposing the queued
 /// bytes themselves to the caller.
 #[must_use]
-pub(crate) fn connection_reuse_after_response(
+pub(super) fn connection_reuse_after_response(
     conn: &crate::pool::ConnectionGuard,
 ) -> ResponseConnectionReuse {
     if conn.has_pending_bytes() {
@@ -101,12 +111,16 @@ pub(crate) fn connection_reuse_after_response(
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
 
     #[test]
     fn response_transfer_error_pool_fate_matches_disconnect_semantics() {
         let disconnect = ResponseTransferError::ClientDisconnect(std::io::Error::from(
+            std::io::ErrorKind::BrokenPipe,
+        ));
+        let client_write = ResponseTransferError::ClientWrite(std::io::Error::from(
             std::io::ErrorKind::BrokenPipe,
         ));
         let eof = ResponseTransferError::BackendEof {
@@ -116,6 +130,7 @@ mod tests {
         let io = ResponseTransferError::Io(anyhow::anyhow!("backend dirty"));
 
         assert!(!disconnect.must_remove_connection());
+        assert!(client_write.must_remove_connection());
         assert!(eof.must_remove_connection());
         assert!(io.must_remove_connection());
     }

--- a/src/session/response_transfer.rs
+++ b/src/session/response_transfer.rs
@@ -29,14 +29,36 @@ pub(crate) enum ResponseTransferError {
     Io(anyhow::Error),
 }
 
+/// Fate of a backend connection after a response transfer.
+#[allow(clippy::enum_variant_names)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum BackendConnectionOutcome {
+    BackendHealthy,
+    BackendDirty,
+    BackendFailed,
+}
+
 impl ResponseTransferError {
-    /// Whether this failure leaves the backend connection unusable.
+    /// Derive the backend connection fate from the response-transfer outcome.
     ///
     /// A plain client disconnect after a complete response has been captured is
     /// safe for connection reuse. Backend EOF and other I/O errors may leave
-    /// unread bytes in flight and must retire it.
-    pub(super) const fn must_remove_connection(&self) -> bool {
-        !matches!(self, Self::ClientDisconnect(_))
+    /// unread bytes in flight and must retire it. If the connection still has
+    /// queued bytes after the transfer, it is dirty even when the transfer
+    /// itself only saw a client disconnect.
+    pub(super) const fn pool_fate(
+        &self,
+        reuse: ResponseConnectionReuse,
+    ) -> BackendConnectionOutcome {
+        match reuse {
+            ResponseConnectionReuse::QueuedBytes { .. } => BackendConnectionOutcome::BackendDirty,
+            ResponseConnectionReuse::Reusable => match self {
+                Self::ClientDisconnect(_) => BackendConnectionOutcome::BackendHealthy,
+                Self::ClientWrite(_) | Self::BackendEof { .. } | Self::Io(_) => {
+                    BackendConnectionOutcome::BackendFailed
+                }
+            },
+        }
     }
 
     /// Convert the transfer outcome into an `anyhow` error for older call sites
@@ -87,12 +109,23 @@ impl std::error::Error for ResponseTransferError {
 }
 
 /// Reuse decision after a response transfer completed successfully.
+#[derive(Debug, Clone, Copy)]
 pub(super) enum ResponseConnectionReuse {
     /// No queued bytes remain on the connection.
     Reusable,
     /// Bytes are queued for the next response and the connection must stay on
     /// the same processing path until they are consumed.
     QueuedBytes { len: usize },
+}
+
+impl ResponseConnectionReuse {
+    /// Derive the backend connection fate from a successful transfer.
+    pub(super) const fn pool_fate(self) -> BackendConnectionOutcome {
+        match self {
+            Self::Reusable => BackendConnectionOutcome::BackendHealthy,
+            Self::QueuedBytes { .. } => BackendConnectionOutcome::BackendDirty,
+        }
+    }
 }
 
 /// Inspect a connection after response transfer without exposing the queued
@@ -129,10 +162,34 @@ mod tests {
         };
         let io = ResponseTransferError::Io(anyhow::anyhow!("backend dirty"));
 
-        assert!(!disconnect.must_remove_connection());
-        assert!(client_write.must_remove_connection());
-        assert!(eof.must_remove_connection());
-        assert!(io.must_remove_connection());
+        assert_eq!(
+            disconnect.pool_fate(ResponseConnectionReuse::Reusable),
+            BackendConnectionOutcome::BackendHealthy
+        );
+        assert_eq!(
+            disconnect.pool_fate(ResponseConnectionReuse::QueuedBytes { len: 1 }),
+            BackendConnectionOutcome::BackendDirty
+        );
+        assert_eq!(
+            client_write.pool_fate(ResponseConnectionReuse::Reusable),
+            BackendConnectionOutcome::BackendFailed
+        );
+        assert_eq!(
+            eof.pool_fate(ResponseConnectionReuse::Reusable),
+            BackendConnectionOutcome::BackendFailed
+        );
+        assert_eq!(
+            io.pool_fate(ResponseConnectionReuse::Reusable),
+            BackendConnectionOutcome::BackendFailed
+        );
+        assert_eq!(
+            ResponseConnectionReuse::Reusable.pool_fate(),
+            BackendConnectionOutcome::BackendHealthy
+        );
+        assert_eq!(
+            ResponseConnectionReuse::QueuedBytes { len: 12 }.pool_fate(),
+            BackendConnectionOutcome::BackendDirty
+        );
     }
 
     #[test]

--- a/src/session/session_error.rs
+++ b/src/session/session_error.rs
@@ -74,12 +74,16 @@ impl From<crate::session::response_transfer::ResponseTransferError> for SessionE
             crate::session::response_transfer::ResponseTransferError::ClientDisconnect(io_err) => {
                 Self::ClientDisconnect(io_err)
             }
+            crate::session::response_transfer::ResponseTransferError::ClientWrite(io_err) => {
+                Self::ClientDisconnect(io_err)
+            }
             other => Self::Backend(other.into_anyhow()),
         }
     }
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)]
 mod tests {
     use super::*;
     use std::io::ErrorKind;
@@ -129,5 +133,14 @@ mod tests {
             };
         let e = SessionError::from(response_transfer_err);
         assert!(matches!(e, SessionError::Backend(_)));
+    }
+
+    #[test]
+    fn client_disconnect_from_response_transfer_client_write() {
+        let io_err = std::io::Error::from(ErrorKind::BrokenPipe);
+        let response_transfer_err =
+            crate::session::response_transfer::ResponseTransferError::ClientWrite(io_err);
+        let e = SessionError::from(response_transfer_err);
+        assert!(matches!(e, SessionError::ClientDisconnect(_)));
     }
 }

--- a/tests/proxy/routing/least_loaded.rs
+++ b/tests/proxy/routing/least_loaded.rs
@@ -289,7 +289,7 @@ async fn test_least_loaded_counts_checked_out_pool_connections() {
     let backend0 = live_backend("backend0", backend0_port, 2);
     let backend1 = live_backend("backend1", backend1_port, 2);
 
-    let held_backend1 = backend1.get_pooled_connection().await.unwrap();
+    let held_backend1 = backend1.checkout_connection_guard().await.unwrap();
 
     selector.add_backend(
         ServerName::try_new("backend0".to_string()).unwrap(),

--- a/tests/proxy/routing/least_loaded.rs
+++ b/tests/proxy/routing/least_loaded.rs
@@ -311,7 +311,7 @@ async fn test_least_loaded_counts_checked_out_pool_connections() {
         "least-loaded must count checked-out pool connections, not only router pending counts"
     );
 
-    drop(held_backend1);
+    drop(held_backend1.complete_success());
 }
 
 #[test]


### PR DESCRIPTION
This branch tightens backend connection fate handling and makes cleanup explicit on the response path.

What changed:
- replace boolean pool-fate checks with typed outcomes
- make per-command batch cleanup explicit instead of relying on implicit drop behavior
- add a regression test for cancel-time cleanup behavior
- clear the guardrails TODO once the planned items were implemented

Verification:
- cargo nextest run
- cargo clippy
- cargo fmt --check
- bench-release-cache-miss-e2e.sh with 1/1/1 and 10x repeats