### PR TITLE
[codex] Clean up unnecessary async tests

### DIFF
--- a/src/cache/article.rs
+++ b/src/cache/article.rs
@@ -2044,8 +2044,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_cached_article_clone() {
+    #[test]
+    fn test_cached_article_clone() {
         let article = create_test_cached_article("<test@example.com>");
 
         let cloned = article.clone();

--- a/src/cache/mock_hybrid.rs
+++ b/src/cache/mock_hybrid.rs
@@ -157,8 +157,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn upsert_keeps_existing_semantic_payload_over_longer_metadata_only_response() {
+    #[test]
+    fn upsert_keeps_existing_semantic_payload_over_longer_metadata_only_response() {
         let cache = MockHybridCache::new(1024);
         cache.upsert_ingest(
             &msg_id(),
@@ -182,8 +182,8 @@ mod tests {
         assert!(entry.should_try_backend(BackendId::from_index(1)));
     }
 
-    #[tokio::test]
-    async fn basic_ops() -> Result<()> {
+    #[test]
+    fn basic_ops() -> Result<()> {
         let cache = MockHybridCache::new(1024 * 1024);
 
         let message_id = msgid("<test@example.com>");
@@ -204,8 +204,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn upsert_accepts_borrowed_backend_bytes() -> Result<()> {
+    #[test]
+    fn upsert_accepts_borrowed_backend_bytes() -> Result<()> {
         let cache = MockHybridCache::new(1024 * 1024);
         let message_id = msgid("<borrowed@example.com>");
         let buffer = b"220 0 <borrowed@example.com>\r\nSubject: Test\r\n\r\nBody\r\n.\r\n";
@@ -221,8 +221,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn cache_miss_updates_stats() -> Result<()> {
+    #[test]
+    fn cache_miss_updates_stats() -> Result<()> {
         let cache = MockHybridCache::new(1024 * 1024);
 
         let message_id = msgid("<nonexistent@example.com>");
@@ -237,8 +237,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn upsert_preserves_larger_buffer() -> Result<()> {
+    #[test]
+    fn upsert_preserves_larger_buffer() -> Result<()> {
         let cache = MockHybridCache::new(1024 * 1024);
 
         let message_id = msgid("<test@example.com>");
@@ -264,8 +264,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn record_missing_creates_availability_entry() -> Result<()> {
+    #[test]
+    fn record_missing_creates_availability_entry() -> Result<()> {
         let cache = MockHybridCache::new(1024 * 1024);
 
         let message_id = msgid("<missing@example.com>");
@@ -281,8 +281,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn tracks_availability() -> Result<()> {
+    #[test]
+    fn tracks_availability() -> Result<()> {
         let cache = MockHybridCache::new(1024 * 1024);
 
         let message_id = msgid("<avail@example.com>");
@@ -302,8 +302,8 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test]
-    async fn close_succeeds() -> Result<()> {
+    #[test]
+    fn close_succeeds() -> Result<()> {
         let cache = MockHybridCache::new(1024 * 1024);
 
         let message_id = msgid("<test@example.com>");

--- a/src/cache/mod.rs
+++ b/src/cache/mod.rs
@@ -141,8 +141,8 @@ impl<const N: usize> From<&[u8; N]> for CacheIngestResponse {
 mod tests {
     use super::*;
 
-    #[tokio::test]
-    async fn cache_ingest_response_equality_spans_storage_forms() {
+    #[test]
+    fn cache_ingest_response_equality_spans_storage_forms() {
         let bytes = b"220 0 <test@example.com>\r\nBody\r\n.\r\n";
         let pool =
             crate::pool::BufferPool::new(crate::types::BufferSize::try_new(1024).unwrap(), 1)
@@ -166,8 +166,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn cache_ingest_response_status_code_spans_storage_forms() {
+    #[test]
+    fn cache_ingest_response_status_code_spans_storage_forms() {
         let bytes = b"220 0 <test@example.com>\r\nBody\r\n.\r\n";
         let pool =
             crate::pool::BufferPool::new(crate::types::BufferSize::try_new(1024).unwrap(), 1)

--- a/src/pool/buffer.rs
+++ b/src/pool/buffer.rs
@@ -1206,8 +1206,8 @@ mod tests {
     }
     use tokio::io::AsyncWriteExt;
 
-    #[tokio::test]
-    async fn test_buffer_pool_creation() {
+    #[test]
+    fn test_buffer_pool_creation() {
         let pool = BufferPool::new(BufferSize::try_new(8192).unwrap(), 10);
 
         assert_eq!(pool.stats(), (0, 0, 10));
@@ -1219,8 +1219,8 @@ mod tests {
         // Buffer automatically returned on drop
     }
 
-    #[tokio::test]
-    async fn test_acquire_starts_empty_with_stable_capacity() {
+    #[test]
+    fn test_acquire_starts_empty_with_stable_capacity() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
 
         let capacity = {
@@ -1304,8 +1304,8 @@ mod tests {
         assert_eq!(&*buffer, b"220 long");
     }
 
-    #[tokio::test]
-    async fn test_copy_from_slice_overwrites_and_allows_up_to_capacity() {
+    #[test]
+    fn test_copy_from_slice_overwrites_and_allows_up_to_capacity() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
         let mut buffer = pool.acquire();
         let capacity = buffer.capacity();
@@ -1320,9 +1320,9 @@ mod tests {
         assert_eq!(buffer.capacity(), capacity);
     }
 
-    #[tokio::test]
+    #[test]
     #[should_panic(expected = "data exceeds buffer capacity")]
-    async fn test_copy_from_slice_rejects_larger_than_capacity() {
+    fn test_copy_from_slice_rejects_larger_than_capacity() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
         let mut buffer = pool.acquire();
         let too_large = vec![b'X'; buffer.capacity() + 1];
@@ -1330,8 +1330,8 @@ mod tests {
         buffer.copy_from_slice(&too_large);
     }
 
-    #[tokio::test]
-    async fn test_clear_only_changes_initialized_length() {
+    #[test]
+    fn test_clear_only_changes_initialized_length() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
         let mut buffer = pool.acquire();
         let capacity = buffer.capacity();
@@ -1343,8 +1343,8 @@ mod tests {
         assert_eq!(buffer.capacity(), capacity);
     }
 
-    #[tokio::test]
-    async fn test_resized_buffers_are_discarded_instead_of_repooled() {
+    #[test]
+    fn test_resized_buffers_are_discarded_instead_of_repooled() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1).with_capture_pool(8, 1);
 
         let normal_capacity = {
@@ -1369,8 +1369,8 @@ mod tests {
         assert_eq!(capture.capacity(), 8);
     }
 
-    #[tokio::test]
-    async fn test_buffer_pool_get_and_return() {
+    #[test]
+    fn test_buffer_pool_get_and_return() {
         let pool = BufferPool::new(BufferSize::try_new(4096).unwrap(), 5);
 
         // Get a buffer
@@ -1388,8 +1388,8 @@ mod tests {
         assert_eq!(buffer2.capacity(), 4096);
     }
 
-    #[tokio::test]
-    async fn test_buffer_pool_exhaustion() {
+    #[test]
+    fn test_buffer_pool_exhaustion() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 2);
 
         // Lazily allocate all pool-owned buffers.
@@ -1406,8 +1406,8 @@ mod tests {
         drop(buf3);
     }
 
-    #[tokio::test]
-    async fn test_try_acquire_reports_exhaustion_without_allocating() {
+    #[test]
+    fn test_try_acquire_reports_exhaustion_without_allocating() {
         let _guard = hot_path_metrics_test_guard();
         reset_hot_path_allocation_metrics();
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
@@ -1433,8 +1433,8 @@ mod tests {
         assert_eq!(pool.stats(), (0, 1, 1));
     }
 
-    #[tokio::test]
-    async fn test_buffer_hold_metrics_record_regular_and_capture_drops() {
+    #[test]
+    fn test_buffer_hold_metrics_record_regular_and_capture_drops() {
         let _guard = hot_path_metrics_test_guard();
         reset_hot_path_allocation_metrics();
         let pool =
@@ -1460,8 +1460,8 @@ mod tests {
         super::set_response_write_metrics_enabled(was_enabled);
     }
 
-    #[tokio::test]
-    async fn test_oversized_capture_buffer_is_not_reused() {
+    #[test]
+    fn test_oversized_capture_buffer_is_not_reused() {
         let pool =
             BufferPool::new(BufferSize::try_new(1024).unwrap(), 1).with_capture_pool(8192, 1);
 
@@ -1474,8 +1474,8 @@ mod tests {
         assert_eq!(capture2.capacity(), 8192);
     }
 
-    #[tokio::test]
-    async fn test_capture_pool_lazily_allocates_configured_count() {
+    #[test]
+    fn test_capture_pool_lazily_allocates_configured_count() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1).with_capture_pool(8, 4);
 
         assert_eq!(pool.capture_pool_size.load(Ordering::Relaxed), 0);
@@ -1496,8 +1496,8 @@ mod tests {
         assert_eq!(pool.capture_pool_size.load(Ordering::Relaxed), 4);
     }
 
-    #[tokio::test]
-    async fn test_chunked_response_helpers_without_flattening() {
+    #[test]
+    fn test_chunked_response_helpers_without_flattening() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1).with_capture_pool(8, 4);
         let mut response = ChunkedResponse::default();
         response.extend_from_slice(&pool, b"220 0 <id>\r\nBody\r\n.\r\n");
@@ -1511,8 +1511,8 @@ mod tests {
         assert_eq!(&prefix[..], b"220 0 <id>\r\n");
     }
 
-    #[tokio::test]
-    async fn test_chunked_response_uses_more_capture_buffers_instead_of_growing_one() {
+    #[test]
+    fn test_chunked_response_uses_more_capture_buffers_instead_of_growing_one() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1).with_capture_pool(8, 4);
         let mut response = ChunkedResponse::default();
 
@@ -1525,8 +1525,8 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_chunked_response_copy_prefix_clamps_to_length() {
+    #[test]
+    fn test_chunked_response_copy_prefix_clamps_to_length() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1).with_capture_pool(8, 4);
         let mut response = ChunkedResponse::default();
         response.extend_from_slice(&pool, b"430\r\n");
@@ -1536,8 +1536,8 @@ mod tests {
         assert_eq!(&prefix[..], b"430\r\n");
     }
 
-    #[tokio::test]
-    async fn test_chunked_response_can_own_range_without_copying() {
+    #[test]
+    fn test_chunked_response_can_own_range_without_copying() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 2);
         let mut buffer = pool.acquire();
         buffer.copy_from_slice(b"xx220 0 <id>\r\nBody\r\n.\r\nyy");
@@ -1551,8 +1551,8 @@ mod tests {
         assert_eq!(first, b"220 0 <id>\r\nBody\r\n.\r\n");
     }
 
-    #[tokio::test]
-    async fn test_chunked_response_can_share_pooled_range_without_copying() {
+    #[test]
+    fn test_chunked_response_can_share_pooled_range_without_copying() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 2);
         let mut buffer = pool.acquire();
         buffer.copy_from_slice(b"xx220 0 <id>\r\nBody\r\n.\r\nyy");
@@ -1570,8 +1570,8 @@ mod tests {
         assert_eq!(pool.available_buffers(), 1);
     }
 
-    #[tokio::test]
-    async fn test_freeze_detaches_bytes_from_pool_ownership() {
+    #[test]
+    fn test_freeze_detaches_bytes_from_pool_ownership() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 1);
         let mut buffer = pool.acquire();
         buffer.copy_from_slice(b"223 0 <id>\r\n");
@@ -1613,8 +1613,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_buffer_alignment() {
+    #[test]
+    fn test_buffer_alignment() {
         let pool = BufferPool::new(BufferSize::try_new(8192).unwrap(), 1);
         let buffer = pool.acquire();
 
@@ -1624,8 +1624,8 @@ mod tests {
         assert_eq!(buffer.capacity() % 4096, 0);
     }
 
-    #[tokio::test]
-    async fn test_buffer_clear_and_resize() {
+    #[test]
+    fn test_buffer_clear_and_resize() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 2);
 
         let mut buffer = pool.acquire();
@@ -1644,8 +1644,8 @@ mod tests {
         // Note: buffer may contain previous bytes outside the initialized range.
     }
 
-    #[tokio::test]
-    async fn test_buffer_pool_max_size_enforcement() {
+    #[test]
+    fn test_buffer_pool_max_size_enforcement() {
         let pool = BufferPool::new(BufferSize::try_new(512).unwrap(), 3);
 
         // Get all buffers
@@ -1666,8 +1666,8 @@ mod tests {
         // (We can't directly test pool size, but the implementation handles it)
     }
 
-    #[tokio::test]
-    async fn test_buffer_wrong_size_not_returned() {
+    #[test]
+    fn test_buffer_wrong_size_not_returned() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 2);
 
         let buffer = pool.acquire();
@@ -1677,8 +1677,8 @@ mod tests {
         drop(buffer);
     }
 
-    #[tokio::test]
-    async fn test_buffer_pool_multiple_get_return_cycles() {
+    #[test]
+    fn test_buffer_pool_multiple_get_return_cycles() {
         let pool = BufferPool::new(BufferSize::try_new(4096).unwrap(), 5);
 
         // Do multiple get/return cycles
@@ -1702,8 +1702,8 @@ mod tests {
         // (Arc ensures shared ownership)
     }
 
-    #[tokio::test]
-    async fn test_different_buffer_sizes() {
+    #[test]
+    fn test_different_buffer_sizes() {
         let small_pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 5);
         let medium_pool = BufferPool::new(BufferSize::try_new(8192).unwrap(), 5);
         let large_pool = BufferPool::new(BufferSize::try_new(65536).unwrap(), 5);
@@ -1742,8 +1742,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_pooled_buffer_deref() {
+    #[test]
+    fn test_pooled_buffer_deref() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 5);
         let mut buffer = pool.acquire();
 
@@ -1758,8 +1758,8 @@ mod tests {
         assert_eq!(&*buffer, b"Hello");
     }
 
-    #[tokio::test]
-    async fn test_pooled_buffer_as_ref() {
+    #[test]
+    fn test_pooled_buffer_as_ref() {
         let pool = BufferPool::new(BufferSize::try_new(512).unwrap(), 5);
         let mut buffer = pool.acquire();
 
@@ -1771,8 +1771,8 @@ mod tests {
         assert_eq!(slice.len(), 9);
     }
 
-    #[tokio::test]
-    async fn test_copy_from_slice_updates_initialized() {
+    #[test]
+    fn test_copy_from_slice_updates_initialized() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 5);
         let mut buffer = pool.acquire();
 
@@ -1785,9 +1785,9 @@ mod tests {
         assert_eq!(buffer.initialized(), 11);
     }
 
-    #[tokio::test]
+    #[test]
     #[should_panic(expected = "data exceeds buffer capacity")]
-    async fn test_copy_from_slice_panic_on_overflow() {
+    fn test_copy_from_slice_panic_on_overflow() {
         let pool = BufferPool::new(BufferSize::try_new(10).unwrap(), 5);
         let mut buffer = pool.acquire();
 
@@ -1795,15 +1795,15 @@ mod tests {
         buffer.copy_from_slice(&too_large); // Should panic
     }
 
-    #[tokio::test]
-    async fn test_buffer_pool_debug() {
+    #[test]
+    fn test_buffer_pool_debug() {
         let pool = BufferPool::new(BufferSize::try_new(2048).unwrap(), 5);
         let debug_str = format!("{pool:?}");
         assert!(debug_str.contains("BufferPool"));
     }
 
-    #[tokio::test]
-    async fn test_buffer_initialized_tracking() {
+    #[test]
+    fn test_buffer_initialized_tracking() {
         let pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 5);
         let mut buffer = pool.acquire();
 
@@ -1817,8 +1817,8 @@ mod tests {
         assert_eq!(&*buffer, b"Second write");
     }
 
-    #[tokio::test]
-    async fn test_buffer_capacity_vs_initialized() {
+    #[test]
+    fn test_buffer_capacity_vs_initialized() {
         let pool = BufferPool::new(BufferSize::try_new(8192).unwrap(), 5);
         let mut buffer = pool.acquire();
 
@@ -1833,8 +1833,8 @@ mod tests {
         assert_eq!(buffer.initialized(), 5);
     }
 
-    #[tokio::test]
-    async fn test_empty_slice_copy() {
+    #[test]
+    fn test_empty_slice_copy() {
         let pool = BufferPool::new(BufferSize::try_new(512).unwrap(), 5);
         let mut buffer = pool.acquire();
 
@@ -1844,8 +1844,8 @@ mod tests {
         assert_eq!(&*buffer, b"");
     }
 
-    #[tokio::test]
-    async fn test_buffer_reuse_preserves_capacity() {
+    #[test]
+    fn test_buffer_reuse_preserves_capacity() {
         let pool = BufferPool::new(BufferSize::try_new(2048).unwrap(), 5);
 
         {

--- a/src/session/precheck.rs
+++ b/src/session/precheck.rs
@@ -592,18 +592,15 @@ pub fn spawn_background_precheck(
 ) {
     let owned = deps.clone_deps();
     tokio::spawn(async move {
-        // Check cache first - if we have a complete article, no need to query backends
-        if let Some(cached) = owned.cache.get(&msg_id).await
-            && cached.is_complete_article()
+        let cached = owned.cache.get(&msg_id).await;
+        if cached
+            .as_ref()
+            .is_some_and(|entry| entry.is_complete_article())
         {
-            // Already have full article cached - nothing to do
             return;
         }
 
-        let availability = owned
-            .cache
-            .get(&msg_id)
-            .await
+        let availability = cached
             .map(|entry| entry.to_availability(owned.router.backend_count()))
             .unwrap_or_default();
         let results = query_all_backends(&owned, &request, &availability).await;

--- a/tests/cache/bug_430_caching.rs
+++ b/tests/cache/bug_430_caching.rs
@@ -77,8 +77,8 @@ async fn test_multiple_430s_update_same_entry() {
 }
 
 /// Test that 430 responses increment 4xx error metrics
-#[tokio::test]
-async fn test_430_increments_4xx_metrics() {
+#[test]
+fn test_430_increments_4xx_metrics() {
     let metrics = MetricsCollector::new(2); // 2 backends
 
     let backend_id = BackendId::from_index(0);

--- a/tests/cache/unified_cache.rs
+++ b/tests/cache/unified_cache.rs
@@ -15,16 +15,16 @@ use super::article_response_bytes;
 // UnifiedCache Tests
 // ============================================================================
 
-#[tokio::test]
-async fn test_unified_cache_memory_construction() {
+#[test]
+fn test_unified_cache_memory_construction() {
     let cache = UnifiedCache::memory(1000, Duration::from_secs(60));
     assert!(!cache.is_hybrid());
     assert_eq!(cache.capacity(), 1000);
     assert_eq!(cache.entry_count(), 0);
 }
 
-#[tokio::test]
-async fn test_unified_cache_availability_construction() {
+#[test]
+fn test_unified_cache_availability_construction() {
     let cache = UnifiedCache::availability(std::time::Duration::MAX);
     assert!(!cache.is_hybrid());
     assert_eq!(cache.capacity(), AvailabilityIndex::new().capacity_bytes());
@@ -138,14 +138,14 @@ async fn test_unified_cache_availability_records_only_missing_facts() {
     assert_eq!(result.availability().missing_bits(), 0b0000_0010);
 }
 
-#[tokio::test]
-async fn test_unified_cache_is_hybrid_false_for_memory() {
+#[test]
+fn test_unified_cache_is_hybrid_false_for_memory() {
     let cache = UnifiedCache::memory(1000, Duration::from_secs(60));
     assert!(!cache.is_hybrid());
 }
 
-#[tokio::test]
-async fn test_unified_cache_hit_rate_initially_zero() {
+#[test]
+fn test_unified_cache_hit_rate_initially_zero() {
     let cache = UnifiedCache::memory(1000, Duration::from_secs(60));
     // Hit rate should be 0 (or NaN which displays as 0) when no operations
     let hit_rate = cache.hit_rate();
@@ -181,8 +181,8 @@ async fn test_unified_cache_weighted_size() {
 // CacheStatsProvider Tests
 // ============================================================================
 
-#[tokio::test]
-async fn test_cache_stats_provider_article_cache() {
+#[test]
+fn test_cache_stats_provider_article_cache() {
     use nntp_proxy::cache::CacheStatsProvider;
 
     let cache = ArticleCache::new(10000, Duration::from_secs(60));
@@ -193,8 +193,8 @@ async fn test_cache_stats_provider_article_cache() {
     assert!(stats.disk.is_none()); // Memory-only cache has no disk stats
 }
 
-#[tokio::test]
-async fn test_cache_stats_provider_unified_cache_memory() {
+#[test]
+fn test_cache_stats_provider_unified_cache_memory() {
     use nntp_proxy::cache::CacheStatsProvider;
 
     let cache = UnifiedCache::memory(10000, Duration::from_secs(60));

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -138,8 +138,8 @@ async fn test_round_robin_distribution() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn test_config_file_loading() -> Result<()> {
+#[test]
+fn test_config_file_loading() -> Result<()> {
     let config_content = r#"
 [[servers]]
 host = "test1.example.com"

--- a/tests/rfc3977/session.rs
+++ b/tests/rfc3977/session.rs
@@ -71,8 +71,8 @@ async fn test_auth_command_integration() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn test_auth_handler_validate() -> Result<()> {
+#[test]
+fn test_auth_handler_validate() -> Result<()> {
     let handler = AuthHandler::new(Some("user".to_string()), Some("pass".to_string()))?;
 
     assert!(handler.is_enabled());
@@ -83,8 +83,8 @@ async fn test_auth_handler_validate() -> Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn test_auth_handler_disabled() -> Result<()> {
+#[test]
+fn test_auth_handler_disabled() -> Result<()> {
     let handler = AuthHandler::new(None, None)?;
 
     assert!(!handler.is_enabled());

--- a/tests/rfc4643/authentication.rs
+++ b/tests/rfc4643/authentication.rs
@@ -34,8 +34,8 @@ fn auth_handler(username: &str, password: &str) -> Arc<AuthHandler> {
     Arc::new(AuthHandler::new(Some(username.to_string()), Some(password.to_string())).unwrap())
 }
 
-#[tokio::test]
-async fn test_auth_handler_enabled_state() {
+#[test]
+fn test_auth_handler_enabled_state() {
     for (username, password, enabled) in [
         (None, None, false),
         (Some("user"), Some("pass"), true),
@@ -51,8 +51,8 @@ async fn test_auth_handler_enabled_state() {
     }
 }
 
-#[tokio::test]
-async fn test_auth_handler_validates_credentials() {
+#[test]
+fn test_auth_handler_validates_credentials() {
     let handler = auth_handler("alice", "secret123");
     for (username, password, valid) in [
         ("alice", "secret123", true),
@@ -64,8 +64,8 @@ async fn test_auth_handler_validates_credentials() {
     }
 }
 
-#[tokio::test]
-async fn test_auth_disabled_accepts_any_credentials() {
+#[test]
+fn test_auth_disabled_accepts_any_credentials() {
     let handler = AuthHandler::new(None, None).unwrap();
 
     assert!(handler.validate_credentials("anything", "works"));
@@ -73,8 +73,8 @@ async fn test_auth_disabled_accepts_any_credentials() {
     assert!(handler.validate_credentials("random", "stuff"));
 }
 
-#[tokio::test]
-async fn test_auth_handler_partial_config_disabled() {
+#[test]
+fn test_auth_handler_partial_config_disabled() {
     // Only username, no password - should be disabled
     let handler1 = AuthHandler::new(Some("user".to_string()), None).unwrap();
     assert!(!handler1.is_enabled());
@@ -84,8 +84,8 @@ async fn test_auth_handler_partial_config_disabled() {
     assert!(!handler2.is_enabled());
 }
 
-#[tokio::test]
-async fn test_auth_handler_empty_string_credentials() {
+#[test]
+fn test_auth_handler_empty_string_credentials() {
     // SECURITY: Empty credentials must be rejected, not silently disable auth
     let result = AuthHandler::new(Some(String::new()), Some(String::new()));
     assert!(
@@ -94,8 +94,8 @@ async fn test_auth_handler_empty_string_credentials() {
     );
 }
 
-#[tokio::test]
-async fn test_auth_handler_case_sensitive() {
+#[test]
+fn test_auth_handler_case_sensitive() {
     let handler = auth_handler("Alice", "Secret");
     for (username, password, valid) in [
         ("Alice", "Secret", true),
@@ -107,31 +107,31 @@ async fn test_auth_handler_case_sensitive() {
     }
 }
 
-#[tokio::test]
-async fn test_auth_handler_whitespace_in_credentials() {
+#[test]
+fn test_auth_handler_whitespace_in_credentials() {
     let handler = auth_handler("user name", "pass word");
 
     assert!(handler.validate_credentials("user name", "pass word"));
     assert!(!handler.validate_credentials("username", "password"));
 }
 
-#[tokio::test]
-async fn test_auth_handler_special_characters() {
+#[test]
+fn test_auth_handler_special_characters() {
     let handler = auth_handler("user@example.com", "p@$$w0rd!#%");
 
     assert!(handler.validate_credentials("user@example.com", "p@$$w0rd!#%"));
 }
 
-#[tokio::test]
-async fn test_auth_handler_unicode_credentials() {
+#[test]
+fn test_auth_handler_unicode_credentials() {
     let handler = auth_handler("用户", "密码");
 
     assert!(handler.validate_credentials("用户", "密码"));
     assert!(!handler.validate_credentials("user", "password"));
 }
 
-#[tokio::test]
-async fn test_auth_handler_debug_output() {
+#[test]
+fn test_auth_handler_debug_output() {
     for (handler, enabled) in [
         (auth_handler("supersecret", "topsecretpassword"), true),
         (Arc::new(AuthHandler::new(None, None).unwrap()), false),
@@ -144,8 +144,8 @@ async fn test_auth_handler_debug_output() {
     }
 }
 
-#[tokio::test]
-async fn test_auth_command_sequence_valid() {
+#[test]
+fn test_auth_command_sequence_valid() {
     for (command, expected, is_user) in [
         ("AUTHINFO USER alice\r\n", "alice", true),
         ("AUTHINFO PASS secret\r\n", "secret", false),
@@ -164,8 +164,8 @@ async fn test_auth_command_sequence_valid() {
     }
 }
 
-#[tokio::test]
-async fn test_auth_responses_are_valid_nntp() {
+#[test]
+fn test_auth_responses_are_valid_nntp() {
     let handler = auth_handler("user", "pass");
 
     for (response, prefix) in [
@@ -221,15 +221,15 @@ async fn test_reject_response_formatting() {
     assert!(response.ends_with("\r\n"));
 }
 
-#[tokio::test]
-async fn test_command_classification_for_stateless() {
+#[test]
+fn test_command_classification_for_stateless() {
     for command in ["ARTICLE <msgid@example.com>\r\n", "LIST\r\n"] {
         assert_eq!(classify(command), CommandAction::ForwardStateless);
     }
 }
 
-#[tokio::test]
-async fn test_session_with_auth_handler() {
+#[test]
+fn test_session_with_auth_handler() {
     use crate::test_helpers::{
         create_test_addr, create_test_auth_handler_with, create_test_buffer_pool,
     };
@@ -245,8 +245,8 @@ async fn test_session_with_auth_handler() {
     // Session should be created successfully with auth handler
 }
 
-#[tokio::test]
-async fn test_session_with_disabled_auth() {
+#[test]
+fn test_session_with_disabled_auth() {
     use crate::test_helpers::{
         create_test_addr, create_test_auth_handler_disabled, create_test_buffer_pool,
     };
@@ -262,8 +262,8 @@ async fn test_session_with_disabled_auth() {
     assert!(!auth_handler.is_enabled());
 }
 
-#[tokio::test]
-async fn test_config_client_auth_enabled_state() {
+#[test]
+fn test_config_client_auth_enabled_state() {
     use nntp_proxy::config::{ClientAuth, UserCredentials};
 
     for (config, enabled) in [
@@ -290,8 +290,8 @@ async fn test_config_client_auth_enabled_state() {
     }
 }
 
-#[tokio::test]
-async fn test_auth_handler_with_very_long_credentials() {
+#[test]
+fn test_auth_handler_with_very_long_credentials() {
     let long_user = "a".repeat(1000);
     let long_pass = "b".repeat(1000);
 
@@ -302,8 +302,8 @@ async fn test_auth_handler_with_very_long_credentials() {
     assert!(!handler.validate_credentials("short", &long_pass));
 }
 
-#[tokio::test]
-async fn test_multiple_auth_handlers_independent() {
+#[test]
+fn test_multiple_auth_handlers_independent() {
     let handler1 = auth_handler("user1", "pass1");
     let handler2 = auth_handler("user2", "pass2");
 
@@ -314,8 +314,8 @@ async fn test_multiple_auth_handlers_independent() {
     assert!(!handler2.validate_credentials("user1", "pass1"));
 }
 
-#[tokio::test]
-async fn test_auth_handler_clone_via_arc() {
+#[test]
+fn test_auth_handler_clone_via_arc() {
     use crate::test_helpers::create_test_auth_handler;
 
     let handler = create_test_auth_handler();
@@ -326,8 +326,8 @@ async fn test_auth_handler_clone_via_arc() {
     assert_eq!(Arc::strong_count(&handler), 2);
 }
 
-#[tokio::test]
-async fn test_session_builder_with_auth_handler() {
+#[test]
+fn test_session_builder_with_auth_handler() {
     use crate::test_helpers::{
         create_test_addr, create_test_auth_handler, create_test_buffer_pool,
     };
@@ -343,8 +343,8 @@ async fn test_session_builder_with_auth_handler() {
     assert!(!session.is_per_command_routing());
 }
 
-#[tokio::test]
-async fn test_session_builder_with_router_and_auth() {
+#[test]
+fn test_session_builder_with_router_and_auth() {
     use crate::test_helpers::{
         create_test_addr, create_test_auth_handler, create_test_buffer_pool, create_test_router,
     };
@@ -380,20 +380,20 @@ async fn test_proxy_creates_auth_handler_from_config() {
     assert!(!proxy.servers().is_empty());
 }
 
-#[tokio::test]
-async fn test_auth_with_empty_command() {
+#[test]
+fn test_auth_with_empty_command() {
     let _action = classify("");
     // Should be rejected or handled gracefully, not crash
 }
 
-#[tokio::test]
-async fn test_auth_with_whitespace_only_command() {
+#[test]
+fn test_auth_with_whitespace_only_command() {
     let _action = classify("   \r\n");
     // Should be handled gracefully
 }
 
-#[tokio::test]
-async fn test_auth_case_variations() {
+#[test]
+fn test_auth_case_variations() {
     for (command, is_user) in [
         ("AUTHINFO USER test\r\n", true),
         ("authinfo user test\r\n", true),
@@ -444,8 +444,8 @@ async fn test_concurrent_auth_handlers() {
     assert_eq!(incorrect, 50);
 }
 
-#[tokio::test]
-async fn test_auth_handler_response_consistency() {
+#[test]
+fn test_auth_handler_response_consistency() {
     let handler = auth_handler("user", "pass");
 
     // Call multiple times, should always return same static responses
@@ -455,8 +455,8 @@ async fn test_auth_handler_response_consistency() {
     }
 }
 
-#[tokio::test]
-async fn test_auth_with_newlines_in_credentials() {
+#[test]
+fn test_auth_with_newlines_in_credentials() {
     // Newlines in credentials should work (unlikely but valid)
     let handler = auth_handler("user\nname", "pass\nword");
 
@@ -464,8 +464,8 @@ async fn test_auth_with_newlines_in_credentials() {
     assert!(!handler.validate_credentials("username", "password"));
 }
 
-#[tokio::test]
-async fn test_auth_with_null_bytes_in_credentials() {
+#[test]
+fn test_auth_with_null_bytes_in_credentials() {
     // Null bytes in credentials (edge case)
     let handler = auth_handler("user\0name", "pass\0word");
 

--- a/tests/rfc4643/backend.rs
+++ b/tests/rfc4643/backend.rs
@@ -298,8 +298,8 @@ fn test_authinfo_pass_empty() {
 }
 
 /// Test buffer pool creation and usage
-#[tokio::test]
-async fn test_buffer_pool_basic_usage() {
+#[test]
+fn test_buffer_pool_basic_usage() {
     let buffer_pool = BufferPool::new(BufferSize::try_new(8192).unwrap(), 2);
 
     // Get buffer
@@ -317,8 +317,8 @@ async fn test_buffer_pool_basic_usage() {
 }
 
 /// Test buffer pool with different sizes
-#[tokio::test]
-async fn test_buffer_pool_different_sizes() {
+#[test]
+fn test_buffer_pool_different_sizes() {
     let sizes = [1024, 4096, 8192, 16384];
 
     for size in &sizes {

--- a/tests/rfc4643/integration.rs
+++ b/tests/rfc4643/integration.rs
@@ -189,8 +189,8 @@ async fn test_auth_handler_integration() {
     assert!(auth_success); // Valid credentials
 }
 
-#[tokio::test]
-async fn test_config_auth_round_trip() {
+#[test]
+fn test_config_auth_round_trip() {
     // Create config with auth
     let config = Config {
         servers: vec![],

--- a/tests/rfc4643/review_claims.rs
+++ b/tests/rfc4643/review_claims.rs
@@ -290,8 +290,8 @@ async fn test_uninit_buffer_pattern_is_safe() {
 }
 
 /// Test that the buffer pool pattern is sound even with multiple get/return cycles.
-#[tokio::test]
-async fn test_buffer_pool_safety_across_cycles() {
+#[test]
+fn test_buffer_pool_safety_across_cycles() {
     use crate::test_helpers::create_test_buffer_pool;
 
     let pool = create_test_buffer_pool();

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -1167,8 +1167,8 @@ mod tests {
         assert!(response.contains("100 help follows"));
     }
 
-    #[tokio::test]
-    async fn test_create_test_config() {
+    #[test]
+    fn test_create_test_config() {
         let config = create_test_config(vec![(19002, "server1"), (19003, "server2")]);
 
         assert_eq!(config.servers.len(), 2);


### PR DESCRIPTION
## What changed

- Converted synchronous tests from `#[tokio::test] async fn` to plain `#[test] fn` where the test body does not suspend.
- Left the `retry_once!` tests async because the macro expands to a Tokio sleep await.
- Collapsed background precheck's duplicate cache lookup into a single awaited lookup before deriving article availability.

## Why

These tests did not need Tokio runtime setup, which made the async marker misleading and added avoidable test harness overhead. The precheck tweak removes one redundant cache await in background work.

## Validation

- `nix develop -c cargo nextest run` - 2223 passed, 1 skipped
- `nix develop -c cargo fmt --check`
- `nix develop -c cargo clippy --all-targets -- -W clippy::unused_async`
- pre-commit hook: `cargo fmt`, `cargo clippy`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Converted numerous test functions from async Tokio tests to synchronous unit tests across multiple test files for better test execution efficiency.

* **Chores**
  * Optimized session precheck cache operations by consolidating multiple cache lookups into a single read, reducing redundant operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->