### PR TITLE
Harden pending guards and fix retry overflow

### DIFF
--- a/src/router/mod.rs
+++ b/src/router/mod.rs
@@ -378,7 +378,7 @@ pub struct CommandGuard {
 
 impl CommandGuard {
     /// Create a new guard that will call `complete_command` on drop.
-    pub const fn new(router: Arc<BackendSelector>, backend_id: BackendId) -> Self {
+    const fn new(router: Arc<BackendSelector>, backend_id: BackendId) -> Self {
         Self {
             router,
             backend_id,
@@ -481,6 +481,22 @@ impl BackendSelector {
     #[inline]
     fn find_backend(&self, backend_id: BackendId) -> Option<&BackendInfo> {
         self.backends.iter().find(|b| b.id == backend_id)
+    }
+
+    /// Create a guard for a backend already reserved by `route()`.
+    #[must_use]
+    pub fn guard_for_routed_backend(router: Arc<Self>, backend_id: BackendId) -> CommandGuard {
+        CommandGuard::new(router, backend_id)
+    }
+
+    /// Create a guard for manually selected backend work.
+    ///
+    /// This increments `pending_count` before creating the guard, so the drop path
+    /// always has a matching decrement.
+    #[must_use]
+    pub fn guard_for_manual_backend(router: Arc<Self>, backend_id: BackendId) -> CommandGuard {
+        router.mark_backend_pending(backend_id);
+        CommandGuard::new(router, backend_id)
     }
 
     /// Get the tier for a backend
@@ -822,7 +838,7 @@ impl BackendSelector {
                 f64::MAX
             };
 
-            tracing::debug!(
+            tracing::trace!(
                 backend_id = backend.id.as_index(),
                 backend_name = backend.name.as_str(),
                 pool = %backend.provider.name(),
@@ -939,7 +955,7 @@ impl BackendSelector {
     #[inline]
     fn queue_depth_limit(max_connections: usize, per_connection_percent: u16) -> usize {
         let product = max_connections.saturating_mul(usize::from(per_connection_percent));
-        (product + 99) / 100
+        product.div_ceil(100)
     }
 
     #[inline]
@@ -1298,13 +1314,11 @@ mod tests {
     fn command_guard_decrements_on_drop() {
         let (router, backend_id) = make_router_with_backend();
 
-        // Simulate route incrementing the pending count.
-        router.mark_backend_pending(backend_id);
-        assert_eq!(router.backend_load(backend_id).unwrap().get(), 1);
-
-        // Guard should decrement on drop
+        // Manual guard increments on creation and decrements on drop.
+        assert_eq!(router.backend_load(backend_id).unwrap().get(), 0);
         {
-            let _guard = CommandGuard::new(router.clone(), backend_id);
+            let _guard = BackendSelector::guard_for_manual_backend(router.clone(), backend_id);
+            assert_eq!(router.backend_load(backend_id).unwrap().get(), 1);
         }
         assert_eq!(router.backend_load(backend_id).unwrap().get(), 0);
     }
@@ -1313,10 +1327,8 @@ mod tests {
     fn command_guard_explicit_complete() {
         let (router, backend_id) = make_router_with_backend();
 
-        router.mark_backend_pending(backend_id);
+        let guard = BackendSelector::guard_for_manual_backend(router.clone(), backend_id);
         assert_eq!(router.backend_load(backend_id).unwrap().get(), 1);
-
-        let guard = CommandGuard::new(router.clone(), backend_id);
         guard.complete();
         assert_eq!(router.backend_load(backend_id).unwrap().get(), 0);
     }
@@ -1325,12 +1337,9 @@ mod tests {
     fn command_guard_no_double_decrement() {
         let (router, backend_id) = make_router_with_backend();
 
-        // Start with pending count of 1
-        router.mark_backend_pending(backend_id);
-        assert_eq!(router.backend_load(backend_id).unwrap().get(), 1);
-
         // Explicit complete + drop should only decrement once
-        let guard = CommandGuard::new(router.clone(), backend_id);
+        let guard = BackendSelector::guard_for_manual_backend(router.clone(), backend_id);
+        assert_eq!(router.backend_load(backend_id).unwrap().get(), 1);
         guard.complete();
         // After complete(), count should be 0; drop should be a no-op
         assert_eq!(router.backend_load(backend_id).unwrap().get(), 0);
@@ -1341,7 +1350,7 @@ mod tests {
     #[test]
     fn command_guard_backend_id_accessor() {
         let (router, backend_id) = make_router_with_backend();
-        let guard = CommandGuard::new(router, backend_id);
+        let guard = BackendSelector::guard_for_routed_backend(router, backend_id);
         assert_eq!(guard.backend_id(), backend_id);
     }
 

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio::sync::Notify;
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use crate::protocol::RequestContext;
 use crate::session::precheck;
@@ -380,7 +380,7 @@ impl ClientSession {
         availability: Option<ArticleAvailability>,
         io: &mut RequestExecutionIo<'_>,
     ) -> Result<(), SessionError> {
-        debug!(
+        trace!(
             "Client {} starting availability routing for request kind={:?}, verb={:?}",
             self.client_addr,
             request.kind(),
@@ -390,7 +390,8 @@ impl ClientSession {
         let mut availability = availability.unwrap_or_default();
         let mut unavailable_backends = SuppressedBackends::empty();
         let mut is_retry_attempt = false;
-        debug!(
+        let mut retry_stat_sweep_done = false;
+        trace!(
             "Client {} availability routing: missing_bits={:08b}, backend_count={}",
             self.client_addr,
             availability.missing_bits(),
@@ -398,6 +399,21 @@ impl ClientSession {
         );
 
         while !availability.all_exhausted(router.backend_count()) {
+            if is_retry_attempt && !retry_stat_sweep_done {
+                self.parallel_retry_stat_sweep(
+                    router,
+                    request,
+                    &mut ArticleAttemptState {
+                        availability: &mut availability,
+                        client_to_backend_bytes: io.client_to_backend_bytes,
+                        backend_connection: io.backend_connection,
+                        unavailable_backends: &mut unavailable_backends,
+                    },
+                )
+                .await?;
+                retry_stat_sweep_done = true;
+            }
+
             let attempt = self
                 .try_backend_for_article(
                     router,
@@ -424,7 +440,7 @@ impl ClientSession {
                 Ok(BackendAttemptResult::ArticleNotFound { missing }) => {
                     is_retry_attempt = true;
                     let backend_id = missing.backend_id();
-                    debug!(
+                    trace!(
                         "Client {} backend {:?} returned 430 during retry",
                         self.client_addr, backend_id
                     );
@@ -458,7 +474,7 @@ impl ClientSession {
             }
         }
 
-        debug!(
+        trace!(
             "Client {} all backends exhausted for {:?}, sending 430",
             self.client_addr,
             request.message_id_value()
@@ -503,10 +519,12 @@ impl ClientSession {
                 .prepare_ordered_large_transfer_attempt(
                     &router,
                     request,
-                    &mut availability,
-                    &mut client_to_backend_bytes,
-                    &mut backend_connection,
-                    &mut unavailable_backends,
+                    &mut ArticleAttemptState {
+                        availability: &mut availability,
+                        client_to_backend_bytes: &mut client_to_backend_bytes,
+                        backend_connection: &mut backend_connection,
+                        unavailable_backends: &mut unavailable_backends,
+                    },
                     is_retry_attempt,
                 )
                 .await
@@ -680,20 +698,17 @@ impl ClientSession {
         &self,
         router: &Arc<BackendSelector>,
         request: &RequestContext,
-        availability: &mut crate::cache::ArticleAvailability,
-        client_to_backend_bytes: &mut ClientToBackendBytes,
-        backend_connection: &mut Option<(crate::types::BackendId, crate::pool::ConnectionGuard)>,
-        unavailable_backends: &mut SuppressedBackends,
+        state: &mut ArticleAttemptState<'_>,
         is_retry_attempt: bool,
     ) -> Result<OrderedLargeTransferAttempt, SessionError> {
-        if let Some(delay) =
-            router.queue_backpressure_delay_for_article(availability, *unavailable_backends)
+        if let Some(delay) = router
+            .queue_backpressure_delay_for_article(state.availability, *state.unavailable_backends)
         {
             tokio::time::sleep(delay).await;
         }
         let route_request = crate::router::RouteRequest::new(self.client_id)
-            .with_availability(availability)
-            .suppressing_backends(*unavailable_backends);
+            .with_availability(state.availability)
+            .suppressing_backends(*state.unavailable_backends);
         let backend = match router.route(route_request) {
             Ok(backend) => backend,
             Err(err) => {
@@ -708,24 +723,19 @@ impl ClientSession {
             }
         };
         let backend_id = backend.backend_id();
-        let guard = crate::router::CommandGuard::new(router.clone(), backend_id);
+        let guard =
+            crate::router::BackendSelector::guard_for_routed_backend(router.clone(), backend_id);
         let Some(provider) = self.retry_backend_provider(
             router,
             &backend,
             request,
             RetryAttemptKind::OrderedPipeline,
         ) else {
-            unavailable_backends.suppress(backend_id);
+            state.unavailable_backends.suppress(backend_id);
             return Ok(Err(OrderedLargeTransferNoAttempt::BackendUnavailable));
         };
-        let mut state = ArticleAttemptState {
-            availability,
-            client_to_backend_bytes,
-            backend_connection,
-            unavailable_backends,
-        };
         let prepared = self
-            .prepare_backend_attempt(provider, &backend, request, &mut state, is_retry_attempt)
+            .prepare_backend_attempt(provider, &backend, request, state, is_retry_attempt)
             .await;
         let Some((conn, status_code, buffer)) = (match prepared {
             Ok(prepared) => prepared,

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -4,7 +4,7 @@
 //! response validation, and writing backend responses to clients.
 
 use crate::protocol::{RequestContext, RequestKind, RequestResponseMetadata, StatusCode};
-use crate::router::{ArticleBackend, BackendSelector, CommandGuard, SuppressedBackends};
+use crate::router::{ArticleBackend, BackendSelector, SuppressedBackends};
 use crate::session::SessionError;
 use crate::session::response_transfer::{ResponseConnectionReuse, ResponseTransferError};
 use crate::session::retry::retry_once;
@@ -15,10 +15,11 @@ use crate::session::routing::{
 use crate::session::{ClientSession, backend};
 use crate::types::{BackendId, BackendToClientBytes, ClientToBackendBytes};
 use anyhow::Result;
+use futures::stream::{FuturesUnordered, StreamExt};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 const BACKEND_TIMING_SAMPLE_MASK: u64 = 0x0f;
 static BACKEND_TIMING_SAMPLE_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -132,6 +133,12 @@ enum BackendReadAttemptError {
     Backend(anyhow::Error),
 }
 
+enum RetryStatProbeOutcome {
+    Missing(BackendId),
+    Present,
+    Unavailable(BackendId),
+}
+
 /// Any client write failure after the full backend response is already owned is terminal.
 ///
 /// The backend connection is already clean at this point, but the client may have received a
@@ -185,7 +192,7 @@ impl ClientSession {
         let backend_id = backend.backend_id();
         let provider = router.backend_provider(backend_id);
         if provider.is_none() {
-            debug!(
+            trace!(
                 client = %self.client_addr,
                 backend = backend_id.as_index(),
                 command_verb = ?request.verb(),
@@ -229,7 +236,7 @@ impl ClientSession {
             }
         };
         let backend_id = backend.backend_id();
-        debug!(
+        trace!(
             client = %self.client_addr,
             backend = backend_id.as_index(),
             command_verb = ?request.verb(),
@@ -237,7 +244,7 @@ impl ClientSession {
             missing_bits = format_args!("{:08b}", state.availability.missing_bits()),
             "Article retry selected backend for direct attempt"
         );
-        let guard = CommandGuard::new(router.clone(), backend_id);
+        let guard = BackendSelector::guard_for_routed_backend(router.clone(), backend_id);
         let Some(provider) =
             self.retry_backend_provider(router, &backend, request, RetryAttemptKind::Direct)
         else {
@@ -253,7 +260,7 @@ impl ClientSession {
 
         let backend = match AuthoritativeArticleMissing::from_status_code(backend, status_code) {
             Ok(missing) => {
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     backend = backend_id.as_index(),
                     command_verb = ?request.verb(),
@@ -307,6 +314,106 @@ impl ClientSession {
         Ok(BackendAttemptResult::Success)
     }
 
+    pub(super) async fn parallel_retry_stat_sweep(
+        &self,
+        router: &Arc<BackendSelector>,
+        request: &RequestContext,
+        state: &mut ArticleAttemptState<'_>,
+    ) -> Result<(), SessionError> {
+        if !request.has_message_id()
+            || request.is_stat()
+            || !matches!(
+                request.kind(),
+                RequestKind::Article | RequestKind::Body | RequestKind::Head
+            )
+        {
+            return Ok(());
+        }
+
+        let Some(stat_request) = Self::stat_probe_request(request) else {
+            return Ok(());
+        };
+
+        let mut candidates = Vec::new();
+        for tier in router.tiers() {
+            for backend_id in router.backend_ids_in_tier(tier) {
+                if state.unavailable_backends.contains(backend_id)
+                    || !state.availability.should_try(backend_id)
+                {
+                    continue;
+                }
+                let Some(provider) = router.backend_provider(backend_id) else {
+                    continue;
+                };
+                if provider.stat_missing_enabled() {
+                    candidates.push((backend_id, provider.clone()));
+                }
+            }
+        }
+
+        if candidates.len() < 2 {
+            return Ok(());
+        }
+
+        let mut probes = FuturesUnordered::new();
+        for (backend_id, provider) in candidates {
+            let router = Arc::clone(router);
+            let stat_request = stat_request.clone();
+            probes.push(async move {
+                let _guard = BackendSelector::guard_for_manual_backend(router, backend_id);
+                let conn = match provider.get_pooled_connection().await {
+                    Ok(conn) => conn,
+                    Err(_) => return RetryStatProbeOutcome::Unavailable(backend_id),
+                };
+                let mut conn = crate::pool::ConnectionGuard::new(conn, provider);
+                let mut buffer = self.buffer_pool.acquire();
+                let read =
+                    backend::send_request(&mut **conn.get_mut(), &stat_request, &mut buffer).await;
+                let status_code = match read {
+                    Ok(read) => read.status_code(),
+                    Err(_) => {
+                        conn.retire_with_cooldown();
+                        return RetryStatProbeOutcome::Unavailable(backend_id);
+                    }
+                };
+
+                if self
+                    .capture_suppressed_430_response(&mut conn, backend_id, &stat_request, buffer)
+                    .await
+                    .is_err()
+                {
+                    conn.retire_with_cooldown();
+                    return RetryStatProbeOutcome::Unavailable(backend_id);
+                }
+                let _ = conn.release();
+
+                if status_code.is_some_and(|status| status.as_u16() == 430) {
+                    RetryStatProbeOutcome::Missing(backend_id)
+                } else {
+                    RetryStatProbeOutcome::Present
+                }
+            });
+        }
+
+        while let Some(outcome) = probes.next().await {
+            match outcome {
+                RetryStatProbeOutcome::Missing(backend_id) => {
+                    let missing = AuthoritativeArticleMissing { backend_id };
+                    self.record_authoritative_article_missing(&missing, state.availability);
+                    if let Some(msg_id) = request.message_id_value() {
+                        self.cache.record_backend_missing(msg_id, backend_id).await;
+                    }
+                }
+                RetryStatProbeOutcome::Present => {}
+                RetryStatProbeOutcome::Unavailable(backend_id) => {
+                    state.unavailable_backends.suppress(backend_id);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     async fn write_successful_retry_response(
         &self,
         conn: crate::pool::ConnectionGuard,
@@ -338,7 +445,7 @@ impl ClientSession {
     ) -> Result<PreparedBackendAttempt, SessionError> {
         let backend_id = backend.backend_id();
         let request_wire_len = request.request_wire_len().get();
-        debug!(
+        trace!(
             client = %self.client_addr,
             backend = backend_id.as_index(),
             command_verb = ?request.verb(),
@@ -383,7 +490,7 @@ impl ClientSession {
             Some(status_code) => status_code,
             None => {
                 read_status.log_warnings(&buffer, self.client_addr, backend_id);
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     backend = backend_id.as_index(),
                     command_verb = ?request.verb(),
@@ -404,7 +511,7 @@ impl ClientSession {
             }
         };
 
-        debug!(
+        trace!(
             client = %self.client_addr,
             backend = backend_id.as_index(),
             command_verb = ?request.verb(),
@@ -680,7 +787,7 @@ impl ClientSession {
             }
             Some(cached) => {
                 let (cached_backend_id, cached_conn) = cached;
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     cached_backend = cached_backend_id.as_index(),
                     backend = backend_id.as_index(),
@@ -692,7 +799,7 @@ impl ClientSession {
                 );
                 let _ = cached_conn.release();
                 let checkout_status = provider.status_counts();
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     backend = backend_id.as_index(),
                     command_verb = ?request.verb(),
@@ -706,7 +813,7 @@ impl ClientSession {
                 );
                 let conn = provider.get_pooled_connection().await?;
                 let checkout_status = provider.status_counts();
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     backend = backend_id.as_index(),
                     command_verb = ?request.verb(),
@@ -724,7 +831,7 @@ impl ClientSession {
             }
             None => {
                 let checkout_status = provider.status_counts();
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     backend = backend_id.as_index(),
                     command_verb = ?request.verb(),
@@ -738,7 +845,7 @@ impl ClientSession {
                 );
                 let conn = provider.get_pooled_connection().await?;
                 let checkout_status = provider.status_counts();
-                debug!(
+                trace!(
                     client = %self.client_addr,
                     backend = backend_id.as_index(),
                     command_verb = ?request.verb(),
@@ -774,7 +881,7 @@ impl ClientSession {
         let mut guard = self
             .checkout_direct_backend_connection(provider, backend_id, request, backend_connection)
             .await?;
-        debug!(
+        trace!(
             client = %self.client_addr,
             backend = backend_id.as_index(),
             command_verb = ?request.verb(),
@@ -1723,6 +1830,112 @@ mod tests {
             body_commands.load(Ordering::SeqCst),
             1,
             "first attempt should go directly to BODY/ARTICLE/HEAD without STAT probe"
+        );
+    }
+
+    #[tokio::test]
+    async fn retry_stat_sweep_marks_missing_across_multiple_backends() {
+        let session = test_session();
+        let (port0, stat0, body0) = spawn_stat_missing_probe_server().await;
+        let (port1, stat1, body1) = spawn_stat_missing_probe_server().await;
+        let router = router_with_tiered_backends([
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port0)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                0,
+            ),
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port1)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                1,
+            ),
+        ]);
+
+        let request = request_context(b"BODY <missing@example.com>\r\n");
+        let mut availability = ArticleAvailability::new();
+        let mut client_to_backend_bytes = ClientToBackendBytes::zero();
+        let mut backend_connection = None;
+        let mut unavailable_backends = SuppressedBackends::empty();
+        let mut state = ArticleAttemptState {
+            availability: &mut availability,
+            client_to_backend_bytes: &mut client_to_backend_bytes,
+            backend_connection: &mut backend_connection,
+            unavailable_backends: &mut unavailable_backends,
+        };
+
+        session
+            .parallel_retry_stat_sweep(&router, &request, &mut state)
+            .await
+            .expect("parallel retry STAT sweep should succeed");
+
+        assert!(availability.is_missing(BackendId::from_index(0)));
+        assert!(availability.is_missing(BackendId::from_index(1)));
+        assert_eq!(stat0.load(Ordering::SeqCst), 1);
+        assert_eq!(stat1.load(Ordering::SeqCst), 1);
+        assert_eq!(body0.load(Ordering::SeqCst), 0);
+        assert_eq!(body1.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn retry_stat_sweep_leaves_pending_counts_balanced() {
+        let session = test_session();
+        let (port0, _stat0, _body0) = spawn_stat_missing_probe_server().await;
+        let (port1, _stat1, _body1) = spawn_stat_missing_probe_server().await;
+        let router = router_with_tiered_backends([
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port0)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                0,
+            ),
+            (
+                DeadpoolConnectionProvider::builder("127.0.0.1", port1)
+                    .max_connections(1)
+                    .stat_missing(true)
+                    .build()
+                    .unwrap(),
+                1,
+            ),
+        ]);
+
+        let request = request_context(b"BODY <missing@example.com>\r\n");
+        let mut availability = ArticleAvailability::new();
+        let mut client_to_backend_bytes = ClientToBackendBytes::zero();
+        let mut backend_connection = None;
+        let mut unavailable_backends = SuppressedBackends::empty();
+        let mut state = ArticleAttemptState {
+            availability: &mut availability,
+            client_to_backend_bytes: &mut client_to_backend_bytes,
+            backend_connection: &mut backend_connection,
+            unavailable_backends: &mut unavailable_backends,
+        };
+
+        session
+            .parallel_retry_stat_sweep(&router, &request, &mut state)
+            .await
+            .expect("parallel retry STAT sweep should succeed");
+
+        assert_eq!(
+            router
+                .backend_load(BackendId::from_index(0))
+                .expect("backend 0 should exist")
+                .get(),
+            0
+        );
+        assert_eq!(
+            router
+                .backend_load(BackendId::from_index(1))
+                .expect("backend 1 should exist")
+                .get(),
+            0
         );
     }
 


### PR DESCRIPTION
Stacked on the logging/runtime cleanup branch so the pending-guard changes stay reviewable on their own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added concurrent backend availability probing for article retry operations, enabling faster detection of missing articles across multiple backends.

* **Chores**
  * Reduced logging verbosity by adjusting internal log levels.
  * Optimized backend selection and queue depth calculations for improved efficiency.
  * Refactored internal backend retry and connection management logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->