### PR TITLE
MSRV cleanup and private-first encapsulation

### DIFF
--- a/benches/cache_miss_roundtrip_callgrind.rs
+++ b/benches/cache_miss_roundtrip_callgrind.rs
@@ -61,7 +61,7 @@ supported! {
     fn metadata_only_cache() -> Cache {
         Cache {
             article_cache_capacity: CacheCapacity::try_new(32 * 1024 * 1024).unwrap(),
-            article_cache_ttl_secs: nntp_proxy::constants::duration_polyfill::from_minutes(5),
+            article_cache_ttl_secs: std::time::Duration::from_secs(300),
             store_article_bodies: false,
             adaptive_precheck: false,
             availability_index_path: None,

--- a/benches/end_to_end_proxy.rs
+++ b/benches/end_to_end_proxy.rs
@@ -53,7 +53,7 @@ fn bench_config(backend_port: u16, cache: Option<Cache>) -> Config {
 fn memory_cache() -> Cache {
     Cache {
         article_cache_capacity: CacheCapacity::try_new(32 * 1024 * 1024).unwrap(),
-        article_cache_ttl_secs: nntp_proxy::constants::duration_polyfill::from_minutes(5),
+        article_cache_ttl_secs: std::time::Duration::from_secs(300),
         store_article_bodies: true,
         adaptive_precheck: false,
         availability_index_path: None,

--- a/docs/operator/runtime-and-routing.md
+++ b/docs/operator/runtime-and-routing.md
@@ -12,8 +12,6 @@ Shorthands:
 - `--headless`
 - `--tui`
 
-`--no-tui` still exists as a hidden compatibility alias for headless mode.
-
 ## Dashboard attach/listen
 
 Headless mode can publish dashboard state over a loopback websocket:

--- a/src/args.rs
+++ b/src/args.rs
@@ -66,12 +66,8 @@ pub struct CommonArgs {
     pub tui: bool,
 
     /// Shorthand for `--ui headless`.
-    #[arg(long, help_heading = "General", conflicts_with_all = ["ui", "tui", "no_tui"])]
+    #[arg(long, help_heading = "General", conflicts_with_all = ["ui", "tui"])]
     pub headless: bool,
-
-    /// Disable the terminal dashboard and run in headless mode.
-    #[arg(long, hide = true, help_heading = "General")]
-    pub no_tui: bool,
 
     /// Bind the dashboard websocket publisher to a free loopback IP:PORT distinct from the proxy listener.
     #[arg(
@@ -123,7 +119,6 @@ pub struct CommonArgs {
     /// Backend selection strategy
     #[arg(
         long = "backend-selection",
-        alias = "backend-strategy",
         value_enum,
         env = "NNTP_PROXY_BACKEND_SELECTION",
         help_heading = "Routing"
@@ -133,7 +128,6 @@ pub struct CommonArgs {
     /// Article cache capacity in memory (e.g., "64mb", "1gb")
     #[arg(
         long = "article-cache-capacity",
-        alias = "cache-capacity",
         env = "NNTP_PROXY_ARTICLE_CACHE_CAPACITY",
         help_heading = "Cache"
     )]
@@ -142,8 +136,6 @@ pub struct CommonArgs {
     /// Article cache TTL in seconds
     #[arg(
         long = "article-cache-ttl",
-        alias = "cache-ttl",
-        alias = "ttl-secs",
         env = "NNTP_PROXY_ARTICLE_CACHE_TTL_SECS",
         help_heading = "Cache"
     )]
@@ -152,8 +144,6 @@ pub struct CommonArgs {
     /// Store full article bodies in the article cache (true) or track availability only (false)
     #[arg(
         long = "store-article-bodies",
-        alias = "cache-articles",
-        alias = "store-articles",
         env = "NNTP_PROXY_STORE_ARTICLE_BODIES",
         help_heading = "Cache"
     )]
@@ -200,11 +190,9 @@ impl CommonArgs {
     }
 
     /// Get the effective UI/runtime mode.
-    ///
-    /// `--no-tui` remains as a hidden compatibility alias for headless mode.
     #[must_use]
     pub const fn effective_ui_mode(&self) -> UiMode {
-        if self.no_tui || self.headless {
+        if self.headless {
             UiMode::Headless
         } else if self.tui {
             UiMode::Tui
@@ -276,34 +264,6 @@ impl CommonArgs {
         Ok(())
     }
 
-    fn legacy_env_var<E>(env_get: &E, keys: &[&str]) -> Option<String>
-    where
-        E: Fn(&str) -> Option<String>,
-    {
-        keys.iter().find_map(|key| env_get(key))
-    }
-
-    fn env_bool<E>(env_get: &E, keys: &[&str]) -> Option<bool>
-    where
-        E: Fn(&str) -> Option<String>,
-    {
-        Self::legacy_env_var(env_get, keys)?.parse().ok()
-    }
-
-    fn env_u64<E>(env_get: &E, keys: &[&str]) -> Option<u64>
-    where
-        E: Fn(&str) -> Option<String>,
-    {
-        Self::legacy_env_var(env_get, keys)?.parse().ok()
-    }
-
-    fn env_cache_capacity<E>(env_get: &E, keys: &[&str]) -> Option<CacheCapacity>
-    where
-        E: Fn(&str) -> Option<String>,
-    {
-        Self::legacy_env_var(env_get, keys)?.parse().ok()
-    }
-
     fn apply_overrides_with_env<E>(&self, config: &mut Config, env_get: E)
     where
         E: Fn(&str) -> Option<String>,
@@ -318,13 +278,13 @@ impl CommonArgs {
 
         let article_cache_capacity = self
             .article_cache_capacity
-            .or_else(|| Self::env_cache_capacity(&env_get, &["NNTP_PROXY_CACHE_CAPACITY"]));
+            .or_else(|| env_get("NNTP_PROXY_ARTICLE_CACHE_CAPACITY")?.parse().ok());
         let article_cache_ttl_secs = self
             .article_cache_ttl_secs
-            .or_else(|| Self::env_u64(&env_get, &["NNTP_PROXY_CACHE_TTL"]));
+            .or_else(|| env_get("NNTP_PROXY_ARTICLE_CACHE_TTL_SECS")?.parse().ok());
         let store_article_bodies = self
             .store_article_bodies
-            .or_else(|| Self::env_bool(&env_get, &["NNTP_PROXY_CACHE_ARTICLES"]));
+            .or_else(|| env_get("NNTP_PROXY_STORE_ARTICLE_BODIES")?.parse().ok());
 
         // Cache overrides — create cache section if needed
         if article_cache_capacity.is_some()
@@ -507,7 +467,7 @@ mod tests {
     }
 
     #[test]
-    fn test_common_args_parse_primary_and_legacy_flags() {
+    fn test_common_args_parse_primary_flags() {
         let args = CommonArgs::parse_from([
             "nntp-proxy",
             "--ui",
@@ -533,31 +493,6 @@ mod tests {
         assert_eq!(args.article_cache_ttl_secs, Some(7200));
         assert_eq!(args.store_article_bodies, Some(true));
         assert_eq!(args.effective_ui_mode(), UiMode::Tui);
-
-        let legacy_args = CommonArgs::parse_from([
-            "nntp-proxy",
-            "--no-tui",
-            "--cache-capacity",
-            "256mb",
-            "--backend-strategy",
-            "weighted-round-robin",
-            "--cache-ttl",
-            "3600",
-            "--store-articles",
-            "false",
-        ]);
-
-        assert_eq!(
-            legacy_args.backend_selection,
-            Some(BackendSelectionStrategy::WeightedRoundRobin)
-        );
-        assert_eq!(
-            legacy_args.article_cache_capacity,
-            Some(CacheCapacity::try_new(256_000_000).unwrap())
-        );
-        assert_eq!(legacy_args.article_cache_ttl_secs, Some(3600));
-        assert_eq!(legacy_args.store_article_bodies, Some(false));
-        assert_eq!(legacy_args.effective_ui_mode(), UiMode::Headless);
     }
 
     #[test]
@@ -754,7 +689,6 @@ mod tests {
             ui: UiMode::Headless,
             tui: false,
             headless: false,
-            no_tui: false,
             tui_listen: None,
             tui_attach: None,
             port: None,
@@ -822,13 +756,13 @@ mod tests {
         assert_eq!(cache.article_cache_capacity.get(), 128 * 1024 * 1024);
         assert_eq!(
             cache.article_cache_ttl_secs,
-            crate::constants::duration_polyfill::from_hours(2)
+            Duration::from_secs(2 * 60 * 60)
         );
         assert!(!cache.store_article_bodies);
     }
 
     #[test]
-    fn test_apply_overrides_legacy_env_compat() {
+    fn test_apply_overrides_cache_env() {
         let args = default_args();
         let mut config = Config {
             cache: None,
@@ -836,9 +770,9 @@ mod tests {
         };
 
         args.apply_overrides_with_env(&mut config, |key| match key {
-            "NNTP_PROXY_CACHE_CAPACITY" => Some("128mb".to_string()),
-            "NNTP_PROXY_CACHE_TTL" => Some("7200".to_string()),
-            "NNTP_PROXY_CACHE_ARTICLES" => Some("false".to_string()),
+            "NNTP_PROXY_ARTICLE_CACHE_CAPACITY" => Some("128mb".to_string()),
+            "NNTP_PROXY_ARTICLE_CACHE_TTL_SECS" => Some("7200".to_string()),
+            "NNTP_PROXY_STORE_ARTICLE_BODIES" => Some("false".to_string()),
             _ => None,
         });
 
@@ -846,7 +780,7 @@ mod tests {
         assert_eq!(cache.article_cache_capacity.get(), 128_000_000);
         assert_eq!(
             cache.article_cache_ttl_secs,
-            crate::constants::duration_polyfill::from_hours(2)
+            Duration::from_secs(2 * 60 * 60)
         );
         assert!(!cache.store_article_bodies);
     }

--- a/src/bin/nntp-proxy.rs
+++ b/src/bin/nntp-proxy.rs
@@ -416,7 +416,6 @@ mod tests {
             ui: UiMode::Headless,
             tui: false,
             headless: false,
-            no_tui: false,
             tui_listen: None,
             tui_attach: None,
             port: None,

--- a/src/cache/hybrid.rs
+++ b/src/cache/hybrid.rs
@@ -107,7 +107,7 @@ impl Default for HybridCacheConfig {
             memory_capacity: 256 * 1024 * 1024,     // 256 MB memory
             disk_capacity: 10 * 1024 * 1024 * 1024, // 10 GB disk
             disk_path: std::path::PathBuf::from("/var/cache/nntp-proxy"),
-            ttl: crate::constants::duration_polyfill::from_hours(1), // 1 hour
+            ttl: Duration::from_secs(60 * 60), // 1 hour
             compression: CompressionCodec::Lz4,
             shards: 16, // Match indexer shards for consistent lock contention
         }

--- a/src/cache/hybrid_codec.rs
+++ b/src/cache/hybrid_codec.rs
@@ -19,12 +19,6 @@ use super::article::{CachedArticleNumber, CachedPayload, parse_payload};
 use super::availability::ArticleAvailability;
 use super::ttl;
 
-#[cfg(test)]
-const DISK_ENTRY_MAGIC_V3: u32 = 0x4e50_4333; // "NPC3": legacy u8 availability bitmaps.
-#[cfg(test)]
-const DISK_ENTRY_MAGIC_V4: u32 = 0x4e50_4334; // "NPC4": legacy usize availability bitmaps.
-#[cfg(test)]
-const DISK_ENTRY_MAGIC_V5: u32 = 0x4e50_4335; // "NPC5": legacy checked + missing bitmaps.
 const DISK_ENTRY_MAGIC_V6: u32 = 0x4e50_4336; // "NPC6"
 const PAYLOAD_MISSING: u8 = 0;
 const PAYLOAD_AVAILABILITY_ONLY: u8 = 1;
@@ -1007,33 +1001,11 @@ mod tests {
     }
 
     #[test]
-    fn test_code_decode_rejects_legacy_u8_bitmap_magic() {
+    fn test_code_decode_rejects_non_current_magic() {
         let entry = disk_cached_article_from_ingest_bytes(b"220 article\r\n").unwrap();
         let mut encoded = Vec::new();
         entry.encode(&mut encoded).unwrap();
-        encoded[..4].copy_from_slice(&DISK_ENTRY_MAGIC_V3.to_le_bytes());
-
-        let result = DiskCachedArticle::decode(&mut encoded.as_slice());
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_code_decode_rejects_legacy_usize_bitmap_magic() {
-        let entry = disk_cached_article_from_ingest_bytes(b"220 article\r\n").unwrap();
-        let mut encoded = Vec::new();
-        entry.encode(&mut encoded).unwrap();
-        encoded[..4].copy_from_slice(&DISK_ENTRY_MAGIC_V4.to_le_bytes());
-
-        let result = DiskCachedArticle::decode(&mut encoded.as_slice());
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_code_decode_rejects_legacy_checked_bitmap_magic() {
-        let entry = disk_cached_article_from_ingest_bytes(b"220 article\r\n").unwrap();
-        let mut encoded = Vec::new();
-        entry.encode(&mut encoded).unwrap();
-        encoded[..4].copy_from_slice(&DISK_ENTRY_MAGIC_V5.to_le_bytes());
+        encoded[..4].copy_from_slice(&0x4e50_4335u32.to_le_bytes());
 
         let result = DiskCachedArticle::decode(&mut encoded.as_slice());
         assert!(result.is_err());

--- a/src/cache/mock_hybrid.rs
+++ b/src/cache/mock_hybrid.rs
@@ -67,10 +67,7 @@ impl MockHybridCache {
 
         // Check for existing entry - don't overwrite larger semantic payloads with smaller ones.
         if let Some(existing) = storage.get(&key) {
-            if existing.availability().is_missing(backend) {
-                return;
-            }
-            if existing.payload_len() > entry_len {
+            if existing.availability().is_missing(backend) || existing.payload_len() > entry_len {
                 return;
             }
             entry.availability = existing.availability();

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -170,27 +170,10 @@ impl<S> DecompressStream<S> {
         }
     }
 
-    /// Consume the wrapper, returning the inner stream.
-    pub fn into_inner(self) -> S {
-        self.inner
-    }
-
     /// Get a reference to the inner stream.
     #[inline]
     pub const fn get_ref(&self) -> &S {
         &self.inner
-    }
-
-    /// Get a mutable reference to the inner stream.
-    #[inline]
-    pub const fn get_mut(&mut self) -> &mut S {
-        &mut self.inner
-    }
-
-    /// Get bandwidth stats: (compressed bytes read from network, decompressed bytes delivered).
-    #[inline]
-    pub const fn bandwidth_stats(&self) -> (u64, u64) {
-        (self.bytes_compressed_in, self.bytes_decompressed_out)
     }
 }
 
@@ -420,19 +403,6 @@ mod tests {
 
         assert_eq!(output.len(), original.len());
         assert_eq!(output, original);
-    }
-
-    #[tokio::test]
-    async fn test_bandwidth_stats() {
-        let original = b"Test data for bandwidth tracking\r\n";
-        let (_tx, mut stream) = feed_compressed(original).await;
-
-        let mut output = Vec::new();
-        stream.read_to_end(&mut output).await.unwrap();
-
-        let (compressed_in, decompressed_out) = stream.bandwidth_stats();
-        assert!(compressed_in > 0);
-        assert_eq!(decompressed_out, original.len() as u64);
     }
 
     #[test]

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -63,7 +63,7 @@ pub fn cache_max_capacity() -> CacheCapacity {
 #[inline]
 #[must_use]
 pub const fn cache_ttl() -> Duration {
-    crate::constants::duration_polyfill::from_hours(1)
+    Duration::from_secs(60 * 60)
 }
 
 /// Default for caching article bodies in explicit `[cache]` sections.
@@ -217,7 +217,7 @@ pub const fn disk_cache_shards() -> usize {
 /// Prevents stale connections from accumulating during overnight idle periods.
 #[inline]
 pub const fn backend_idle_timeout() -> Duration {
-    crate::constants::duration_polyfill::from_minutes(10)
+    Duration::from_secs(600)
 }
 
 /// Default connection replacement cooldown.

--- a/src/config/loading.rs
+++ b/src/config/loading.rs
@@ -252,6 +252,7 @@ fn migrate_client_auth_users(config: &mut Config, raw: &toml::Value) -> bool {
 }
 
 fn migrate_legacy_config(config: &mut Config, raw: &toml::Value) -> bool {
+    // TODO(0.6): remove legacy schema migration after the 0.5 compatibility window.
     migrate_proxy_routing(config, raw)
         | migrate_proxy_memory(config, raw)
         | migrate_cache_precheck(config, raw)
@@ -758,7 +759,7 @@ mod tests {
         let server = parse_server_from_env(0, &env).unwrap();
         assert_eq!(
             server.connection_keepalive,
-            Some(crate::constants::duration_polyfill::from_minutes(5))
+            Some(std::time::Duration::from_secs(300))
         );
     }
 

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -965,10 +965,7 @@ mod tests {
     fn test_cache_default() {
         let cache = Cache::default();
         assert_eq!(cache.article_cache_capacity.get(), 64 * 1024 * 1024); // 64 MB
-        assert_eq!(
-            cache.article_cache_ttl_secs,
-            crate::constants::duration_polyfill::from_hours(1)
-        );
+        assert_eq!(cache.article_cache_ttl_secs, Duration::from_secs(60 * 60));
         assert!(!cache.store_article_bodies);
     }
 
@@ -1154,7 +1151,7 @@ mod tests {
 
     #[test]
     fn test_server_builder_with_keepalive() {
-        let keepalive = crate::constants::duration_polyfill::from_minutes(5);
+        let keepalive = Duration::from_secs(300);
         let server = Server::builder("localhost", Port::try_new(119).unwrap())
             .connection_keepalive(keepalive)
             .build()

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -88,26 +88,28 @@ fn validate_server(server: &Server) {
     // - max_connections cannot be 0 (NonZeroUsize via MaxConnections)
 
     // Warn if connection_keepalive is outside recommended range
-    if let Some(keepalive) = server.connection_keepalive {
-        if keepalive < MIN_RECOMMENDED_KEEPALIVE {
-            tracing::warn!(
-                "Server '{}' has connection_keepalive set to {:?} (< {:?}). \
-                 This may cause excessive health check traffic and connection churn. \
-                 Consider using at least {:?} or None to disable.",
-                server.name.as_str(),
-                keepalive,
-                MIN_RECOMMENDED_KEEPALIVE,
-                MIN_RECOMMENDED_KEEPALIVE
-            );
-        } else if keepalive > MAX_RECOMMENDED_KEEPALIVE {
-            tracing::warn!(
-                "Server '{}' has connection_keepalive set to {:?} (> {:?} / 5 minutes). \
-                 This may not detect stale connections quickly enough. Consider a lower value.",
-                server.name.as_str(),
-                keepalive,
-                MAX_RECOMMENDED_KEEPALIVE
-            );
-        }
+    if let Some(keepalive) = server.connection_keepalive
+        && keepalive < MIN_RECOMMENDED_KEEPALIVE
+    {
+        tracing::warn!(
+            "Server '{}' has connection_keepalive set to {:?} (< {:?}). \
+             This may cause excessive health check traffic and connection churn. \
+             Consider using at least {:?} or None to disable.",
+            server.name.as_str(),
+            keepalive,
+            MIN_RECOMMENDED_KEEPALIVE,
+            MIN_RECOMMENDED_KEEPALIVE
+        );
+    } else if let Some(keepalive) = server.connection_keepalive
+        && keepalive > MAX_RECOMMENDED_KEEPALIVE
+    {
+        tracing::warn!(
+            "Server '{}' has connection_keepalive set to {:?} (> {:?} / 5 minutes). \
+             This may not detect stale connections quickly enough. Consider a lower value.",
+            server.name.as_str(),
+            keepalive,
+            MAX_RECOMMENDED_KEEPALIVE
+        );
     }
 }
 
@@ -262,10 +264,7 @@ mod tests {
 
     #[test]
     fn test_validate_server_with_recommended_keepalive() {
-        let server = create_test_server(
-            "test",
-            Some(crate::constants::duration_polyfill::from_minutes(1)),
-        );
+        let server = create_test_server("test", Some(Duration::from_secs(60)));
         validate_server(&server);
     }
 
@@ -279,10 +278,7 @@ mod tests {
     #[test]
     fn test_validate_server_with_high_keepalive_warns() {
         // This should warn but not fail
-        let server = create_test_server(
-            "test",
-            Some(crate::constants::duration_polyfill::from_minutes(10)),
-        );
+        let server = create_test_server("test", Some(Duration::from_secs(600)));
         validate_server(&server);
     }
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,23 +5,6 @@
 
 use std::time::Duration;
 
-/// Polyfill for `Duration` constructors unavailable on the project MSRV.
-pub mod duration_polyfill {
-    use super::Duration;
-
-    #[inline]
-    #[must_use]
-    pub const fn from_minutes(value: u64) -> Duration {
-        Duration::from_secs(value * 60)
-    }
-
-    #[inline]
-    #[must_use]
-    pub const fn from_hours(value: u64) -> Duration {
-        Duration::from_secs(value * 60 * 60)
-    }
-}
-
 /// Buffer size constants
 ///
 /// All buffer sizes are carefully chosen for NNTP workloads:
@@ -143,7 +126,7 @@ pub mod timeout {
     pub const BACKEND_READ: Duration = Duration::from_secs(30);
 
     /// Timeout for executing a command on backend
-    pub const COMMAND_EXECUTION: Duration = crate::constants::duration_polyfill::from_minutes(1);
+    pub const COMMAND_EXECUTION: Duration = Duration::from_secs(60);
 
     /// Connection timeout for backend connections
     pub const CONNECTION: Duration = Duration::from_secs(10);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,13 +37,13 @@
 pub mod args;
 pub mod auth;
 pub mod client;
-pub mod compression;
+mod compression;
 pub mod connection_error;
 pub mod formatting;
 mod io_util;
 pub mod logging;
 pub mod metrics;
-pub mod network;
+mod network;
 pub mod protocol;
 mod proxy;
 pub mod stream;

--- a/src/metrics/snapshot.rs
+++ b/src/metrics/snapshot.rs
@@ -285,7 +285,7 @@ mod tests {
             stateful_sessions: 2,
             client_to_backend_bytes: ClientToBackendBytes::new(1500),
             backend_to_client_bytes: BackendToClientBytes::new(3500),
-            uptime: crate::constants::duration_polyfill::from_hours(1),
+            uptime: Duration::from_secs(60 * 60),
             backend_stats: vec![backend1, backend2].into(),
             user_stats: vec![],
             cache_entries: 0,

--- a/src/network.rs
+++ b/src/network.rs
@@ -3,10 +3,6 @@
 //! This module provides utilities for optimizing TCP socket performance
 //! for high-throughput NNTP transfers.
 //!
-//! Includes trait-based optimization strategies for different connection types
-//! (plain TCP, TLS) with configurable buffer sizes.
-
-use crate::stream::ConnectionStream;
 use anyhow::{Context, Result};
 use socket2::SockRef;
 use std::time::Duration;
@@ -23,19 +19,6 @@ const TCP_USER_TIMEOUT: Duration = Duration::from_secs(30);
 /// `IP_TOS` value for throughput optimization
 #[cfg(target_os = "linux")]
 const TOS_THROUGHPUT: u32 = 0x08;
-
-/// Trait for network optimization strategies
-pub trait NetworkOptimizer {
-    /// Apply optimizations to improve network performance
-    ///
-    /// # Errors
-    /// Returns any socket option error reported by the operating system while
-    /// applying the optimization strategy.
-    fn optimize(&self) -> Result<()>;
-
-    /// Get a description of the optimization strategy
-    fn description(&self) -> &'static str;
-}
 
 /// Apply core TCP optimizations to a socket reference
 fn apply_core_optimizations(
@@ -95,133 +78,29 @@ const fn platform_optimization_desc() -> &'static str {
     }
 }
 
-/// TCP-specific optimizations for high-throughput scenarios
-pub struct TcpOptimizer<'a> {
-    stream: &'a TcpStream,
+/// Apply TCP optimizations for high-throughput client sockets.
+pub(crate) fn optimize_tcp_stream(
+    stream: &TcpStream,
     recv_buffer_size: usize,
     send_buffer_size: usize,
-}
+) -> Result<()> {
+    let sock_ref = SockRef::from(stream);
 
-impl<'a> TcpOptimizer<'a> {
-    /// Create a new TCP optimizer with default high-throughput settings
-    pub const fn new(stream: &'a TcpStream) -> Self {
-        Self {
-            stream,
-            recv_buffer_size: crate::constants::socket::HIGH_THROUGHPUT_RECV_BUFFER,
-            send_buffer_size: crate::constants::socket::HIGH_THROUGHPUT_SEND_BUFFER,
-        }
-    }
+    apply_core_optimizations(&sock_ref, recv_buffer_size, send_buffer_size)
+        .context("Failed to apply core TCP optimizations")?;
 
-    /// Create optimizer with custom buffer sizes using builder pattern
-    pub const fn with_buffer_sizes(
-        stream: &'a TcpStream,
-        recv_size: usize,
-        send_size: usize,
-    ) -> Self {
-        Self {
-            stream,
-            recv_buffer_size: recv_size,
-            send_buffer_size: send_size,
-        }
-    }
-}
+    #[cfg(target_os = "linux")]
+    apply_linux_optimizations(&sock_ref, "TCP stream");
 
-impl NetworkOptimizer for TcpOptimizer<'_> {
-    fn optimize(&self) -> Result<()> {
-        let sock_ref = SockRef::from(self.stream);
+    debug!(
+        "Applied TCP optimizations: recv_buffer={}, send_buffer={}, linger={}s, nodelay=true{}",
+        recv_buffer_size,
+        send_buffer_size,
+        LINGER_TIMEOUT.as_secs(),
+        platform_optimization_desc()
+    );
 
-        // Core optimizations (required)
-        apply_core_optimizations(&sock_ref, self.recv_buffer_size, self.send_buffer_size)
-            .context("Failed to apply core TCP optimizations")?;
-
-        // Platform-specific optimizations (best-effort)
-        #[cfg(target_os = "linux")]
-        apply_linux_optimizations(&sock_ref, "TCP stream");
-
-        debug!(
-            "Applied TCP optimizations: recv_buffer={}, send_buffer={}, linger={}s, nodelay=true{}",
-            self.recv_buffer_size,
-            self.send_buffer_size,
-            LINGER_TIMEOUT.as_secs(),
-            platform_optimization_desc()
-        );
-
-        Ok(())
-    }
-
-    fn description(&self) -> &'static str {
-        "TCP high-throughput optimization"
-    }
-}
-
-/// High-level optimizer that works with `ConnectionStream`
-pub struct ConnectionOptimizer<'a> {
-    stream: &'a ConnectionStream,
-    recv_buffer_size: Option<usize>,
-    send_buffer_size: Option<usize>,
-}
-
-impl<'a> ConnectionOptimizer<'a> {
-    /// Create a new connection optimizer with default buffer sizes
-    pub const fn new(stream: &'a ConnectionStream) -> Self {
-        Self {
-            stream,
-            recv_buffer_size: None,
-            send_buffer_size: None,
-        }
-    }
-
-    /// Create a connection optimizer with custom buffer sizes
-    pub const fn with_buffer_sizes(
-        stream: &'a ConnectionStream,
-        recv_size: usize,
-        send_size: usize,
-    ) -> Self {
-        Self {
-            stream,
-            recv_buffer_size: Some(recv_size),
-            send_buffer_size: Some(send_size),
-        }
-    }
-}
-
-impl NetworkOptimizer for ConnectionOptimizer<'_> {
-    fn optimize(&self) -> Result<()> {
-        // Use functional pattern matching to create and optimize in one step
-        let optimize_fn = |desc: &str, result: Result<()>| {
-            debug!("Using {}", desc);
-            result
-        };
-
-        // Get the underlying TCP stream for optimization regardless of compression layer
-        let tcp = self.stream.underlying_tcp_stream();
-        if let (Some(recv), Some(send)) = (self.recv_buffer_size, self.send_buffer_size) {
-            let desc = if self.stream.is_encrypted() {
-                "TLS optimization via underlying TCP stream with custom buffers"
-            } else {
-                "TCP high-throughput optimization with custom buffers"
-            };
-            optimize_fn(
-                desc,
-                TcpOptimizer::with_buffer_sizes(tcp, recv, send).optimize(),
-            )
-        } else {
-            let desc = if self.stream.is_encrypted() {
-                "TLS optimization via underlying TCP stream"
-            } else {
-                "TCP high-throughput optimization"
-            };
-            optimize_fn(desc, TcpOptimizer::new(tcp).optimize())
-        }
-    }
-
-    fn description(&self) -> &'static str {
-        if self.stream.is_encrypted() {
-            "Connection-level TLS optimization"
-        } else {
-            "Connection-level TCP optimization"
-        }
-    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -231,158 +110,13 @@ mod tests {
     use tokio::net::TcpListener;
 
     #[test]
-    fn test_constants() {
-        assert_eq!(HIGH_THROUGHPUT_RECV_BUFFER, 16 * 1024 * 1024);
-        assert_eq!(HIGH_THROUGHPUT_SEND_BUFFER, 16 * 1024 * 1024);
-    }
-
-    #[test]
-    fn test_buffer_size_is_reasonable() {
-        // Buffer sizes should be large but not excessive
-        const _: () = assert!(HIGH_THROUGHPUT_RECV_BUFFER >= 1024 * 1024); // At least 1MB
-        const _: () = assert!(HIGH_THROUGHPUT_RECV_BUFFER <= 128 * 1024 * 1024); // At most 128MB
-        const _: () = assert!(HIGH_THROUGHPUT_SEND_BUFFER >= 1024 * 1024);
-        const _: () = assert!(HIGH_THROUGHPUT_SEND_BUFFER <= 128 * 1024 * 1024);
-    }
-
-    #[test]
     fn test_buffer_sizes_are_equal() {
         assert_eq!(HIGH_THROUGHPUT_RECV_BUFFER, HIGH_THROUGHPUT_SEND_BUFFER);
     }
 
     #[test]
-    fn test_buffer_sizes_are_power_of_two_or_multiple() {
-        let size = HIGH_THROUGHPUT_RECV_BUFFER;
-        assert_eq!(size % (1024 * 1024), 0);
-    }
-
-    #[tokio::test]
-    async fn test_connection_optimizer() {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let tcp_stream = std::net::TcpStream::connect(addr).unwrap();
-        tcp_stream.set_nonblocking(true).unwrap();
-        let tokio_stream = TcpStream::from_std(tcp_stream).unwrap();
-
-        let conn_stream = ConnectionStream::plain(tokio_stream);
-
-        let optimizer = ConnectionOptimizer::new(&conn_stream);
-        let result = optimizer.optimize();
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_buffer_size_calculation() {
-        assert_eq!(HIGH_THROUGHPUT_RECV_BUFFER, 16 * 1024 * 1024);
-        assert_eq!(HIGH_THROUGHPUT_RECV_BUFFER, 16_777_216);
-        assert_eq!(HIGH_THROUGHPUT_RECV_BUFFER / 1024, 16384); // KB
-        assert_eq!(HIGH_THROUGHPUT_RECV_BUFFER / (1024 * 1024), 16); // MB
-    }
-
-    #[test]
-    fn test_buffer_size_for_large_articles() {
-        let typical_large_article = 10 * 1024 * 1024; // 10MB
-        let very_large_article = 100 * 1024 * 1024; // 100MB
-        assert!(HIGH_THROUGHPUT_RECV_BUFFER > typical_large_article);
-        assert!(HIGH_THROUGHPUT_RECV_BUFFER < very_large_article);
-    }
-
-    #[tokio::test]
-    async fn test_tcp_optimizer() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let optimizer = TcpOptimizer::new(&stream);
-
-        assert_eq!(optimizer.description(), "TCP high-throughput optimization");
-
-        // Should not panic - actual socket optimization might fail in test environment
-        let _ = optimizer.optimize();
-    }
-
-    #[tokio::test]
-    async fn test_connection_optimizer_tcp() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let tcp_stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let connection_stream = ConnectionStream::plain(tcp_stream);
-        let optimizer = ConnectionOptimizer::new(&connection_stream);
-
-        assert_eq!(optimizer.description(), "Connection-level TCP optimization");
-
-        // Should not panic - actual socket optimization might fail in test environment
-        let _ = optimizer.optimize();
-    }
-
-    #[tokio::test]
-    async fn test_connection_optimizer_trait_usage() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let tcp_stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let connection_stream = ConnectionStream::plain(tcp_stream);
-
-        // Test that ConnectionOptimizer implements NetworkOptimizer trait
-        let optimizer: Box<dyn NetworkOptimizer> =
-            Box::new(ConnectionOptimizer::new(&connection_stream));
-
-        assert_eq!(optimizer.description(), "Connection-level TCP optimization");
-        let _ = optimizer.optimize();
-    }
-
-    #[tokio::test]
-    async fn test_connection_optimizer_with_custom_buffers() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let tcp_stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let connection_stream = ConnectionStream::plain(tcp_stream);
-        let optimizer = ConnectionOptimizer::with_buffer_sizes(&connection_stream, 4096, 8192);
-
-        assert_eq!(optimizer.description(), "Connection-level TCP optimization");
-        let _ = optimizer.optimize();
-    }
-
-    #[tokio::test]
-    async fn test_optimizer_creation() {
-        // Test that we can create optimizers with tokio streams
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let tokio_stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-
-        let optimizer = TcpOptimizer::new(&tokio_stream);
-        assert_eq!(
-            optimizer.recv_buffer_size,
-            crate::constants::socket::HIGH_THROUGHPUT_RECV_BUFFER
-        );
-        assert_eq!(
-            optimizer.send_buffer_size,
-            crate::constants::socket::HIGH_THROUGHPUT_SEND_BUFFER
-        );
-    }
-
-    #[tokio::test]
-    async fn test_custom_buffer_sizes() {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-
-        let tokio_stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-
-        let optimizer = TcpOptimizer::with_buffer_sizes(&tokio_stream, 1024, 2048);
-        assert_eq!(optimizer.recv_buffer_size, 1024);
-        assert_eq!(optimizer.send_buffer_size, 2048);
-    }
-
-    // Platform-specific description tests
-
-    #[test]
     fn test_platform_optimization_desc() {
         let desc = platform_optimization_desc();
-        // Check that it returns a valid string (platform-specific content)
         #[cfg(target_os = "linux")]
         assert!(desc.contains("tcp_user_timeout"));
         #[cfg(target_os = "windows")]
@@ -392,174 +126,12 @@ mod tests {
         let _ = desc;
     }
 
-    // Constructor tests
-
     #[tokio::test]
-    async fn test_tcp_optimizer_new_uses_defaults() {
+    async fn test_optimize_tcp_stream_accepts_zero_buffers() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
         let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
 
-        let optimizer = TcpOptimizer::new(&stream);
-
-        assert_eq!(
-            optimizer.recv_buffer_size,
-            crate::constants::socket::HIGH_THROUGHPUT_RECV_BUFFER
-        );
-        assert_eq!(
-            optimizer.send_buffer_size,
-            crate::constants::socket::HIGH_THROUGHPUT_SEND_BUFFER
-        );
-    }
-
-    #[tokio::test]
-    async fn test_tcp_optimizer_with_custom_buffers() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-
-        let recv_size = 512 * 1024;
-        let send_size = 1024 * 1024;
-        let optimizer = TcpOptimizer::with_buffer_sizes(&stream, recv_size, send_size);
-
-        assert_eq!(optimizer.recv_buffer_size, recv_size);
-        assert_eq!(optimizer.send_buffer_size, send_size);
-    }
-
-    // Description tests
-
-    #[tokio::test]
-    async fn test_tcp_optimizer_description() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-
-        let optimizer = TcpOptimizer::new(&stream);
-        assert_eq!(optimizer.description(), "TCP high-throughput optimization");
-    }
-
-    #[tokio::test]
-    async fn test_connection_optimizer_description_tcp() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let stream = ConnectionStream::plain(tcp);
-
-        let optimizer = ConnectionOptimizer::new(&stream);
-        assert_eq!(optimizer.description(), "Connection-level TCP optimization");
-    }
-
-    // ConnectionOptimizer buffer configuration tests
-
-    #[tokio::test]
-    async fn test_connection_optimizer_new_no_custom_buffers() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let stream = ConnectionStream::plain(tcp);
-
-        let optimizer = ConnectionOptimizer::new(&stream);
-        assert!(optimizer.recv_buffer_size.is_none());
-        assert!(optimizer.send_buffer_size.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_connection_optimizer_with_custom_buffers_sets_sizes() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let stream = ConnectionStream::plain(tcp);
-
-        let recv = 16384;
-        let send = 32768;
-        let optimizer = ConnectionOptimizer::with_buffer_sizes(&stream, recv, send);
-        assert_eq!(optimizer.recv_buffer_size, Some(recv));
-        assert_eq!(optimizer.send_buffer_size, Some(send));
-    }
-
-    // Edge case tests
-
-    #[tokio::test]
-    async fn test_tcp_optimizer_with_zero_buffers() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-
-        // Zero buffer sizes leave the OS defaults in place.
-        let optimizer = TcpOptimizer::with_buffer_sizes(&stream, 0, 0);
-        assert_eq!(optimizer.recv_buffer_size, 0);
-        assert_eq!(optimizer.send_buffer_size, 0);
-        optimizer.optimize().unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_tcp_optimizer_with_very_large_buffers() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-
-        // Very large buffer sizes (system may reject these, but we test the constructor)
-        let large_size = 128 * 1024 * 1024; // 128MB
-        let optimizer = TcpOptimizer::with_buffer_sizes(&stream, large_size, large_size);
-        assert_eq!(optimizer.recv_buffer_size, large_size);
-        assert_eq!(optimizer.send_buffer_size, large_size);
-    }
-
-    #[tokio::test]
-    async fn test_tcp_optimizer_with_asymmetric_buffers() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-
-        // Asymmetric buffers (common for download-heavy workloads)
-        let recv_size = 32 * 1024 * 1024; // 32MB
-        let send_size = 1024 * 1024; // 1MB
-        let optimizer = TcpOptimizer::with_buffer_sizes(&stream, recv_size, send_size);
-        assert_eq!(optimizer.recv_buffer_size, recv_size);
-        assert_eq!(optimizer.send_buffer_size, send_size);
-    }
-
-    // NetworkOptimizer trait tests
-
-    #[tokio::test]
-    async fn test_tcp_optimizer_implements_network_optimizer() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
-
-        let optimizer = TcpOptimizer::new(&stream);
-        // Can be used as a trait object
-        let _: &dyn NetworkOptimizer = &optimizer;
-    }
-
-    #[tokio::test]
-    async fn test_connection_optimizer_implements_network_optimizer() {
-        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        let tcp = tokio::net::TcpStream::connect(addr).await.unwrap();
-        let stream = ConnectionStream::plain(tcp);
-
-        let optimizer = ConnectionOptimizer::new(&stream);
-        // Can be used as a trait object
-        let _: &dyn NetworkOptimizer = &optimizer;
-    }
-
-    // Constants tests
-
-    #[test]
-    fn test_linger_timeout_constant() {
-        assert_eq!(LINGER_TIMEOUT, Duration::from_secs(5));
-    }
-
-    #[test]
-    #[cfg(target_os = "linux")]
-    fn test_tcp_user_timeout_constant() {
-        assert_eq!(TCP_USER_TIMEOUT, Duration::from_secs(30));
-    }
-
-    #[test]
-    #[cfg(target_os = "linux")]
-    fn test_tos_throughput_constant() {
-        assert_eq!(TOS_THROUGHPUT, 0x08);
+        optimize_tcp_stream(&stream, 0, 0).unwrap();
     }
 }

--- a/src/pool/deadpool_connection.rs
+++ b/src/pool/deadpool_connection.rs
@@ -12,6 +12,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
@@ -266,7 +267,7 @@ impl TcpManager {
         let stream_socket = socket2::SockRef::from(&tcp_stream);
         stream_socket.set_keepalive(true)?;
         let keepalive = socket2::TcpKeepalive::new()
-            .with_time(crate::constants::duration_polyfill::from_minutes(1))
+            .with_time(Duration::from_secs(60))
             .with_interval(std::time::Duration::from_secs(10));
         stream_socket.set_tcp_keepalive(&keepalive)?;
         stream_socket.set_tcp_nodelay(true)?;

--- a/src/pool/health_check.rs
+++ b/src/pool/health_check.rs
@@ -171,7 +171,7 @@ pub fn check_tcp_alive(
 ///
 /// This is a pure function extracted for testability.
 #[inline]
-pub(crate) fn validate_date_response(response: &str) -> Result<(), HealthCheckError> {
+fn validate_date_response(response: &str) -> Result<(), HealthCheckError> {
     if response.starts_with(EXPECTED_DATE_RESPONSE_PREFIX) {
         Ok(())
     } else {

--- a/src/protocol/request.rs
+++ b/src/protocol/request.rs
@@ -137,12 +137,6 @@ impl RequestResponseMetadata {
     }
 
     #[must_use]
-    #[allow(dead_code)]
-    pub(crate) const fn status(self) -> StatusCode {
-        self.status
-    }
-
-    #[must_use]
     pub(crate) const fn wire_len(self) -> ResponseWireLen {
         self.wire_len
     }
@@ -600,7 +594,7 @@ impl RequestContext {
     }
 
     #[inline]
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub(crate) fn complete_backend_response(
         &mut self,
         backend_id: BackendId,
@@ -610,12 +604,6 @@ impl RequestContext {
         self.backend_id = Some(backend_id);
         self.response = Some(RequestResponseMetadata::new(status, response.len().into()));
         self.response_payload = Some(response);
-    }
-
-    #[inline]
-    #[allow(dead_code)]
-    pub(crate) fn take_response_payload(&mut self) -> Option<crate::pool::ChunkedResponse> {
-        self.response_payload.take()
     }
 
     #[inline]

--- a/src/proxy/builder.rs
+++ b/src/proxy/builder.rs
@@ -443,7 +443,7 @@ mod tests {
         let mut config = create_test_config();
         config.cache = Some(Cache {
             article_cache_capacity: CacheCapacity::try_new(capacity).unwrap(),
-            article_cache_ttl_secs: crate::constants::duration_polyfill::from_minutes(1),
+            article_cache_ttl_secs: Duration::from_secs(60),
             store_article_bodies: false,
             adaptive_precheck: false,
             disk: None,

--- a/src/proxy/lifecycle.rs
+++ b/src/proxy/lifecycle.rs
@@ -12,7 +12,6 @@ use tracing::{debug, info, warn};
 
 use crate::cache::UnifiedCache;
 use crate::config::RoutingMode;
-use crate::network::NetworkOptimizer;
 use crate::pool::ConnectionProvider;
 use crate::router;
 use crate::session::ClientSession;
@@ -250,13 +249,11 @@ impl NntpProxy {
     /// Apply TCP optimizations to client socket
     #[inline]
     pub(super) fn apply_tcp_optimizations(&self, client_stream: &TcpStream) {
-        use crate::network::TcpOptimizer;
-        TcpOptimizer::with_buffer_sizes(
+        crate::network::optimize_tcp_stream(
             client_stream,
             self.memory.socket_recv_buffer_size,
             self.memory.socket_send_buffer_size,
         )
-        .optimize()
         .map_err(|e| debug!("Failed to optimize client socket: {}", e))
         .ok();
     }
@@ -853,7 +850,7 @@ mod tests {
         for server in proxy.servers() {
             assert_eq!(
                 server.backend_idle_timeout,
-                crate::constants::duration_polyfill::from_minutes(10),
+                Duration::from_secs(600),
                 "Server '{}' should have default 10-minute backend_idle_timeout",
                 server.name.as_ref(),
             );
@@ -1002,7 +999,7 @@ mod tests {
                 Server::builder("server2.example.com", Port::try_new(119).unwrap())
                     .name("Long Timeout")
                     .max_connections(MaxConnections::try_new(2).unwrap())
-                    .backend_idle_timeout(crate::constants::duration_polyfill::from_hours(24)) // 24h
+                    .backend_idle_timeout(Duration::from_secs(24 * 60 * 60)) // 24h
                     .build()
                     .unwrap(),
             ],
@@ -1036,7 +1033,7 @@ mod tests {
                 Server::builder("server2.example.com", Port::try_new(119).unwrap())
                     .name("Long Timeout")
                     .max_connections(MaxConnections::try_new(2).unwrap())
-                    .backend_idle_timeout(crate::constants::duration_polyfill::from_hours(24))
+                    .backend_idle_timeout(Duration::from_secs(24 * 60 * 60))
                     .build()
                     .unwrap(),
             ],

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -7,6 +7,7 @@
 
 use crate::types::ThreadCount;
 use anyhow::{Context, Result};
+use std::time::Duration;
 
 const TOKIO_WORKER_THREAD_STACK_SIZE: usize = 8 * 1024 * 1024;
 
@@ -276,8 +277,7 @@ pub fn spawn_cache_stats_logger(proxy: &std::sync::Arc<crate::NntpProxy>) {
     // Cache is always present now
     let cache = Arc::clone(proxy.cache());
     tokio::spawn(async move {
-        let mut interval =
-            tokio::time::interval(crate::constants::duration_polyfill::from_minutes(1));
+        let mut interval = tokio::time::interval(Duration::from_secs(60));
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
         loop {
@@ -1084,7 +1084,7 @@ pub fn spawn_idle_connection_clearer(proxy: &std::sync::Arc<crate::NntpProxy>) {
     use std::time::Duration;
 
     /// How often to check for idle backends
-    const CHECK_INTERVAL: Duration = crate::constants::duration_polyfill::from_minutes(1);
+    const CHECK_INTERVAL: Duration = Duration::from_secs(60);
 
     let proxy = Arc::clone(proxy);
 

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -1075,47 +1075,44 @@ impl ClientSession {
             "Sending request to backend and waiting for classifiable response bytes"
         );
         let result =
-            if Self::should_use_stat_missing_probe(provider, request, stat_probe_retry_only) {
-                if let Some(stat_request) = Self::stat_probe_request(request) {
+            if Self::should_use_stat_missing_probe(provider, request, stat_probe_retry_only)
+                && let Some(stat_request) = Self::stat_probe_request(request)
+            {
+                debug!(
+                    client = %self.client_addr,
+                    backend = backend.backend_id().as_index(),
+                    command_verb = ?request.verb(),
+                    msg_id = ?request.message_id_value(),
+                    "Running STAT miss probe before backend article fetch"
+                );
+
+                let (probe_response, mut probe_buffer, probe_timings) = self
+                    .execute_and_read_response(&mut guard, backend, &stat_request)
+                    .await
+                    .map_err(|BackendReadAttemptError::Backend(e)| e)?;
+                if probe_response
+                    .status_code()
+                    .is_some_and(|status| status.as_u16() == 430)
+                {
                     debug!(
                         client = %self.client_addr,
                         backend = backend.backend_id().as_index(),
                         command_verb = ?request.verb(),
                         msg_id = ?request.message_id_value(),
-                        "Running STAT miss probe before backend article fetch"
+                        "STAT miss probe returned 430; skipping backend article fetch"
                     );
-
-                    let (probe_response, mut probe_buffer, probe_timings) = self
-                        .execute_and_read_response(&mut guard, backend, &stat_request)
-                        .await
-                        .map_err(|BackendReadAttemptError::Backend(e)| e)?;
-                    if probe_response
-                        .status_code()
-                        .is_some_and(|status| status.as_u16() == 430)
-                    {
-                        debug!(
-                            client = %self.client_addr,
-                            backend = backend.backend_id().as_index(),
-                            command_verb = ?request.verb(),
-                            msg_id = ?request.message_id_value(),
-                            "STAT miss probe returned 430; skipping backend article fetch"
-                        );
-                        Ok((probe_response, probe_buffer, probe_timings))
-                    } else {
-                        crate::session::backend::observe_response(
-                            &stat_request,
-                            &mut probe_buffer,
-                            &mut guard,
-                            &self.buffer_pool,
-                            backend.backend_id(),
-                        )
-                        .await
-                        .map_err(SessionError::from)?;
-                        let _ = probe_timings;
-                        self.execute_and_read_response(&mut guard, backend, request)
-                            .await
-                    }
+                    Ok((probe_response, probe_buffer, probe_timings))
                 } else {
+                    crate::session::backend::observe_response(
+                        &stat_request,
+                        &mut probe_buffer,
+                        &mut guard,
+                        &self.buffer_pool,
+                        backend.backend_id(),
+                    )
+                    .await
+                    .map_err(SessionError::from)?;
+                    let _ = probe_timings;
                     self.execute_and_read_response(&mut guard, backend, request)
                         .await
                 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -167,22 +167,22 @@
 
 #![deny(clippy::disallowed_methods)]
 
-pub mod auth_state;
+mod auth_state;
 pub(crate) mod backend;
 pub(crate) mod common;
 pub(crate) mod connection;
-pub mod core;
-pub mod handlers;
-pub mod metrics_ext;
-pub mod mode_state;
+mod core;
+mod handlers;
+mod metrics_ext;
+mod mode_state;
 pub(crate) mod multiline_framing;
-pub mod precheck;
+mod precheck;
 pub(crate) mod response_transfer;
 pub(crate) mod retry;
 pub(crate) mod routing;
-pub mod session_error;
+mod session_error;
 pub(crate) mod shared_client_writer;
-pub mod state;
+mod state;
 
 pub use auth_state::AuthState;
 pub use backend::format_hex_preview;

--- a/src/session/response_transfer.rs
+++ b/src/session/response_transfer.rs
@@ -60,23 +60,6 @@ impl ResponseTransferError {
             },
         }
     }
-
-    /// Convert the transfer outcome into an `anyhow` error for older call sites
-    /// that still bubble untyped errors.
-    pub(super) fn into_anyhow(self) -> anyhow::Error {
-        match self {
-            Self::ClientDisconnect(io_err) => anyhow::Error::from(io_err),
-            Self::ClientWrite(io_err) => anyhow::Error::from(io_err),
-            Self::Io(e) => e,
-            Self::BackendEof {
-                backend_id,
-                bytes_received,
-            } => anyhow::anyhow!(
-                "Backend {backend_id:?} closed connection before complete multiline response \
-                 ({bytes_received} bytes received)"
-            ),
-        }
-    }
 }
 
 impl std::fmt::Display for ResponseTransferError {
@@ -208,18 +191,5 @@ mod tests {
             backend_eof.to_string().contains("99 bytes received"),
             "display should include received byte count"
         );
-    }
-
-    #[test]
-    fn response_transfer_into_anyhow_keeps_backend_eof_context() {
-        let err = ResponseTransferError::BackendEof {
-            backend_id: crate::types::BackendId::from_index(3),
-            bytes_received: 7,
-        }
-        .into_anyhow();
-
-        let rendered = err.to_string();
-        assert!(rendered.contains("closed connection"));
-        assert!(rendered.contains("7 bytes received"));
     }
 }

--- a/src/session/session_error.rs
+++ b/src/session/session_error.rs
@@ -77,7 +77,7 @@ impl From<crate::session::response_transfer::ResponseTransferError> for SessionE
             crate::session::response_transfer::ResponseTransferError::ClientWrite(io_err) => {
                 Self::ClientDisconnect(io_err)
             }
-            other => Self::Backend(other.into_anyhow()),
+            other => Self::Backend(anyhow::Error::new(other)),
         }
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,7 +5,7 @@
 pub mod config;
 pub mod metrics;
 pub mod metrics_recording;
-pub mod network;
+mod network;
 pub mod pool;
 pub mod protocol;
 pub mod tui;

--- a/src/types/config/mod.rs
+++ b/src/types/config/mod.rs
@@ -53,8 +53,8 @@ mod tests {
     fn test_timeout_types_available() {
         use std::time::Duration;
         let _ = ConnectionTimeout::new(Duration::from_secs(30));
-        let _ = BackendReadTimeout::new(crate::constants::duration_polyfill::from_minutes(1));
-        let _ = CommandExecutionTimeout::new(crate::constants::duration_polyfill::from_minutes(2));
+        let _ = BackendReadTimeout::new(Duration::from_secs(60));
+        let _ = CommandExecutionTimeout::new(Duration::from_secs(120));
         let _ = HealthCheckTimeout::new(Duration::from_secs(10));
     }
 

--- a/src/types/config/timeout.rs
+++ b/src/types/config/timeout.rs
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn large_timeout_one_day() {
-        let large = crate::constants::duration_polyfill::from_hours(24);
+        let large = Duration::from_secs(24 * 60 * 60);
         let timeout = CommandExecutionTimeout::new(large);
         assert_eq!(timeout.as_secs(), 86400);
     }

--- a/tests/test_metrics.rs
+++ b/tests/test_metrics.rs
@@ -101,7 +101,7 @@ fn test_metrics_snapshot_total_bytes() {
         stateful_sessions: 2,
         client_to_backend_bytes: ClientToBackendBytes::new(1000),
         backend_to_client_bytes: BackendToClientBytes::new(5000),
-        uptime: nntp_proxy::constants::duration_polyfill::from_minutes(1),
+        uptime: std::time::Duration::from_secs(60),
         ..Default::default()
     };
 


### PR DESCRIPTION
## Summary

This PR implements the Rust 1.88/private-first cleanup pass in small reviewable commits. The focus is to delete legacy or unused surface area, prefer private items over broad crate/module visibility, and use newer Rust expression forms only where they reduce nesting without making ownership or hot paths harder to reason about.

The cleanup intentionally avoids `src/session/multiline_framing.rs` and the normal forwarding path semantics. The `client` module remains public because it looks like the intended future library facade. Config-file migration is also retained for now per follow-up direction, with a `TODO(0.6)` marker on the migration entry point so the scheduled removal is visible.

## What Changed

- Removed legacy CLI compatibility aliases:
  - `--no-tui`
  - `--backend-strategy`
  - `--cache-capacity`
  - `--cache-ttl`
  - `--ttl-secs`
  - `--cache-articles`
  - `--store-articles`
  - legacy cache env fallbacks `NNTP_PROXY_CACHE_*`
- Replaced the local `duration_polyfill` module with Rust 1.88-safe `Duration::from_secs(...)` calls.
- Collapsed narrow conditional branches with let chains / boolean composition in config validation, STAT probe execution, and mock hybrid-cache mutation.
- Deleted the trait/builder TCP optimization abstraction and kept the single concrete socket optimization operation used by production.
- Removed unused decompression accessors and the bandwidth-stats-only test.
- Removed `ResponseTransferError::into_anyhow` and converted through `anyhow::Error::new` at the session boundary.
- Collapsed V3/V4/V5 disk-cache magic tests into one generic non-current-magic rejection test.
- Made internal crate/session modules private where explicit re-exports already provide the intended facade.
- Tightened test-only helpers with `#[cfg(test)]`, removed an unused payload-taking helper, and made health-check DATE validation module-private.

## Commit Stack

- `35192a2e` Remove legacy CLI compatibility aliases
- `da26211a` Flatten small conditional branches
- `acc29c3c` Collapse TCP optimization to one function
- `5228cf7a` Replace duration constructor polyfill
- `14b2c207` Remove unused decompression accessors
- `0334d5bc` Remove legacy response transfer error adapter
- `ea7a7a6e` Collapse legacy disk cache magic tests
- `f0cf06f9` Hide internal crate modules
- `92b4306b` Tighten test-only request helpers

## Validation

- `nix develop -c cargo check --all-targets`
- `nix develop -c cargo fmt --check`
- `nix develop -c cargo clippy`
- `nix develop -c cargo nextest run`

Final `nextest` result: 2227 tests passed, 1 skipped.