### PR TITLE
swap runtime CPU pinning to rustix and remove dead ordered pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2027,7 +2027,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix 0.29.0",
+ "nix",
  "winapi",
 ]
 
@@ -2160,18 +2160,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.31.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
-dependencies = [
- "bitflags 2.13.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
-]
-
-[[package]]
 name = "nntp-proxy"
 version = "0.5.1"
 dependencies = [
@@ -2196,13 +2184,13 @@ dependencies = [
  "iai-callgrind",
  "memchr",
  "moka",
- "nix 0.31.3",
  "nutype",
  "pin-project-lite",
  "postcard",
  "proptest",
  "rand 0.10.1",
  "ratatui",
+ "rustix",
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
@@ -2252,7 +2240,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2981,7 +2969,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3436,7 +3424,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3446,7 +3434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3488,7 +3476,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix 0.29.0",
+ "nix",
  "num-derive",
  "num-traits",
  "ordered-float",
@@ -4267,7 +4255,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ anyhow = "1.0"
 thiserror = "2.0"
 socket2 = { version = "0.6", features = ["all"] }  # Safe cross-platform socket operations
 crossbeam = { version = "0.8", features = ["alloc", "std"] }  # Lock-free data structures with minimal features
-nix = { version = "0.31", features = ["sched", "process"] }  # Low-level system calls for CPU pinning
+rustix = { version = "1.1", features = ["thread"] }  # Low-level system calls for CPU pinning
 deadpool = "0.13"
 memchr = { version = "2.8", features = ["libc"] }  # Fast byte searching with system optimizations
 uuid = { version = "1.23", features = ["v4"] }  # Unique IDs for request tracking

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -16,8 +16,20 @@ const TOKIO_WORKER_THREAD_STACK_SIZE: usize = 8 * 1024 * 1024;
 pub struct RuntimeConfig {
     /// Number of worker threads
     worker_threads: usize,
-    /// Whether to enable CPU pinning (Linux only)
-    enable_cpu_pinning: bool,
+    /// CPU pinning behavior
+    cpu_pinning: CpuPinning,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CpuPinning {
+    Enabled,
+    Disabled,
+}
+
+impl CpuPinning {
+    const fn is_enabled(self) -> bool {
+        matches!(self, Self::Enabled)
+    }
 }
 
 impl RuntimeConfig {
@@ -32,14 +44,14 @@ impl RuntimeConfig {
 
         Self {
             worker_threads,
-            enable_cpu_pinning: true,
+            cpu_pinning: CpuPinning::Enabled,
         }
     }
 
     /// Disable CPU pinning
     #[must_use]
     pub const fn without_cpu_pinning(mut self) -> Self {
-        self.enable_cpu_pinning = false;
+        self.cpu_pinning = CpuPinning::Disabled;
         self
     }
 
@@ -65,9 +77,13 @@ impl RuntimeConfig {
     pub fn build_runtime(self) -> Result<tokio::runtime::Runtime> {
         let rt = if self.is_single_threaded() {
             tracing::info!("Starting NNTP proxy with single-threaded runtime");
-            tokio::runtime::Builder::new_current_thread()
+            let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
-                .build()?
+                .build()?;
+            if self.cpu_pinning.is_enabled() {
+                pin_current_thread_to_first_available_cpu(self.worker_threads);
+            }
+            rt
         } else {
             let num_cpus = std::thread::available_parallelism().map_or(1, std::num::NonZero::get);
             tracing::info!(
@@ -75,16 +91,19 @@ impl RuntimeConfig {
                 self.worker_threads,
                 num_cpus
             );
-            tokio::runtime::Builder::new_multi_thread()
+
+            let mut builder = tokio::runtime::Builder::new_multi_thread();
+            builder
                 .worker_threads(self.worker_threads)
                 .thread_stack_size(TOKIO_WORKER_THREAD_STACK_SIZE)
-                .enable_all()
-                .build()?
-        };
+                .enable_all();
 
-        if self.enable_cpu_pinning {
-            pin_to_cpu_cores(self.worker_threads);
-        }
+            if self.cpu_pinning.is_enabled() {
+                configure_worker_cpu_pinning(&mut builder, self.worker_threads);
+            }
+
+            builder.build()?
+        };
 
         Ok(rt)
     }
@@ -96,40 +115,116 @@ impl Default for RuntimeConfig {
     }
 }
 
-/// Pin current process to specific CPU cores for optimal performance
+/// Pin the current thread to one CPU core for more stable scheduler locality.
 ///
 /// This is a best-effort operation - failures are logged but not fatal.
 ///
 /// # Arguments
-/// * `num_cores` - Number of CPU cores to pin to (`0..num_cores`)
+/// * `core` - CPU core ID to pin the current thread to
 #[cfg(target_os = "linux")]
-fn pin_to_cpu_cores(num_cores: usize) {
-    use nix::sched::{CpuSet, sched_setaffinity};
-    use nix::unistd::Pid;
+fn pin_current_thread_to_cpu(core: usize) {
+    use rustix::thread::{gettid, sched_setaffinity};
 
-    let mut cpu_set = CpuSet::new();
-    for core in 0..num_cores {
-        let _ = cpu_set.set(core);
-    }
+    let cpu_set = build_single_cpu_affinity_set(core);
 
-    match sched_setaffinity(Pid::from_raw(0), &cpu_set) {
+    match sched_setaffinity(Some(gettid()), &cpu_set) {
         Ok(()) => {
-            tracing::info!(
-                "Successfully pinned process to {} CPU cores for optimal performance",
-                num_cores
-            );
+            tracing::info!("Successfully pinned thread to CPU core {core}");
         }
         Err(e) => {
             tracing::warn!(
-                "Failed to set CPU affinity: {}, continuing without pinning",
-                e
+                "Failed to pin thread to CPU core {core}: {e}, continuing without pinning"
             );
         }
     }
 }
 
+#[cfg(target_os = "linux")]
+fn build_single_cpu_affinity_set(core: usize) -> rustix::thread::CpuSet {
+    let mut cpu_set = rustix::thread::CpuSet::new();
+    cpu_set.set(core);
+    cpu_set
+}
+
+#[cfg(target_os = "linux")]
+fn pin_current_thread_to_first_available_cpu(requested_cores: usize) {
+    let cores = available_cpu_cores(requested_cores);
+    pin_current_thread_to_cpu(cores[0]);
+}
+
+#[cfg(target_os = "linux")]
+fn configure_worker_cpu_pinning(builder: &mut tokio::runtime::Builder, worker_threads: usize) {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    let cores = Arc::new(available_cpu_cores(worker_threads));
+    let next_worker = Arc::new(AtomicUsize::new(0));
+
+    builder.on_thread_start({
+        let cores = Arc::clone(&cores);
+        let next_worker = Arc::clone(&next_worker);
+        move || {
+            let worker_index = next_worker.fetch_add(1, Ordering::Relaxed);
+            let core = cores[worker_index % cores.len()];
+            pin_current_thread_to_cpu(core);
+        }
+    });
+}
+
+#[cfg(target_os = "linux")]
+fn available_cpu_cores(requested_cores: usize) -> Vec<usize> {
+    use rustix::thread::{CpuSet, sched_getaffinity};
+
+    let requested_cores = requested_cores.max(1);
+
+    match sched_getaffinity(None) {
+        Ok(affinity) => cpu_cores_from_affinity(&affinity, requested_cores),
+        Err(error) => {
+            tracing::warn!(
+                "Failed to read CPU affinity mask: {error}, falling back to CPU IDs from zero"
+            );
+            (0..requested_cores.min(CpuSet::MAX_CPU)).collect()
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn cpu_cores_from_affinity(
+    affinity: &rustix::thread::CpuSet,
+    requested_cores: usize,
+) -> Vec<usize> {
+    let mut cores = Vec::with_capacity(requested_cores);
+
+    for core in 0..rustix::thread::CpuSet::MAX_CPU {
+        if affinity.is_set(core) {
+            cores.push(core);
+            if cores.len() == requested_cores {
+                break;
+            }
+        }
+    }
+
+    if cores.is_empty() {
+        cores.push(0);
+    }
+
+    cores
+}
+
 #[cfg(not(target_os = "linux"))]
-fn pin_to_cpu_cores(_num_cores: usize) {
+fn pin_current_thread_to_first_available_cpu(_requested_cores: usize) {
+    tracing::info!("CPU pinning not available on this platform");
+}
+
+#[cfg(not(target_os = "linux"))]
+fn configure_worker_cpu_pinning(_builder: &mut tokio::runtime::Builder, _worker_threads: usize) {
+    tracing::info!("CPU pinning not available on this platform");
+}
+
+#[cfg(not(target_os = "linux"))]
+fn pin_current_thread_to_cpu(_core: usize) {
     tracing::info!("CPU pinning not available on this platform");
 }
 
@@ -1111,7 +1206,7 @@ mod tests {
         // Should default to single-threaded (1 thread)
         assert_eq!(config.worker_threads(), 1);
         assert!(config.is_single_threaded());
-        assert!(config.enable_cpu_pinning); // CPU pinning helps even with 1 thread
+        assert_eq!(config.cpu_pinning, CpuPinning::Enabled);
     }
 
     #[test]
@@ -1138,7 +1233,7 @@ mod tests {
         let config = RuntimeConfig::from_args(Some(thread_count));
 
         assert_eq!(config.worker_threads(), 8);
-        assert!(config.enable_cpu_pinning);
+        assert_eq!(config.cpu_pinning, CpuPinning::Enabled);
     }
 
     #[test]
@@ -1147,7 +1242,7 @@ mod tests {
         let config = RuntimeConfig::from_args(Some(thread_count)).without_cpu_pinning();
 
         assert_eq!(config.worker_threads(), 4);
-        assert!(!config.enable_cpu_pinning);
+        assert_eq!(config.cpu_pinning, CpuPinning::Disabled);
     }
 
     #[test]
@@ -1159,10 +1254,33 @@ mod tests {
         assert_eq!(config.worker_threads(), expected.worker_threads());
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
-    fn test_pin_to_cpu_cores_non_fatal() {
-        // Should not panic even if pinning fails
-        pin_to_cpu_cores(1);
+    fn test_build_single_cpu_affinity_set_sets_requested_core() {
+        let cpu_set = build_single_cpu_affinity_set(4);
+
+        assert!(cpu_set.is_set(4));
+        assert!(!cpu_set.is_set(3));
+        assert!(!cpu_set.is_set(5));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_cpu_cores_from_affinity_uses_allowed_cpu_ids() {
+        let mut affinity = rustix::thread::CpuSet::new();
+        affinity.set(2);
+        affinity.set(4);
+        affinity.set(6);
+
+        assert_eq!(cpu_cores_from_affinity(&affinity, 2), vec![2, 4]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_cpu_cores_from_affinity_falls_back_when_mask_is_empty() {
+        let affinity = rustix::thread::CpuSet::new();
+
+        assert_eq!(cpu_cores_from_affinity(&affinity, 4), vec![0]);
     }
 
     // Edge case tests
@@ -1186,12 +1304,44 @@ mod tests {
     }
 
     #[test]
+    fn test_build_runtime_single_threaded_without_cpu_pinning() {
+        let rt = RuntimeConfig::from_args(Some(ThreadCount::new(1).unwrap()))
+            .without_cpu_pinning()
+            .build_runtime()
+            .unwrap();
+
+        let value = rt.block_on(async { 7usize });
+        assert_eq!(value, 7);
+    }
+
+    #[test]
+    fn test_build_runtime_multi_threaded_without_cpu_pinning() {
+        let rt = RuntimeConfig::from_args(Some(ThreadCount::new(2).unwrap()))
+            .without_cpu_pinning()
+            .build_runtime()
+            .unwrap();
+
+        let value = rt.block_on(async { tokio::task::spawn(async { 11usize }).await.unwrap() });
+        assert_eq!(value, 11);
+    }
+
+    #[test]
+    fn test_build_runtime_multi_threaded_with_cpu_pinning() {
+        let rt = RuntimeConfig::from_args(Some(ThreadCount::new(2).unwrap()))
+            .build_runtime()
+            .unwrap();
+
+        let value = rt.block_on(async { tokio::task::spawn(async { 13usize }).await.unwrap() });
+        assert_eq!(value, 13);
+    }
+
+    #[test]
     fn test_runtime_config_clone() {
         let config = RuntimeConfig::from_args(Some(ThreadCount::new(4).unwrap()));
         let cloned = config.clone();
 
         assert_eq!(cloned.worker_threads(), config.worker_threads());
-        assert_eq!(cloned.enable_cpu_pinning, config.enable_cpu_pinning);
+        assert_eq!(cloned.cpu_pinning, config.cpu_pinning);
     }
 
     #[test]
@@ -1201,7 +1351,7 @@ mod tests {
 
         assert!(debug_str.contains("RuntimeConfig"));
         assert!(debug_str.contains("worker_threads"));
-        assert!(debug_str.contains("enable_cpu_pinning"));
+        assert!(debug_str.contains("cpu_pinning"));
     }
 
     #[tokio::test]
@@ -1333,7 +1483,7 @@ mod tests {
             RuntimeConfig::from_args(Some(ThreadCount::new(4).unwrap())).without_cpu_pinning();
 
         assert_eq!(config.worker_threads(), 4);
-        assert!(!config.enable_cpu_pinning);
+        assert_eq!(config.cpu_pinning, CpuPinning::Disabled);
     }
 
     #[test]
@@ -1342,7 +1492,7 @@ mod tests {
             .without_cpu_pinning()
             .without_cpu_pinning(); // Idempotent
 
-        assert!(!config.enable_cpu_pinning);
+        assert_eq!(config.cpu_pinning, CpuPinning::Disabled);
     }
 
     // Getter tests
@@ -1371,41 +1521,6 @@ mod tests {
         assert!(!config.is_single_threaded());
     }
 
-    // CPU pinning platform-specific tests
-
-    #[test]
-    #[cfg(target_os = "linux")]
-    fn test_pin_to_cpu_cores_linux_single_core() {
-        pin_to_cpu_cores(1);
-    }
-
-    #[test]
-    #[cfg(target_os = "linux")]
-    fn test_pin_to_cpu_cores_linux_multi_core() {
-        pin_to_cpu_cores(4);
-    }
-
-    #[test]
-    #[cfg(target_os = "linux")]
-    fn test_pin_to_cpu_cores_linux_zero_cores() {
-        // Edge case: 0 cores should still succeed (no-op)
-        pin_to_cpu_cores(0);
-    }
-
-    #[test]
-    #[cfg(target_os = "linux")]
-    fn test_pin_to_cpu_cores_linux_many_cores() {
-        // Try to pin to more cores than available - should not panic
-        pin_to_cpu_cores(1024);
-    }
-
-    #[test]
-    #[cfg(not(target_os = "linux"))]
-    fn test_pin_to_cpu_cores_non_linux() {
-        // Non-Linux platforms should gracefully no-op
-        pin_to_cpu_cores(4);
-    }
-
     // Default implementation tests
 
     #[test]
@@ -1417,10 +1532,7 @@ mod tests {
             default_config.worker_threads(),
             explicit_config.worker_threads()
         );
-        assert_eq!(
-            default_config.enable_cpu_pinning,
-            explicit_config.enable_cpu_pinning
-        );
+        assert_eq!(default_config.cpu_pinning, explicit_config.cpu_pinning);
     }
 
     #[test]
@@ -1432,7 +1544,7 @@ mod tests {
     #[test]
     fn test_default_has_cpu_pinning_enabled() {
         let config = RuntimeConfig::default();
-        assert!(config.enable_cpu_pinning);
+        assert_eq!(config.cpu_pinning, CpuPinning::Enabled);
     }
 
     // Configuration combination tests
@@ -1441,7 +1553,7 @@ mod tests {
     fn test_config_single_threaded_with_pinning() {
         let config = RuntimeConfig::from_args(Some(ThreadCount::new(1).unwrap()));
         assert!(config.is_single_threaded());
-        assert!(config.enable_cpu_pinning);
+        assert_eq!(config.cpu_pinning, CpuPinning::Enabled);
     }
 
     #[test]
@@ -1449,14 +1561,14 @@ mod tests {
         let config =
             RuntimeConfig::from_args(Some(ThreadCount::new(1).unwrap())).without_cpu_pinning();
         assert!(config.is_single_threaded());
-        assert!(!config.enable_cpu_pinning);
+        assert_eq!(config.cpu_pinning, CpuPinning::Disabled);
     }
 
     #[test]
     fn test_config_multi_threaded_with_pinning() {
         let config = RuntimeConfig::from_args(Some(ThreadCount::new(4).unwrap()));
         assert!(!config.is_single_threaded());
-        assert!(config.enable_cpu_pinning);
+        assert_eq!(config.cpu_pinning, CpuPinning::Enabled);
     }
 
     #[test]
@@ -1464,7 +1576,7 @@ mod tests {
         let config =
             RuntimeConfig::from_args(Some(ThreadCount::new(4).unwrap())).without_cpu_pinning();
         assert!(!config.is_single_threaded());
-        assert!(!config.enable_cpu_pinning);
+        assert_eq!(config.cpu_pinning, CpuPinning::Disabled);
     }
 
     // ========================================================================

--- a/src/session/handlers/article_retry.rs
+++ b/src/session/handlers/article_retry.rs
@@ -4,22 +4,19 @@
 //! to skip backends that have already returned 430 for a given article.
 
 use crate::cache::ArticleAvailability;
-use crate::router::{ArticleBackend, BackendSelector, SuppressedBackends};
+use crate::router::{BackendSelector, SuppressedBackends};
 use crate::session::ClientSession;
 use crate::session::SessionError;
 use crate::session::handlers::cache_operations::{
     CacheLookupResult, write_cached_article_response,
 };
 use crate::session::handlers::command_execution::{
-    ArticleAttemptState, AuthoritativeArticleMissing, BackendAttemptResult, ResponseWriteParams,
-    RetryAttemptKind,
+    ArticleAttemptState, AuthoritativeArticleMissing, BackendAttemptResult,
 };
 use crate::types::{BackendToClientBytes, ClientToBackendBytes};
 use anyhow::Result;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use tokio::io::{AsyncWrite, AsyncWriteExt};
-use tokio::sync::Notify;
 use tracing::{debug, trace, warn};
 
 use crate::protocol::RequestContext;
@@ -44,128 +41,7 @@ pub(super) enum PreparedRequest {
     },
 }
 
-pub(super) struct OrderedPipelineGate {
-    next: AtomicUsize,
-    failed: AtomicBool,
-    notify: Notify,
-}
-
-impl OrderedPipelineGate {
-    pub(super) fn new() -> Self {
-        Self {
-            next: AtomicUsize::new(0),
-            failed: AtomicBool::new(false),
-            notify: Notify::new(),
-        }
-    }
-
-    async fn wait_turn(&self, index: usize) -> OrderedPipelineTurn<'_> {
-        loop {
-            if self.next.load(Ordering::Acquire) == index {
-                return OrderedPipelineTurn {
-                    gate: self,
-                    advanced: false,
-                };
-            }
-
-            let notified = self.notify.notified();
-            if self.next.load(Ordering::Acquire) == index {
-                return OrderedPipelineTurn {
-                    gate: self,
-                    advanced: false,
-                };
-            }
-            notified.await;
-        }
-    }
-
-    fn advance(&self) {
-        self.next.fetch_add(1, Ordering::AcqRel);
-        self.notify.notify_waiters();
-    }
-
-    fn is_failed(&self) -> bool {
-        self.failed.load(Ordering::Acquire)
-    }
-
-    fn fail(&self) {
-        self.failed.store(true, Ordering::Release);
-    }
-}
-
-struct OrderedPipelineTurn<'a> {
-    gate: &'a OrderedPipelineGate,
-    advanced: bool,
-}
-
-impl OrderedPipelineTurn<'_> {
-    fn advance(mut self) {
-        self.advanced = true;
-        self.gate.advance();
-    }
-
-    fn fail_and_advance(mut self) {
-        self.advanced = true;
-        self.gate.fail();
-        self.gate.advance();
-    }
-}
-
-impl Drop for OrderedPipelineTurn<'_> {
-    fn drop(&mut self) {
-        if !self.advanced {
-            self.gate.advance();
-        }
-    }
-}
-
-pub(super) struct OrderedLargeTransferResult {
-    pub(super) additional_client_to_backend_bytes: ClientToBackendBytes,
-    pub(super) backend_to_client_bytes: BackendToClientBytes,
-}
-
-type OrderedLargeTransferAttemptData = (
-    ArticleBackend,
-    crate::router::CommandGuard,
-    crate::pool::ConnectionGuard,
-    crate::protocol::StatusCode,
-    crate::pool::PooledBuffer,
-);
-
-type OrderedLargeTransferAttempt =
-    Result<Option<OrderedLargeTransferAttemptData>, OrderedLargeTransferNoAttempt>;
-
-enum OrderedLargeTransferNoAttempt {
-    BackendUnavailable,
-    NoRetryableBackend,
-}
-
 impl ClientSession {
-    fn additional_ordered_retry_client_to_backend_bytes(
-        client_to_backend_bytes: ClientToBackendBytes,
-        initial_request_wire_len: usize,
-    ) -> ClientToBackendBytes {
-        client_to_backend_bytes
-            .saturating_sub(ClientToBackendBytes::zero().add(initial_request_wire_len))
-    }
-
-    fn finish_ordered_large_transfer_request(
-        backend_connection: &mut Option<(crate::types::BackendId, crate::pool::ConnectionGuard)>,
-        client_to_backend_bytes: ClientToBackendBytes,
-        initial_request_wire_len: usize,
-        backend_to_client_bytes: BackendToClientBytes,
-    ) -> OrderedLargeTransferResult {
-        Self::release_cached_backend_connection(backend_connection);
-        OrderedLargeTransferResult {
-            additional_client_to_backend_bytes:
-                Self::additional_ordered_retry_client_to_backend_bytes(
-                    client_to_backend_bytes,
-                    initial_request_wire_len,
-                ),
-            backend_to_client_bytes,
-        }
-    }
-
     /// Route a single request to a backend and execute it
     ///
     /// This function is `pub(super)` to allow reuse of per-command routing logic by sibling handler modules
@@ -389,14 +265,6 @@ impl ClientSession {
             .map_err(|e| SessionError::from(anyhow::Error::from(e)))
     }
 
-    fn release_cached_backend_connection(
-        backend_connection: &mut Option<(crate::types::BackendId, crate::pool::ConnectionGuard)>,
-    ) {
-        if let Some((_backend_id, conn)) = backend_connection.take() {
-            let _ = conn.complete_success();
-        }
-    }
-
     async fn execute_article_retry_loop(
         &self,
         router: &Arc<BackendSelector>,
@@ -523,285 +391,6 @@ impl ClientSession {
         Ok(())
     }
 
-    pub(super) async fn execute_ordered_large_transfer_request(
-        &self,
-        router: Arc<BackendSelector>,
-        request: &RequestContext,
-        client_writer: crate::session::SharedClientWriter,
-        order: Arc<OrderedPipelineGate>,
-        order_index: usize,
-    ) -> Result<OrderedLargeTransferResult, SessionError> {
-        debug!(
-            client = %self.client_addr,
-            order_index,
-            command_verb = ?request.verb(),
-            msg_id = ?request.message_id_value(),
-            "Starting ordered large-transfer pipeline request"
-        );
-
-        let msg_id = request.message_id_value();
-        let mut availability = self
-            .load_article_availability(msg_id.as_ref(), router.backend_count())
-            .await;
-        let mut backend_connection = None;
-        let mut client_to_backend_bytes = ClientToBackendBytes::zero();
-        let mut backend_to_client_bytes = BackendToClientBytes::zero();
-        let mut unavailable_backends = SuppressedBackends::empty();
-        let mut is_retry_attempt = false;
-
-        while !availability.all_exhausted(router.backend_count()) {
-            let attempt = match self
-                .prepare_ordered_large_transfer_attempt(
-                    &router,
-                    request,
-                    &mut ArticleAttemptState {
-                        availability: &mut availability,
-                        client_to_backend_bytes: &mut client_to_backend_bytes,
-                        backend_connection: &mut backend_connection,
-                        unavailable_backends: &mut unavailable_backends,
-                    },
-                    is_retry_attempt,
-                )
-                .await
-            {
-                Ok(attempt) => attempt,
-                Err(err) => {
-                    Self::release_cached_backend_connection(&mut backend_connection);
-                    let turn = order.wait_turn(order_index).await;
-                    turn.fail_and_advance();
-                    return Err(err);
-                }
-            };
-
-            let Some((backend, guard, mut conn, status_code, buffer)) = (match attempt {
-                Ok(attempt) => attempt,
-                Err(OrderedLargeTransferNoAttempt::BackendUnavailable) => {
-                    is_retry_attempt = true;
-                    continue;
-                }
-                Err(OrderedLargeTransferNoAttempt::NoRetryableBackend) => {
-                    Self::release_cached_backend_connection(&mut backend_connection);
-
-                    let turn = order.wait_turn(order_index).await;
-                    if order.is_failed() {
-                        turn.advance();
-                        return Err(SessionError::Backend(anyhow::anyhow!(
-                            "ordered pipeline request aborted after earlier slot error"
-                        )));
-                    }
-                    let bytes_written = {
-                        let mut client_write = client_writer.lock().await;
-                        Self::write_backend_error_response(&mut *client_write).await
-                    };
-                    match bytes_written {
-                        Ok(bytes_written) => {
-                            backend_to_client_bytes = backend_to_client_bytes.add(bytes_written);
-                            turn.advance();
-                            return Ok(Self::finish_ordered_large_transfer_request(
-                                &mut backend_connection,
-                                client_to_backend_bytes,
-                                request.request_wire_len().get(),
-                                backend_to_client_bytes,
-                            ));
-                        }
-                        Err(err) => {
-                            turn.fail_and_advance();
-                            order.fail();
-                            return Err(err);
-                        }
-                    }
-                }
-            }) else {
-                continue;
-            };
-            let backend_id = backend.backend_id();
-
-            let backend = match AuthoritativeArticleMissing::from_status_code(backend, status_code)
-            {
-                Ok(missing) => {
-                    self.record_authoritative_article_missing(&missing, &mut availability);
-                    if let Some(msg_id) = request.message_id_value() {
-                        self.cache.record_backend_missing(msg_id, backend_id).await;
-                    }
-                    let mut buffer = buffer;
-                    if let Err(err) = crate::session::backend::observe_response(
-                        request,
-                        &mut buffer,
-                        &mut conn,
-                        &self.buffer_pool,
-                        backend_id,
-                    )
-                    .await
-                    .map_err(SessionError::from)
-                    {
-                        Self::release_cached_backend_connection(&mut backend_connection);
-                        let turn = order.wait_turn(order_index).await;
-                        turn.fail_and_advance();
-                        return Err(err);
-                    }
-                    self.release_or_reuse_connection(
-                        conn,
-                        backend_id,
-                        request,
-                        Some(&mut backend_connection),
-                    );
-                    continue;
-                }
-                Err(backend) => backend,
-            };
-
-            let msg_id = request.message_id_value();
-            let response = {
-                let turn = order.wait_turn(order_index).await;
-                if order.is_failed() {
-                    Self::release_cached_backend_connection(&mut backend_connection);
-                    turn.advance();
-                    return Err(SessionError::Backend(anyhow::anyhow!(
-                        "ordered pipeline request aborted after earlier slot error"
-                    )));
-                }
-                let mut client_write = client_writer.lock().await;
-                let response = self
-                    .write_successful_backend_response(
-                        conn,
-                        &mut *client_write,
-                        &backend,
-                        buffer,
-                        ResponseWriteParams {
-                            request,
-                            msg_id: msg_id.as_ref(),
-                            status_code,
-                        },
-                        Some(&mut backend_connection),
-                    )
-                    .await;
-                if response.is_err() {
-                    turn.fail_and_advance();
-                } else {
-                    turn.advance();
-                }
-                response
-            };
-
-            let response = match response {
-                Ok(response) => response,
-                Err(e @ SessionError::ClientDisconnect(_)) => {
-                    order.fail();
-                    Self::release_cached_backend_connection(&mut backend_connection);
-                    return Err(e);
-                }
-                Err(e) => {
-                    order.fail();
-                    Self::release_cached_backend_connection(&mut backend_connection);
-                    return Err(e);
-                }
-            };
-
-            guard.complete();
-            backend_to_client_bytes = backend_to_client_bytes.add(response.wire_len().get());
-            return Ok(Self::finish_ordered_large_transfer_request(
-                &mut backend_connection,
-                client_to_backend_bytes,
-                request.request_wire_len().get(),
-                backend_to_client_bytes,
-            ));
-        }
-
-        {
-            let turn = order.wait_turn(order_index).await;
-            if order.is_failed() {
-                Self::release_cached_backend_connection(&mut backend_connection);
-                turn.advance();
-                return Err(SessionError::Backend(anyhow::anyhow!(
-                    "ordered pipeline request aborted after earlier slot error"
-                )));
-            }
-            let mut client_write = client_writer.lock().await;
-            let response = self
-                .send_430_to_client(&mut *client_write, &mut backend_to_client_bytes)
-                .await;
-            if let Err(err) = response {
-                turn.fail_and_advance();
-                Self::release_cached_backend_connection(&mut backend_connection);
-                return Err(SessionError::from(err));
-            }
-            turn.advance();
-        }
-
-        Ok(Self::finish_ordered_large_transfer_request(
-            &mut backend_connection,
-            client_to_backend_bytes,
-            request.request_wire_len().get(),
-            backend_to_client_bytes,
-        ))
-    }
-
-    async fn prepare_ordered_large_transfer_attempt(
-        &self,
-        router: &Arc<BackendSelector>,
-        request: &RequestContext,
-        state: &mut ArticleAttemptState<'_>,
-        is_retry_attempt: bool,
-    ) -> Result<OrderedLargeTransferAttempt, SessionError> {
-        if let Some(delay) = router
-            .queue_backpressure_delay_for_article(state.availability, *state.unavailable_backends)
-        {
-            tokio::time::sleep(delay).await;
-        }
-        let route_request = crate::router::RouteRequest::new(self.client_id)
-            .with_availability(state.availability)
-            .suppressing_backends(*state.unavailable_backends);
-        let backend = match router.route(route_request) {
-            Ok(backend) => backend,
-            Err(err) => {
-                debug!(
-                    client = %self.client_addr,
-                    error = %err,
-                    command_verb = ?request.verb(),
-                    msg_id = ?request.message_id_value(),
-                    "No eligible backend available for ordered pipeline attempt"
-                );
-                return Ok(Err(OrderedLargeTransferNoAttempt::NoRetryableBackend));
-            }
-        };
-        let backend_id = backend.backend_id();
-        let guard =
-            crate::router::BackendSelector::guard_for_routed_backend(router.clone(), backend_id);
-        let Some(provider) = self.retry_backend_provider(
-            router,
-            &backend,
-            request,
-            RetryAttemptKind::OrderedPipeline,
-        ) else {
-            state.unavailable_backends.suppress(backend_id);
-            return Ok(Err(OrderedLargeTransferNoAttempt::BackendUnavailable));
-        };
-        let prepared = self
-            .prepare_backend_attempt(provider, &backend, request, state, is_retry_attempt)
-            .await;
-        let Some((conn, status_code, buffer)) = (match prepared {
-            Ok(prepared) => prepared,
-            Err(SessionError::Backend(err)) => {
-                state.unavailable_backends.suppress(backend_id);
-                debug!(
-                    client = %self.client_addr,
-                    backend = backend_id.as_index(),
-                    unavailable_backends = format_args!("{:08b}", state.unavailable_backends.bits()),
-                    command_verb = ?request.verb(),
-                    msg_id = ?request.message_id_value(),
-                    error = %err,
-                    "Ordered pipeline backend attempt failed; trying next eligible backend"
-                );
-                return Ok(Err(OrderedLargeTransferNoAttempt::BackendUnavailable));
-            }
-            Err(err) => return Err(err),
-        }) else {
-            return Ok(Ok(None));
-        };
-
-        Ok(Ok(Some((backend, guard, conn, status_code, buffer))))
-    }
-
     /// Load article availability from cache or create fresh tracker
     pub(super) async fn load_article_availability(
         &self,
@@ -848,68 +437,11 @@ impl ClientSession {
 
 #[cfg(test)]
 mod tests {
-    use super::OrderedPipelineGate;
     use crate::cache::UnifiedCache;
     use crate::protocol::{RequestCacheAvailability, StatusCode};
     use crate::session::ClientSession;
-    use crate::types::{BackendId, BackendToClientBytes, ClientToBackendBytes, MessageId};
-    use std::sync::Arc;
+    use crate::types::{BackendId, MessageId};
     use std::time::Duration;
-    use tokio::sync::mpsc;
-
-    #[tokio::test]
-    async fn ordered_pipeline_gate_releases_waiters_in_index_order() {
-        let gate = Arc::new(OrderedPipelineGate::new());
-        let (tx, mut rx) = mpsc::unbounded_channel();
-
-        for index in [2, 0, 1] {
-            let gate = gate.clone();
-            let tx = tx.clone();
-            tokio::spawn(async move {
-                let turn = gate.wait_turn(index).await;
-                tx.send(index).expect("receiver should remain open");
-                turn.advance();
-            });
-        }
-        drop(tx);
-
-        assert_eq!(rx.recv().await, Some(0));
-        assert_eq!(rx.recv().await, Some(1));
-        assert_eq!(rx.recv().await, Some(2));
-        assert_eq!(rx.recv().await, None);
-    }
-
-    #[tokio::test]
-    async fn ordered_pipeline_gate_drop_advances_turn() {
-        let gate = Arc::new(OrderedPipelineGate::new());
-        let (tx, mut rx) = mpsc::unbounded_channel();
-
-        let first = gate.wait_turn(0).await;
-        let waiter = {
-            let gate = gate.clone();
-            tokio::spawn(async move {
-                let turn = gate.wait_turn(1).await;
-                tx.send(()).expect("receiver should remain open");
-                turn.advance();
-            })
-        };
-
-        drop(first);
-        assert_eq!(rx.recv().await, Some(()));
-        waiter.await.expect("waiter task should complete");
-    }
-
-    #[tokio::test]
-    async fn ordered_pipeline_gate_failure_is_visible_to_later_turns() {
-        let gate = Arc::new(OrderedPipelineGate::new());
-
-        let first = gate.wait_turn(0).await;
-        first.fail_and_advance();
-
-        let second = gate.wait_turn(1).await;
-        assert!(gate.is_failed());
-        second.advance();
-    }
 
     #[tokio::test]
     async fn status_fact_preserves_missing_backend_without_payload() {
@@ -950,40 +482,5 @@ mod tests {
         assert!(!availability.should_try(BackendId::from_index(1)));
         assert!(availability.should_try(BackendId::from_index(2)));
         assert_eq!(availability.missing_bits(), 0b0000_0010);
-    }
-
-    #[test]
-    fn ordered_retry_byte_delta_reports_only_extra_attempts() {
-        let delta = ClientSession::additional_ordered_retry_client_to_backend_bytes(
-            crate::types::ClientToBackendBytes::new(24),
-            8,
-        );
-
-        assert_eq!(delta.as_u64(), 16);
-    }
-
-    #[test]
-    fn ordered_retry_byte_delta_saturates_before_first_attempt() {
-        let delta = ClientSession::additional_ordered_retry_client_to_backend_bytes(
-            crate::types::ClientToBackendBytes::new(4),
-            8,
-        );
-
-        assert_eq!(delta.as_u64(), 0);
-    }
-
-    #[test]
-    fn ordered_large_transfer_finish_reports_extra_upload_and_download_bytes() {
-        let mut backend_connection = None;
-        let result = ClientSession::finish_ordered_large_transfer_request(
-            &mut backend_connection,
-            ClientToBackendBytes::new(30),
-            10,
-            BackendToClientBytes::new(42),
-        );
-
-        assert_eq!(result.additional_client_to_backend_bytes.as_u64(), 20);
-        assert_eq!(result.backend_to_client_bytes.as_u64(), 42);
-        assert!(backend_connection.is_none());
     }
 }

--- a/src/session/handlers/command_execution.rs
+++ b/src/session/handlers/command_execution.rs
@@ -60,14 +60,12 @@ pub(super) struct ArticleAttemptState<'a> {
 #[derive(Clone, Copy)]
 pub(super) enum RetryAttemptKind {
     Direct,
-    OrderedPipeline,
 }
 
 impl RetryAttemptKind {
     const fn as_str(self) -> &'static str {
         match self {
             Self::Direct => "direct retry",
-            Self::OrderedPipeline => "ordered pipeline retry",
         }
     }
 }

--- a/src/session/handlers/per_command.rs
+++ b/src/session/handlers/per_command.rs
@@ -16,7 +16,6 @@ use crate::session::common;
 use crate::session::routing::{CommandRoutingDecision, decide_request_routing};
 use crate::session::{ClientSession, connection};
 use anyhow::Result;
-use futures::{StreamExt, stream::FuturesUnordered};
 use std::sync::Arc;
 use tokio::io::{AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
@@ -26,12 +25,7 @@ use crate::command::{CommandAction, CommandHandler};
 use crate::constants::buffer::READER_CAPACITY;
 use crate::router::BackendSelector;
 use crate::session::SessionError;
-use crate::session::handlers::article_retry::OrderedPipelineGate;
 use crate::types::{BackendId, BackendToClientBytes, ClientToBackendBytes, TransferMetrics};
-
-/// Ordered large-transfer pipelining is disabled due to sustained throughput regressions
-/// from long-lived regular buffer holds in the write path.
-const ORDERED_LARGE_TRANSFER_PIPELINE_ENABLED: bool = false;
 
 fn safe_command_log_label(request: &RequestContext) -> &str {
     std::str::from_utf8(request.verb()).unwrap_or("<non-utf8-command>")
@@ -625,13 +619,6 @@ impl ClientSession {
         backend_connection: &mut BatchBackendConnection,
     ) -> Result<BatchLoopAction, SessionError> {
         let batch_size = batch.len();
-
-        if self.can_process_ordered_large_transfer_batch(router, batch, state) {
-            return self
-                .process_ordered_large_transfer_batch(router, client_writer, state, batch)
-                .await;
-        }
-
         for i in 0..batch_size {
             let request = batch.context(i);
             debug!(
@@ -671,98 +658,6 @@ impl ClientSession {
                     ));
                 }
             }
-        }
-
-        Ok(BatchLoopAction::Continue)
-    }
-
-    fn can_process_ordered_large_transfer_batch(
-        &self,
-        router: &Arc<BackendSelector>,
-        batch: &crate::session::handlers::pipeline::RequestBatch,
-        state: &PerCommandLoopState,
-    ) -> bool {
-        if !ORDERED_LARGE_TRANSFER_PIPELINE_ENABLED {
-            return false;
-        }
-
-        if router.backend_count() <= 1
-            || batch.len() <= 1
-            || self.cache_articles
-            || self.adaptive_precheck
-        {
-            return false;
-        }
-
-        let skip_auth_check = self.is_authenticated_cached(state.skip_auth_check);
-        (0..batch.len()).all(|i| {
-            let request = batch.context(i);
-            request.is_large_transfer()
-                && decide_request_routing(
-                    request,
-                    skip_auth_check,
-                    self.auth_handler.is_enabled(),
-                    self.mode_state.routing_mode(),
-                ) == CommandRoutingDecision::Forward
-        })
-    }
-
-    async fn process_ordered_large_transfer_batch(
-        &self,
-        router: &Arc<BackendSelector>,
-        client_writer: &crate::session::SharedClientWriter,
-        state: &mut PerCommandLoopState,
-        batch: &crate::session::handlers::pipeline::RequestBatch,
-    ) -> Result<BatchLoopAction, SessionError> {
-        let batch_size = batch.len();
-        let order = Arc::new(OrderedPipelineGate::new());
-        let mut futures = FuturesUnordered::new();
-
-        state.skip_auth_check = self.is_authenticated_cached(state.skip_auth_check);
-        for i in 0..batch_size {
-            let request = batch.context(i);
-            debug!(
-                "Client {} dispatching ordered pipeline request {} of {}: kind={:?}, verb={:?}",
-                self.client_addr,
-                i + 1,
-                batch_size,
-                request.kind(),
-                request.verb()
-            );
-            state.client_to_backend_bytes = state
-                .client_to_backend_bytes
-                .add(request.request_wire_len().get());
-
-            futures.push(self.execute_ordered_large_transfer_request(
-                router.clone(),
-                request,
-                client_writer.clone(),
-                order.clone(),
-                i,
-            ));
-        }
-
-        let mut first_error = None;
-        while let Some(result) = futures.next().await {
-            match result {
-                Ok(result) => {
-                    state.client_to_backend_bytes = state
-                        .client_to_backend_bytes
-                        .add_u64(result.additional_client_to_backend_bytes.as_u64());
-                    state.backend_to_client_bytes = state
-                        .backend_to_client_bytes
-                        .add_u64(result.backend_to_client_bytes.as_u64());
-                }
-                Err(err) => {
-                    if first_error.is_none() {
-                        first_error = Some(err);
-                    }
-                }
-            }
-        }
-
-        if let Some(err) = first_error {
-            return Err(err);
         }
 
         Ok(BatchLoopAction::Continue)
@@ -1034,10 +929,5 @@ mod tests {
             ),
             "Other errors should NOT be classified as client disconnect"
         );
-    }
-
-    #[test]
-    fn ordered_large_transfer_pipeline_is_disabled() {
-        assert!(!super::ORDERED_LARGE_TRANSFER_PIPELINE_ENABLED);
     }
 }


### PR DESCRIPTION
## What changed
- Replaced the direct `nix` dependency used for Linux CPU pinning with `rustix`.
- Changed multi-thread runtime CPU pinning to run from Tokio worker `on_thread_start`, so the worker threads that drive proxy tasks are pinned instead of only the caller thread.
- Kept the single-thread runtime path pinned on the caller thread before `block_on` drives proxy work.
- Replaced the CPU-pinning boolean with a small `CpuPinning` enum for clearer runtime configuration state.
- Removed the dead ordered large-transfer pipeline path, including its permanently-disabled feature gate and ordered retry/gate support code.
- Added focused runtime tests around CPU affinity mask selection and runtime construction with pinning enabled/disabled.

## Why
- `nix` was only used for CPU affinity, while `rustix` already provided the needed low-level primitives.
- `rustix` was already present transitively in the dependency graph via `crossterm` and `foyer`, so this removes a direct dependency without introducing a new library family.
- The old multi-thread path built Tokio worker threads and then pinned the caller thread, which did not prevent the actual Tokio worker threads from migrating.
- The new worker setup chooses from the current allowed CPU affinity mask when possible, which behaves better under cpuset/systemd/container restrictions than assuming CPU IDs start at zero.
- The ordered large-transfer pipeline had been hard-disabled due to throughput regressions, so keeping the dormant path only added maintenance surface.
- The published `rustix` release already in use here is `1.1.4`, so there was no newer patch to upgrade to.

## Validation
- `cargo test --lib runtime`
- `cargo test --lib per_command`
- `cargo test --lib article_retry`
- `cargo clippy --lib --tests -- -D warnings`
- `cargo fmt --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved CPU pinning mechanism: now uses per-worker thread affinity instead of process-level pinning, with graceful fallbacks on unsupported systems.
  * Removed ordered large transfer pipeline feature and associated routing logic; retry handling now uses availability-aware routing only.

* **Chores**
  * Updated system call dependency for better thread handling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->