### PR TITLE
Fix session user counts and reduce TUI allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,6 +2210,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "twox-hash",
+ "unicode-width",
  "uuid",
  "webpki-roots",
  "yenc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ chrono = { version = "0.4", features = ["serde", "clock"], default-features = fa
 serde_json = "1.0"  # JSON serialization for stats persistence
 postcard = { version = "1.1", features = ["use-std"], default-features = false }  # Compact binary codec for attached TUI dashboard snapshots
 tokio-tungstenite = "0.29"  # WebSocket transport for remote TUI attachment
+unicode-width = "0.2.2"  # Display-width measurement for allocation-free log wrapping
 
 # Derive helpers to reduce newtype boilerplate
 nutype = { version = "0.7", features = ["serde"] }  # Validated newtypes with automatic derives

--- a/src/metrics/collector.rs
+++ b/src/metrics/collector.rs
@@ -1,6 +1,10 @@
 //! Lock-free metrics collector
 
 use super::store::{BackendStore, MetricsStore, UserMetrics};
+use super::types::{
+    CacheEntries, DiskHits, DiskReadIos, DiskWriteIos, PipelineBatches, PipelineCommands,
+    PipelineRequestsCompleted, PipelineRequestsQueued, StatefulSessions,
+};
 use super::{BackendHealthStatus, BackendStats, MetricsSnapshot, UserStats};
 use crate::types::{BackendId, BackendToClientBytes, ClientToBackendBytes};
 use std::path::Path;
@@ -496,18 +500,23 @@ impl MetricsCollector {
             .sum();
 
         let (cache_entries, cache_size_bytes, cache_hit_rate, disk_cache) =
-            cache.map_or((0, 0, 0.0, None), |c| {
+            cache.map_or((CacheEntries::ZERO, 0, 0.0, None), |c| {
                 let stats = c.display_stats();
                 let disk = stats.disk.map(|d| super::snapshot::DiskCacheStats {
-                    disk_hits: d.disk_hits,
+                    disk_hits: DiskHits::new(d.disk_hits),
                     disk_hit_rate: d.disk_hit_rate,
                     disk_capacity: d.capacity,
                     bytes_written: d.bytes_written,
                     bytes_read: d.bytes_read,
-                    write_ios: d.write_ios,
-                    read_ios: d.read_ios,
+                    write_ios: DiskWriteIos::new(d.write_ios),
+                    read_ios: DiskReadIos::new(d.read_ios),
                 });
-                (stats.entry_count, stats.size_bytes, stats.hit_rate, disk)
+                (
+                    CacheEntries::new(stats.entry_count),
+                    stats.size_bytes,
+                    stats.hit_rate,
+                    disk,
+                )
             });
 
         MetricsSnapshot {
@@ -517,7 +526,9 @@ impl MetricsCollector {
             active_connections: super::types::ActiveConnections::new(
                 self.inner.active_connections.load(Ordering::Relaxed),
             ),
-            stateful_sessions: self.inner.stateful_sessions.load(Ordering::Relaxed),
+            stateful_sessions: StatefulSessions::new(
+                self.inner.stateful_sessions.load(Ordering::Relaxed),
+            ),
             client_to_backend_bytes: ClientToBackendBytes::new(total_sent),
             backend_to_client_bytes: BackendToClientBytes::new(total_received),
             uptime: self.inner.start_time.elapsed(),
@@ -527,18 +538,24 @@ impl MetricsCollector {
             cache_size_bytes,
             cache_hit_rate,
             disk_cache,
-            pipeline_batches: self.inner.store.pipeline_batches.load(Ordering::Relaxed),
-            pipeline_commands: self.inner.store.pipeline_commands.load(Ordering::Relaxed),
-            pipeline_requests_queued: self
-                .inner
-                .store
-                .pipeline_requests_queued
-                .load(Ordering::Relaxed),
-            pipeline_requests_completed: self
-                .inner
-                .store
-                .pipeline_requests_completed
-                .load(Ordering::Relaxed),
+            pipeline_batches: PipelineBatches::new(
+                self.inner.store.pipeline_batches.load(Ordering::Relaxed),
+            ),
+            pipeline_commands: PipelineCommands::new(
+                self.inner.store.pipeline_commands.load(Ordering::Relaxed),
+            ),
+            pipeline_requests_queued: PipelineRequestsQueued::new(
+                self.inner
+                    .store
+                    .pipeline_requests_queued
+                    .load(Ordering::Relaxed),
+            ),
+            pipeline_requests_completed: PipelineRequestsCompleted::new(
+                self.inner
+                    .store
+                    .pipeline_requests_completed
+                    .load(Ordering::Relaxed),
+            ),
         }
     }
 
@@ -682,13 +699,22 @@ mod tests {
         let collector = MetricsCollector::new(1);
 
         collector.stateful_session_started();
-        assert_eq!(collector.snapshot(None).stateful_sessions, 1);
+        assert_eq!(
+            collector.snapshot(None).stateful_sessions,
+            StatefulSessions::new(1)
+        );
 
         collector.stateful_session_started();
-        assert_eq!(collector.snapshot(None).stateful_sessions, 2);
+        assert_eq!(
+            collector.snapshot(None).stateful_sessions,
+            StatefulSessions::new(2)
+        );
 
         collector.stateful_session_ended();
-        assert_eq!(collector.snapshot(None).stateful_sessions, 1);
+        assert_eq!(
+            collector.snapshot(None).stateful_sessions,
+            StatefulSessions::new(1)
+        );
     }
 
     #[test]

--- a/src/metrics/collector.rs
+++ b/src/metrics/collector.rs
@@ -511,8 +511,12 @@ impl MetricsCollector {
             });
 
         MetricsSnapshot {
-            total_connections: self.inner.store.total_connections.load(Ordering::Relaxed),
-            active_connections: self.inner.active_connections.load(Ordering::Relaxed),
+            total_connections: crate::types::TotalConnections::new(
+                self.inner.store.total_connections.load(Ordering::Relaxed),
+            ),
+            active_connections: super::types::ActiveConnections::new(
+                self.inner.active_connections.load(Ordering::Relaxed),
+            ),
             stateful_sessions: self.inner.stateful_sessions.load(Ordering::Relaxed),
             client_to_backend_bytes: ClientToBackendBytes::new(total_sent),
             backend_to_client_bytes: BackendToClientBytes::new(total_received),
@@ -657,20 +661,20 @@ mod tests {
     fn test_metrics_collector_connection_lifecycle() {
         let collector = MetricsCollector::new(1);
 
-        assert_eq!(collector.snapshot(None).active_connections, 0);
-        assert_eq!(collector.snapshot(None).total_connections, 0);
+        assert_eq!(collector.snapshot(None).active_connections.get(), 0);
+        assert_eq!(collector.snapshot(None).total_connections.get(), 0);
 
         collector.connection_opened();
-        assert_eq!(collector.snapshot(None).active_connections, 1);
-        assert_eq!(collector.snapshot(None).total_connections, 1);
+        assert_eq!(collector.snapshot(None).active_connections.get(), 1);
+        assert_eq!(collector.snapshot(None).total_connections.get(), 1);
 
         collector.connection_opened();
-        assert_eq!(collector.snapshot(None).active_connections, 2);
-        assert_eq!(collector.snapshot(None).total_connections, 2);
+        assert_eq!(collector.snapshot(None).active_connections.get(), 2);
+        assert_eq!(collector.snapshot(None).total_connections.get(), 2);
 
         collector.connection_closed();
-        assert_eq!(collector.snapshot(None).active_connections, 1);
-        assert_eq!(collector.snapshot(None).total_connections, 2);
+        assert_eq!(collector.snapshot(None).active_connections.get(), 1);
+        assert_eq!(collector.snapshot(None).total_connections.get(), 2);
     }
 
     #[test]

--- a/src/metrics/snapshot.rs
+++ b/src/metrics/snapshot.rs
@@ -8,7 +8,11 @@
 // Snapshot rates are presentation/monitoring values, and the tests exercise
 // exact deterministic fixtures rather than fuzzy comparisons.
 
-use super::types::{ActiveConnections, BackendHealthStatus, ErrorRatePercent};
+use super::types::{
+    ActiveConnections, BackendHealthCounts, BackendHealthStatus, CacheEntries, DiskHits,
+    DiskReadIos, DiskWriteIos, ErrorRatePercent, PipelineBatches, PipelineCommands,
+    PipelineRequestsCompleted, PipelineRequestsQueued, StatefulSessions,
+};
 use crate::types::{BackendId, BackendToClientBytes, ClientToBackendBytes, TotalConnections};
 use std::sync::Arc;
 use std::time::Duration;
@@ -35,7 +39,7 @@ pub struct MetricsSnapshot {
     #[serde(skip, default)]
     pub active_connections: ActiveConnections,
     #[serde(skip, default)]
-    pub stateful_sessions: usize,
+    pub stateful_sessions: StatefulSessions,
     pub client_to_backend_bytes: ClientToBackendBytes,
     pub backend_to_client_bytes: BackendToClientBytes,
     #[serde(skip, default)]
@@ -43,7 +47,7 @@ pub struct MetricsSnapshot {
     pub backend_stats: Arc<[BackendStats]>,
     pub user_stats: Vec<UserStats>,
     #[serde(skip, default)]
-    pub cache_entries: u64,
+    pub cache_entries: CacheEntries,
     #[serde(skip, default)]
     pub cache_size_bytes: u64,
     #[serde(skip, default)]
@@ -52,20 +56,20 @@ pub struct MetricsSnapshot {
     #[serde(skip, default)]
     pub disk_cache: Option<DiskCacheStats>,
     /// Number of pipelined batches (batches with >1 command)
-    pub pipeline_batches: u64,
+    pub pipeline_batches: PipelineBatches,
     /// Total commands processed in pipelined batches
-    pub pipeline_commands: u64,
+    pub pipeline_commands: PipelineCommands,
     /// Total requests enqueued to backend pipeline queues
-    pub pipeline_requests_queued: u64,
+    pub pipeline_requests_queued: PipelineRequestsQueued,
     /// Total requests completed via backend pipeline
-    pub pipeline_requests_completed: u64,
+    pub pipeline_requests_completed: PipelineRequestsCompleted,
 }
 
 /// Disk cache statistics for hybrid cache mode
 #[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
 pub struct DiskCacheStats {
     /// Number of cache hits from disk tier
-    pub disk_hits: u64,
+    pub disk_hits: DiskHits,
     /// Disk hit rate (percentage of hits served from disk vs total hits)
     pub disk_hit_rate: f64,
     /// Configured disk cache capacity in bytes
@@ -75,9 +79,9 @@ pub struct DiskCacheStats {
     /// Bytes read from disk (from foyer statistics)
     pub bytes_read: u64,
     /// Number of write I/O operations
-    pub write_ios: u64,
+    pub write_ios: DiskWriteIos,
     /// Number of read I/O operations
-    pub read_ios: u64,
+    pub read_ios: DiskReadIos,
 }
 
 impl MetricsSnapshot {
@@ -216,17 +220,21 @@ impl MetricsSnapshot {
 
     /// Count backends by health status
     ///
-    /// Returns (healthy, degraded, down) counts.
+    /// Returns typed counts for healthy, degraded, and down backends.
     /// This is a pure calculation using iterator composition.
     #[must_use]
-    pub fn backend_health_counts(&self) -> (usize, usize, usize) {
-        self.backend_stats
-            .iter()
-            .fold((0, 0, 0), |(h, d, dn), stats| match stats.health_status {
-                BackendHealthStatus::Healthy => (h + 1, d, dn),
-                BackendHealthStatus::Degraded => (h, d + 1, dn),
-                BackendHealthStatus::Down => (h, d, dn + 1),
-            })
+    pub fn backend_health_counts(&self) -> BackendHealthCounts {
+        let mut counts = BackendHealthCounts::default();
+
+        for stats in self.backend_stats.iter() {
+            match stats.health_status {
+                BackendHealthStatus::Healthy => counts.healthy.increment(),
+                BackendHealthStatus::Degraded => counts.degraded.increment(),
+                BackendHealthStatus::Down => counts.down.increment(),
+            }
+        }
+
+        counts
     }
 }
 
@@ -234,7 +242,8 @@ impl MetricsSnapshot {
 mod tests {
     use super::*;
     use crate::metrics::{
-        ArticleCount, CommandCount, ErrorCount, FailureCount, RecvMicros, SendMicros, TtfbMicros,
+        ArticleCount, BackendHealthCount, CommandCount, ErrorCount, FailureCount, RecvMicros,
+        SendMicros, TtfbMicros,
     };
     use crate::types::BackendId;
 
@@ -282,20 +291,20 @@ mod tests {
         MetricsSnapshot {
             total_connections: TotalConnections::new(5),
             active_connections: ActiveConnections::new(5),
-            stateful_sessions: 2,
+            stateful_sessions: StatefulSessions::new(2),
             client_to_backend_bytes: ClientToBackendBytes::new(1500),
             backend_to_client_bytes: BackendToClientBytes::new(3500),
             uptime: Duration::from_secs(60 * 60),
             backend_stats: vec![backend1, backend2].into(),
             user_stats: vec![],
-            cache_entries: 0,
+            cache_entries: CacheEntries::ZERO,
             cache_size_bytes: 0,
             cache_hit_rate: 0.0,
             disk_cache: None,
-            pipeline_batches: 0,
-            pipeline_commands: 0,
-            pipeline_requests_queued: 0,
-            pipeline_requests_completed: 0,
+            pipeline_batches: PipelineBatches::ZERO,
+            pipeline_commands: PipelineCommands::ZERO,
+            pipeline_requests_queued: PipelineRequestsQueued::ZERO,
+            pipeline_requests_completed: PipelineRequestsCompleted::ZERO,
         }
     }
 
@@ -466,10 +475,10 @@ mod tests {
     #[test]
     fn test_backend_health_counts() {
         let snapshot = create_test_snapshot();
-        let (healthy, degraded, down) = snapshot.backend_health_counts();
-        assert_eq!(healthy, 1);
-        assert_eq!(degraded, 1);
-        assert_eq!(down, 0);
+        let counts = snapshot.backend_health_counts();
+        assert_eq!(counts.healthy, BackendHealthCount::new(1));
+        assert_eq!(counts.degraded, BackendHealthCount::new(1));
+        assert_eq!(counts.down, BackendHealthCount::ZERO);
     }
 
     #[test]
@@ -497,19 +506,19 @@ mod tests {
             ..Default::default()
         };
 
-        let (healthy, degraded, down) = snapshot.backend_health_counts();
-        assert_eq!(healthy, 2);
-        assert_eq!(degraded, 0);
-        assert_eq!(down, 1);
+        let counts = snapshot.backend_health_counts();
+        assert_eq!(counts.healthy, BackendHealthCount::new(2));
+        assert_eq!(counts.degraded, BackendHealthCount::ZERO);
+        assert_eq!(counts.down, BackendHealthCount::new(1));
     }
 
     #[test]
     fn test_backend_health_counts_empty() {
         let snapshot = MetricsSnapshot::default();
-        let (healthy, degraded, down) = snapshot.backend_health_counts();
-        assert_eq!(healthy, 0);
-        assert_eq!(degraded, 0);
-        assert_eq!(down, 0);
+        let counts = snapshot.backend_health_counts();
+        assert_eq!(counts.healthy, BackendHealthCount::ZERO);
+        assert_eq!(counts.degraded, BackendHealthCount::ZERO);
+        assert_eq!(counts.down, BackendHealthCount::ZERO);
     }
 
     #[test]
@@ -549,7 +558,7 @@ mod tests {
         let snapshot = MetricsSnapshot::default();
         assert_eq!(snapshot.total_connections, TotalConnections::ZERO);
         assert_eq!(snapshot.active_connections, ActiveConnections::ZERO);
-        assert_eq!(snapshot.stateful_sessions, 0);
+        assert_eq!(snapshot.stateful_sessions, StatefulSessions::ZERO);
         assert_eq!(snapshot.total_bytes(), 0);
         assert_eq!(snapshot.uptime, Duration::from_secs(0));
         assert_eq!(snapshot.backend_stats.len(), 0);

--- a/src/metrics/snapshot.rs
+++ b/src/metrics/snapshot.rs
@@ -9,7 +9,7 @@
 // exact deterministic fixtures rather than fuzzy comparisons.
 
 use super::types::{ActiveConnections, BackendHealthStatus, ErrorRatePercent};
-use crate::types::{BackendId, BackendToClientBytes, ClientToBackendBytes};
+use crate::types::{BackendId, BackendToClientBytes, ClientToBackendBytes, TotalConnections};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -31,9 +31,9 @@ use super::UserStats;
 /// from O(backends) to O(1) per update.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct MetricsSnapshot {
-    pub total_connections: u64,
+    pub total_connections: TotalConnections,
     #[serde(skip, default)]
-    pub active_connections: usize,
+    pub active_connections: ActiveConnections,
     #[serde(skip, default)]
     pub stateful_sessions: usize,
     pub client_to_backend_bytes: ClientToBackendBytes,
@@ -280,8 +280,8 @@ mod tests {
         };
 
         MetricsSnapshot {
-            total_connections: 5,
-            active_connections: 5,
+            total_connections: TotalConnections::new(5),
+            active_connections: ActiveConnections::new(5),
             stateful_sessions: 2,
             client_to_backend_bytes: ClientToBackendBytes::new(1500),
             backend_to_client_bytes: BackendToClientBytes::new(3500),
@@ -547,8 +547,8 @@ mod tests {
     #[test]
     fn test_snapshot_default() {
         let snapshot = MetricsSnapshot::default();
-        assert_eq!(snapshot.total_connections, 0);
-        assert_eq!(snapshot.active_connections, 0);
+        assert_eq!(snapshot.total_connections, TotalConnections::ZERO);
+        assert_eq!(snapshot.active_connections, ActiveConnections::ZERO);
         assert_eq!(snapshot.stateful_sessions, 0);
         assert_eq!(snapshot.total_bytes(), 0);
         assert_eq!(snapshot.uptime, Duration::from_secs(0));

--- a/src/metrics/types.rs
+++ b/src/metrics/types.rs
@@ -181,6 +181,40 @@ counter_type!(ActiveConnections, usize);
 // lifetime totals in place of live sessions.
 counter_type!(UserActiveConnections, usize);
 
+// Live dashboard/session counts.
+counter_type!(StatefulSessions, usize);
+counter_type!(PendingRequests, usize);
+counter_type!(BackendHealthCount, usize);
+
+/// Count of backends by health state.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct BackendHealthCounts {
+    pub healthy: BackendHealthCount,
+    pub degraded: BackendHealthCount,
+    pub down: BackendHealthCount,
+}
+
+impl BackendHealthCounts {
+    #[must_use]
+    pub const fn new(healthy: usize, degraded: usize, down: usize) -> Self {
+        Self {
+            healthy: BackendHealthCount::new(healthy),
+            degraded: BackendHealthCount::new(degraded),
+            down: BackendHealthCount::new(down),
+        }
+    }
+}
+
+// Snapshot/presentation counters.
+counter_type!(CacheEntries, u64);
+counter_type!(PipelineBatches, u64);
+counter_type!(PipelineCommands, u64);
+counter_type!(PipelineRequestsQueued, u64);
+counter_type!(PipelineRequestsCompleted, u64);
+counter_type!(DiskHits, u64);
+counter_type!(DiskWriteIos, u64);
+counter_type!(DiskReadIos, u64);
+
 // ============================================================================
 // Time measurements - Different units and types of timing
 // ============================================================================

--- a/src/session/auth_state.rs
+++ b/src/session/auth_state.rs
@@ -6,6 +6,23 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
+/// Result of attempting to authenticate a session.
+#[must_use = "authentication transitions drive user connection gauge updates"]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AuthenticationTransition {
+    /// This call changed the session from unauthenticated to authenticated.
+    NewlyAuthenticated,
+    /// The session had already authenticated before this call.
+    AlreadyAuthenticated,
+}
+
+impl AuthenticationTransition {
+    #[must_use]
+    pub const fn is_new(self) -> bool {
+        matches!(self, Self::NewlyAuthenticated)
+    }
+}
+
 /// Represents the authentication state of a client session
 ///
 /// This type encapsulates the authentication status and username in a
@@ -20,13 +37,16 @@ use std::sync::{Arc, OnceLock};
 /// # Examples
 ///
 /// ```
-/// use nntp_proxy::session::AuthState;
+/// use nntp_proxy::session::{AuthState, AuthenticationTransition};
 ///
 /// let auth_state = AuthState::new();
 /// assert!(!auth_state.is_authenticated());
 ///
 /// // After authentication
-/// auth_state.mark_authenticated("user@example.com");
+/// assert_eq!(
+///     auth_state.mark_authenticated("user@example.com"),
+///     AuthenticationTransition::NewlyAuthenticated
+/// );
 /// assert!(auth_state.is_authenticated());
 /// assert_eq!(auth_state.username().unwrap(), "user@example.com");
 /// ```
@@ -52,7 +72,7 @@ impl AuthState {
     /// # Examples
     ///
     /// ```
-    /// use nntp_proxy::session::AuthState;
+    /// use nntp_proxy::session::{AuthState, AuthenticationTransition};
     ///
     /// let auth_state = AuthState::new();
     /// assert!(!auth_state.is_authenticated());
@@ -80,7 +100,10 @@ impl AuthState {
     /// let auth_state = AuthState::new();
     /// assert!(!auth_state.is_authenticated());
     ///
-    /// auth_state.mark_authenticated("alice");
+    /// assert_eq!(
+    ///     auth_state.mark_authenticated("alice"),
+    ///     AuthenticationTransition::NewlyAuthenticated
+    /// );
     /// assert!(auth_state.is_authenticated());
     /// ```
     #[inline]
@@ -98,29 +121,38 @@ impl AuthState {
     ///
     /// * `username` - The authenticated username
     ///
-    /// # Panics
+    /// # Returns
     ///
-    /// Panics if called multiple times with different usernames (implementation
-    /// detail of `OnceLock::set`).
+    /// Returns whether this call changed the session from unauthenticated to
+    /// authenticated. Repeated successful auth commands return
+    /// [`AuthenticationTransition::AlreadyAuthenticated`] so callers can keep
+    /// connection-open side effects idempotent.
     ///
     /// # Examples
     ///
     /// ```
-    /// use nntp_proxy::session::AuthState;
+    /// use nntp_proxy::session::{AuthState, AuthenticationTransition};
     ///
     /// let auth_state = AuthState::new();
-    /// auth_state.mark_authenticated("bob");
+    /// assert_eq!(
+    ///     auth_state.mark_authenticated("bob"),
+    ///     AuthenticationTransition::NewlyAuthenticated
+    /// );
     ///
     /// assert!(auth_state.is_authenticated());
     /// assert_eq!(auth_state.username().unwrap(), "bob");
     /// ```
     #[inline]
-    pub fn mark_authenticated(&self, username: impl Into<Arc<str>>) {
+    pub fn mark_authenticated(&self, username: impl Into<Arc<str>>) -> AuthenticationTransition {
         let username_arc: Arc<str> = username.into();
         // Set username first (write-once, safe to call multiple times with same value)
         let _ = self.username.set(username_arc);
         // Then mark as authenticated (one-way transition)
-        self.authenticated.store(true, Ordering::Relaxed);
+        if self.authenticated.swap(true, Ordering::Relaxed) {
+            AuthenticationTransition::AlreadyAuthenticated
+        } else {
+            AuthenticationTransition::NewlyAuthenticated
+        }
     }
 
     /// Get the authenticated username if available
@@ -131,12 +163,15 @@ impl AuthState {
     /// # Examples
     ///
     /// ```
-    /// use nntp_proxy::session::AuthState;
+    /// use nntp_proxy::session::{AuthState, AuthenticationTransition};
     ///
     /// let auth_state = AuthState::new();
     /// assert!(auth_state.username().is_none());
     ///
-    /// auth_state.mark_authenticated("charlie");
+    /// assert_eq!(
+    ///     auth_state.mark_authenticated("charlie"),
+    ///     AuthenticationTransition::NewlyAuthenticated
+    /// );
     /// let username = auth_state.username().unwrap();
     /// assert_eq!(username, "charlie");
     ///
@@ -162,13 +197,16 @@ impl AuthState {
     /// # Examples
     ///
     /// ```
-    /// use nntp_proxy::session::AuthState;
+    /// use nntp_proxy::session::{AuthState, AuthenticationTransition};
     ///
     /// let auth_state = AuthState::new();
     /// assert!(!auth_state.is_authenticated_or_skipped(false));
     /// assert!(auth_state.is_authenticated_or_skipped(true)); // Skips check
     ///
-    /// auth_state.mark_authenticated("dave");
+    /// assert_eq!(
+    ///     auth_state.mark_authenticated("dave"),
+    ///     AuthenticationTransition::NewlyAuthenticated
+    /// );
     /// assert!(auth_state.is_authenticated_or_skipped(false));
     /// assert!(auth_state.is_authenticated_or_skipped(true));
     /// ```
@@ -200,7 +238,10 @@ mod tests {
     #[test]
     fn test_mark_authenticated() {
         let state = AuthState::new();
-        state.mark_authenticated("testuser");
+        assert_eq!(
+            state.mark_authenticated("testuser"),
+            AuthenticationTransition::NewlyAuthenticated
+        );
 
         assert!(state.is_authenticated());
         assert_eq!(state.username().unwrap(), "testuser");
@@ -210,7 +251,10 @@ mod tests {
     fn test_mark_authenticated_with_arc() {
         let state = AuthState::new();
         let username: Arc<str> = Arc::from("arcuser");
-        state.mark_authenticated(username);
+        assert_eq!(
+            state.mark_authenticated(username),
+            AuthenticationTransition::NewlyAuthenticated
+        );
 
         assert!(state.is_authenticated());
         assert_eq!(state.username().unwrap(), "arcuser");
@@ -226,7 +270,10 @@ mod tests {
         // Not authenticated, skip=true
         assert!(state.is_authenticated_or_skipped(true));
 
-        state.mark_authenticated("skiptest");
+        assert_eq!(
+            state.mark_authenticated("skiptest"),
+            AuthenticationTransition::NewlyAuthenticated
+        );
 
         // Authenticated, skip=false
         assert!(state.is_authenticated_or_skipped(false));
@@ -245,10 +292,32 @@ mod tests {
     #[test]
     fn test_multiple_mark_same_username() {
         let state = AuthState::new();
-        state.mark_authenticated("same");
-        state.mark_authenticated("same"); // Should not panic
+        assert_eq!(
+            state.mark_authenticated("same"),
+            AuthenticationTransition::NewlyAuthenticated
+        );
+        assert_eq!(
+            state.mark_authenticated("same"),
+            AuthenticationTransition::AlreadyAuthenticated
+        );
 
         assert!(state.is_authenticated());
         assert_eq!(state.username().unwrap(), "same");
+    }
+
+    #[test]
+    fn test_multiple_mark_keeps_original_username() {
+        let state = AuthState::new();
+        assert_eq!(
+            state.mark_authenticated("first"),
+            AuthenticationTransition::NewlyAuthenticated
+        );
+        assert_eq!(
+            state.mark_authenticated("second"),
+            AuthenticationTransition::AlreadyAuthenticated
+        );
+
+        assert!(state.is_authenticated());
+        assert_eq!(state.username().unwrap(), "first");
     }
 }

--- a/src/session/common.rs
+++ b/src/session/common.rs
@@ -83,10 +83,6 @@ where
         .handle_auth_command(auth_action, client_write, auth_username.as_deref())
         .await?;
 
-    if auth_success && let Some(ref username) = *auth_username {
-        auth_state.mark_authenticated(username.clone());
-    }
-
     let bytes_written = BackendToClientBytes::new(bytes as u64);
     let response = auth_response_metadata(auth_action, had_username, auth_success);
 
@@ -160,16 +156,16 @@ where
 
 /// Handle successful authentication with all side effects
 ///
-/// Sets username, records connection stats, updates metrics
+/// Moves the session's live user gauge from anonymous to the authenticated
+/// user, then records connection stats for aggregation.
 #[allow(clippy::needless_pass_by_value)] // The owned username is consumed as part of session state updates.
 pub fn on_authentication_success(
     client_id: crate::types::ClientId,
     client_addr: impl std::fmt::Display,
     username: Option<String>,
     routing_mode: crate::config::RoutingMode,
-    metrics: &crate::metrics::MetricsCollector,
     connection_stats: Option<&crate::metrics::ConnectionStatsAggregator>,
-    set_username_fn: impl FnOnce(Option<String>),
+    set_username_fn: impl FnOnce(String) -> crate::session::AuthenticationTransition,
 ) {
     use tracing::debug;
 
@@ -178,20 +174,34 @@ pub fn on_authentication_success(
     // logging without threading extra lifetimes through the handler chain.
     debug!("Client {} authenticated as: {:?}", client_addr, username);
 
-    // Store username in session
-    set_username_fn(username.clone());
+    let Some(username) = username else {
+        if let Some(stats) = connection_stats {
+            stats.record_session_connection(client_id, None, routing_mode.short_name());
+        }
+        debug!(
+            "Client {} authenticated without a username; keeping anonymous user gauge",
+            client_addr
+        );
+        return;
+    };
+
+    let transition = set_username_fn(username.clone());
 
     // Record connection for aggregation (after auth so we have username)
     if let Some(stats) = connection_stats {
-        stats.record_session_connection(client_id, username.as_deref(), routing_mode.short_name());
+        stats.record_session_connection(
+            client_id,
+            Some(username.as_str()),
+            routing_mode.short_name(),
+        );
     }
 
-    // Track user connection in metrics
-    metrics.user_connection_opened(username.as_deref());
-    debug!(
-        "Client {} opened connection for user: {:?}",
-        client_addr, username
-    );
+    if transition.is_new() {
+        debug!(
+            "Client {} moved connection to authenticated user: {}",
+            client_addr, username
+        );
+    }
 }
 
 #[cfg(test)]
@@ -352,7 +362,6 @@ pub struct AuthCheckContext<'a> {
     pub auth_handler: &'a std::sync::Arc<crate::auth::AuthHandler>,
     pub auth_state: &'a crate::session::AuthState,
     pub routing_mode: &'a crate::config::RoutingMode,
-    pub metrics: &'a crate::metrics::MetricsCollector,
     pub connection_stats: Option<&'a crate::metrics::ConnectionStatsAggregator>,
 }
 
@@ -368,7 +377,7 @@ pub async fn handle_stateful_auth_check<W>(
     auth_username: &mut Option<String>,
     ctx: &AuthCheckContext<'_>,
     client_addr: impl std::fmt::Display + Clone,
-    set_username_fn: impl FnOnce(Option<String>),
+    set_username_fn: impl FnOnce(String) -> crate::session::AuthenticationTransition,
 ) -> anyhow::Result<AuthHandlerResult>
 where
     W: AsyncWriteExt + Unpin,
@@ -411,7 +420,6 @@ where
                         client_addr,
                         auth_username.clone(),
                         *ctx.routing_mode,
-                        ctx.metrics,
                         ctx.connection_stats,
                         set_username_fn,
                     );

--- a/src/session/core.rs
+++ b/src/session/core.rs
@@ -1312,11 +1312,17 @@ mod tests {
         session.metrics.stateful_session_started();
 
         let snapshot = metrics.snapshot(None);
-        assert_eq!(snapshot.stateful_sessions, 1);
+        assert_eq!(
+            snapshot.stateful_sessions,
+            crate::metrics::StatefulSessions::new(1)
+        );
 
         session.metrics.stateful_session_ended();
 
         let snapshot = metrics.snapshot(None);
-        assert_eq!(snapshot.stateful_sessions, 0);
+        assert_eq!(
+            snapshot.stateful_sessions,
+            crate::metrics::StatefulSessions::ZERO
+        );
     }
 }

--- a/src/session/core.rs
+++ b/src/session/core.rs
@@ -3,7 +3,7 @@
 //! This module provides the core data structure for representing an active NNTP client session,
 //! along with a builder pattern for flexible session construction.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use crate::auth::AuthHandler;
 use crate::config::RoutingMode;
@@ -30,6 +30,12 @@ pub struct ClientSession {
     pub(super) auth_state: AuthState,
     /// Metrics collector for session statistics (always enabled)
     pub(super) metrics: crate::metrics::MetricsCollector,
+
+    /// Current owner of this session's live user-connection gauge.
+    ///
+    /// `None` means the session is visible as the anonymous/unauthenticated
+    /// user until authentication moves it to a concrete username.
+    user_connection_username: Mutex<Option<String>>,
 
     /// Connection statistics aggregator for logging connection creation
     pub(super) connection_stats: Option<crate::metrics::ConnectionStatsAggregator>,
@@ -185,6 +191,8 @@ impl ClientSessionBuilder {
             }
         };
 
+        let metrics = self.metrics;
+        metrics.user_connection_opened(None);
         ClientSession {
             client_addr: self.client_addr,
             buffer_pool: self.buffer_pool,
@@ -193,7 +201,8 @@ impl ClientSessionBuilder {
             mode_state: ModeState::new(mode, routing_mode),
             auth_handler: self.auth_handler,
             auth_state: AuthState::new(),
-            metrics: self.metrics,
+            user_connection_username: Mutex::new(None),
+            metrics,
             connection_stats: self.connection_stats,
             cache: self.cache.into_cache(),
             cache_articles: self.cache_articles,
@@ -218,6 +227,7 @@ impl ClientSession {
         auth_handler: Arc<AuthHandler>,
         metrics: MetricsCollector,
     ) -> Self {
+        metrics.user_connection_opened(None);
         Self {
             client_addr,
             buffer_pool,
@@ -226,6 +236,7 @@ impl ClientSession {
             mode_state: ModeState::new(SessionMode::Stateful, RoutingMode::Stateful),
             auth_handler,
             auth_state: AuthState::new(),
+            user_connection_username: Mutex::new(None),
             metrics,
             connection_stats: None,
             cache: Self::default_cache(),
@@ -247,6 +258,7 @@ impl ClientSession {
         auth_handler: Arc<AuthHandler>,
         metrics: MetricsCollector,
     ) -> Self {
+        metrics.user_connection_opened(None);
         Self {
             client_addr,
             buffer_pool,
@@ -255,6 +267,7 @@ impl ClientSession {
             mode_state: ModeState::new(SessionMode::PerCommand, routing_mode),
             auth_handler,
             auth_state: AuthState::new(),
+            user_connection_username: Mutex::new(None),
             metrics,
             connection_stats: None,
             cache: Self::default_cache(),
@@ -346,10 +359,19 @@ impl ClientSession {
     ///
     /// This marks the session as authenticated and stores the username.
     /// Called after successful authentication with the backend.
-    pub(crate) fn set_username(&self, username: Option<String>) {
-        if let Some(name) = username {
-            self.auth_state.mark_authenticated(name);
+    ///
+    /// Returns whether this was the first successful authentication transition
+    /// in this session.
+    pub(crate) fn set_username(&self, name: String) -> crate::session::AuthenticationTransition {
+        let transition = self.auth_state.mark_authenticated(name.clone());
+        if transition.is_new() {
+            self.metrics.user_connection_closed(None);
+            self.metrics.user_connection_opened(Some(&name));
+            if let Ok(mut current) = self.user_connection_username.lock() {
+                *current = Some(name);
+            }
         }
+        transition
     }
 
     /// Get the connection stats aggregator (if enabled)
@@ -371,6 +393,14 @@ impl ClientSession {
     #[inline]
     pub(crate) fn is_authenticated_cached(&self, skip_auth_check: bool) -> bool {
         self.auth_state.is_authenticated_or_skipped(skip_auth_check)
+    }
+}
+
+impl Drop for ClientSession {
+    fn drop(&mut self) {
+        if let Ok(current) = self.user_connection_username.lock() {
+            self.metrics.user_connection_closed(current.as_deref());
+        }
     }
 }
 
@@ -979,6 +1009,38 @@ mod tests {
     }
 
     #[test]
+    fn test_session_counts_as_anonymous_until_drop() {
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
+        let buffer_pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 4);
+        let metrics = MetricsCollector::new(1);
+
+        let session = ClientSession::new(
+            addr.into(),
+            buffer_pool,
+            test_auth_handler(),
+            metrics.clone(),
+        );
+
+        let snapshot = metrics.snapshot(None);
+        let anonymous = snapshot
+            .user_stats
+            .iter()
+            .find(|stats| stats.username == crate::constants::user::ANONYMOUS)
+            .expect("new session should be visible as anonymous");
+        assert_eq!(anonymous.active_connections.get(), 1);
+
+        drop(session);
+
+        let snapshot = metrics.snapshot(None);
+        let anonymous = snapshot
+            .user_stats
+            .iter()
+            .find(|stats| stats.username == crate::constants::user::ANONYMOUS)
+            .expect("anonymous user stats should remain for lifetime totals");
+        assert_eq!(anonymous.active_connections.get(), 0);
+    }
+
+    #[test]
     fn test_set_username_and_get() {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let buffer_pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 4);
@@ -989,7 +1051,10 @@ mod tests {
             test_metrics(),
         );
 
-        session.set_username(Some("testuser".to_string()));
+        assert_eq!(
+            session.set_username("testuser".to_string()),
+            crate::session::AuthenticationTransition::NewlyAuthenticated
+        );
 
         let username = session.username();
         assert!(username.is_some());
@@ -997,19 +1062,51 @@ mod tests {
     }
 
     #[test]
-    fn test_set_username_none() {
+    fn test_set_username_moves_live_connection_from_anonymous_to_user_once() {
         let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let buffer_pool = BufferPool::new(BufferSize::try_new(1024).unwrap(), 4);
+        let metrics = MetricsCollector::new(1);
         let session = ClientSession::new(
             addr.into(),
             buffer_pool,
             test_auth_handler(),
-            test_metrics(),
+            metrics.clone(),
         );
 
-        session.set_username(None);
+        assert_eq!(
+            session.set_username("testuser".to_string()),
+            crate::session::AuthenticationTransition::NewlyAuthenticated
+        );
+        assert_eq!(
+            session.set_username("testuser".to_string()),
+            crate::session::AuthenticationTransition::AlreadyAuthenticated
+        );
 
-        assert!(session.username().is_none());
+        let snapshot = metrics.snapshot(None);
+        let anonymous = snapshot
+            .user_stats
+            .iter()
+            .find(|stats| stats.username == crate::constants::user::ANONYMOUS)
+            .expect("anonymous bucket should exist");
+        let user = snapshot
+            .user_stats
+            .iter()
+            .find(|stats| stats.username == "testuser")
+            .expect("authenticated user bucket should exist");
+        assert_eq!(anonymous.active_connections.get(), 0);
+        assert_eq!(user.active_connections.get(), 1);
+        assert_eq!(user.total_connections.get(), 1);
+
+        drop(session);
+
+        let snapshot = metrics.snapshot(None);
+        let user = snapshot
+            .user_stats
+            .iter()
+            .find(|stats| stats.username == "testuser")
+            .expect("authenticated user bucket should remain");
+        assert_eq!(user.active_connections.get(), 0);
+        assert_eq!(user.total_connections.get(), 1);
     }
 
     #[test]
@@ -1023,7 +1120,10 @@ mod tests {
             test_metrics(),
         );
 
-        session.set_username(Some("testuser".to_string()));
+        assert_eq!(
+            session.set_username("testuser".to_string()),
+            crate::session::AuthenticationTransition::NewlyAuthenticated
+        );
 
         let username1 = session.username();
         let username2 = session.username();
@@ -1111,7 +1211,10 @@ mod tests {
         )
         .build();
 
-        session.set_username(Some("testuser".to_string()));
+        assert_eq!(
+            session.set_username("testuser".to_string()),
+            crate::session::AuthenticationTransition::NewlyAuthenticated
+        );
 
         // Call metrics directly - should record
         session.metrics.record_command(BackendId::from_index(0));
@@ -1169,7 +1272,10 @@ mod tests {
         )
         .build();
 
-        session.set_username(Some("testuser".to_string()));
+        assert_eq!(
+            session.set_username("testuser".to_string()),
+            crate::session::AuthenticationTransition::NewlyAuthenticated
+        );
         session.metrics.user_bytes_sent(session.username(), 1024);
         session
             .metrics

--- a/src/session/handlers/per_command.rs
+++ b/src/session/handlers/per_command.rs
@@ -241,7 +241,6 @@ impl ClientSession {
                 self.client_addr,
                 auth_username.clone(),
                 self.mode_state.routing_mode(),
-                &self.metrics,
                 self.connection_stats(),
                 |username| self.set_username(username),
             );
@@ -476,7 +475,6 @@ impl ClientSession {
             }
         }
 
-        self.metrics.user_connection_closed(self.username());
         Ok(state.transfer_metrics())
     }
 

--- a/src/session/handlers/stateful.rs
+++ b/src/session/handlers/stateful.rs
@@ -373,7 +373,6 @@ impl ClientSession {
                                         auth_handler: &self.auth_handler,
                                         auth_state: &self.auth_state,
                                         routing_mode: &crate::config::RoutingMode::Stateful,
-                                        metrics: &self.metrics,
                                         connection_stats: self.connection_stats(),
                                     },
                                     self.client_addr,
@@ -405,8 +404,6 @@ impl ClientSession {
 
         // Final metrics - report any remaining byte deltas
         state.flush_byte_deltas(&self.metrics, backend_id, self.username());
-
-        self.metrics.user_connection_closed(self.username());
 
         Ok(state.into_metrics())
     }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -184,7 +184,7 @@ mod session_error;
 pub(crate) mod shared_client_writer;
 mod state;
 
-pub use auth_state::AuthState;
+pub use auth_state::{AuthState, AuthenticationTransition};
 pub use backend::format_hex_preview;
 pub use core::{ClientSession, ClientSessionBuilder};
 pub use metrics_ext::MetricsRecorder;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1046,8 +1046,14 @@ mod tests {
         let app = create_test_app(2);
 
         // Initial state checks
-        assert_eq!(app.snapshot().active_connections, 0);
-        assert_eq!(app.snapshot().total_connections, 0);
+        assert_eq!(
+            app.snapshot().active_connections,
+            crate::metrics::ActiveConnections::ZERO
+        );
+        assert_eq!(
+            app.snapshot().total_connections,
+            crate::types::TotalConnections::ZERO
+        );
         assert_eq!(app.snapshot().backend_stats.len(), 2);
         assert!(app.previous_snapshot.is_none());
         assert!(app.latest_client_throughput().is_none());
@@ -1463,8 +1469,8 @@ mod tests {
         let mut app = TuiAppBuilder::new(metrics, router, servers).build();
 
         app.snapshot = Arc::new(MetricsSnapshot {
-            total_connections: 42,
-            active_connections: 3,
+            total_connections: crate::types::TotalConnections::new(42),
+            active_connections: crate::metrics::ActiveConnections::new(3),
             stateful_sessions: 2,
             client_to_backend_bytes: crate::types::ClientToBackendBytes::new(100),
             backend_to_client_bytes: crate::types::BackendToClientBytes::new(250),
@@ -1504,7 +1510,10 @@ mod tests {
         let decoded: DashboardState =
             serde_json::from_str(&json).expect("snapshot should deserialize");
 
-        assert_eq!(decoded.metrics.total_connections, 42);
+        assert_eq!(
+            decoded.metrics.total_connections,
+            crate::types::TotalConnections::new(42)
+        );
         assert_eq!(decoded.metrics.active_connections.get(), 3);
         assert_eq!(decoded.metrics.stateful_sessions, 2);
         assert_eq!(decoded.metrics.cache_entries, 7);

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,10 +2,12 @@
 
 use crate::config::Server;
 use crate::metrics::{MetricsCollector, MetricsSnapshot};
+use crate::metrics::{PendingRequests, StatefulSessions};
 use crate::router::BackendSelector;
 use crate::tui::dashboard::{
-    BackendDisplay, BackendView, BufferPoolStats, DashboardMetrics, DashboardState,
-    DashboardUserStats, RemoteBackendView, RemoteDashboardState,
+    AvailableBuffers, BackendDisplay, BackendView, BufferPoolStats, DashboardMetrics,
+    DashboardState, DashboardUserStats, InUseBuffers, RemoteBackendView, RemoteDashboardState,
+    TotalBuffers,
 };
 use crate::tui::log_capture::LogBuffer;
 use crate::tui::rate_estimator::{CumulativeCount, RateEstimate, RateEstimator, RatePerSecond};
@@ -633,11 +635,13 @@ impl TuiApp {
 
     /// Get pending command count for a backend
     #[must_use]
-    pub fn backend_pending_count(&self, backend_idx: usize) -> usize {
+    pub fn backend_pending_count(&self, backend_idx: usize) -> PendingRequests {
         use crate::types::BackendId;
         self.router
             .backend_load(BackendId::from_index(backend_idx))
-            .map_or(0, |pending| pending.get())
+            .map_or(PendingRequests::ZERO, |pending| {
+                PendingRequests::new(pending.get())
+            })
     }
 
     /// Get load ratio for a backend (pending / `max_connections`)
@@ -651,11 +655,13 @@ impl TuiApp {
 
     /// Get stateful connection count for a backend
     #[must_use]
-    pub fn backend_stateful_count(&self, backend_idx: usize) -> usize {
+    pub fn backend_stateful_count(&self, backend_idx: usize) -> StatefulSessions {
         use crate::types::BackendId;
         self.router
             .stateful_count(BackendId::from_index(backend_idx))
-            .map_or(0, |count| count.get())
+            .map_or(StatefulSessions::ZERO, |count| {
+                StatefulSessions::new(count.get())
+            })
     }
 
     /// Get traffic share percentage for a backend
@@ -894,20 +900,21 @@ impl TuiApp {
     fn snapshot_buffer_pool(pool: &crate::pool::BufferPool) -> BufferPoolStats {
         let (available, in_use, total) = pool.stats();
         BufferPoolStats {
-            available,
-            in_use,
-            total,
+            available: AvailableBuffers::new(available),
+            in_use: InUseBuffers::new(in_use),
+            total: TotalBuffers::new(total),
         }
     }
 
     fn snapshot_metrics(&self) -> DashboardMetrics {
         let mut metrics = DashboardMetrics::from(self.snapshot.as_ref());
-        metrics.in_flight_requests = self
-            .servers
-            .iter()
-            .enumerate()
-            .map(|(idx, _)| self.backend_pending_count(idx))
-            .sum();
+        metrics.in_flight_requests = PendingRequests::new(
+            self.servers
+                .iter()
+                .enumerate()
+                .map(|(idx, _)| self.backend_pending_count(idx).get())
+                .sum(),
+        );
         metrics
     }
 
@@ -1452,7 +1459,7 @@ mod tests {
         );
         assert_eq!(
             snapshot.buffer_pool.as_ref().map(|pool| pool.total),
-            Some(4)
+            Some(crate::tui::dashboard::TotalBuffers::new(4))
         );
     }
 
@@ -1468,7 +1475,7 @@ mod tests {
         app.snapshot = Arc::new(MetricsSnapshot {
             total_connections: crate::types::TotalConnections::new(42),
             active_connections: crate::metrics::ActiveConnections::new(3),
-            stateful_sessions: 2,
+            stateful_sessions: crate::metrics::StatefulSessions::new(2),
             client_to_backend_bytes: crate::types::ClientToBackendBytes::new(100),
             backend_to_client_bytes: crate::types::BackendToClientBytes::new(250),
             uptime: Duration::from_secs(61),
@@ -1483,22 +1490,22 @@ mod tests {
                 total_commands: CommandCount::new(17),
                 errors: ErrorCount::new(1),
             }],
-            cache_entries: 7,
+            cache_entries: crate::metrics::CacheEntries::new(7),
             cache_size_bytes: 8192,
             cache_hit_rate: 12.5,
             disk_cache: Some(DiskCacheStats {
-                disk_hits: 3,
+                disk_hits: crate::metrics::DiskHits::new(3),
                 disk_hit_rate: 50.0,
                 disk_capacity: 1024,
                 bytes_written: 2048,
                 bytes_read: 1024,
-                write_ios: 4,
-                read_ios: 5,
+                write_ios: crate::metrics::DiskWriteIos::new(4),
+                read_ios: crate::metrics::DiskReadIos::new(5),
             }),
-            pipeline_batches: 6,
-            pipeline_commands: 12,
-            pipeline_requests_queued: 8,
-            pipeline_requests_completed: 7,
+            pipeline_batches: crate::metrics::PipelineBatches::new(6),
+            pipeline_commands: crate::metrics::PipelineCommands::new(12),
+            pipeline_requests_queued: crate::metrics::PipelineRequestsQueued::new(8),
+            pipeline_requests_completed: crate::metrics::PipelineRequestsCompleted::new(7),
             ..MetricsSnapshot::default()
         });
 
@@ -1512,12 +1519,24 @@ mod tests {
             crate::types::TotalConnections::new(42)
         );
         assert_eq!(decoded.metrics.active_connections.get(), 3);
-        assert_eq!(decoded.metrics.stateful_sessions, 2);
-        assert_eq!(decoded.metrics.cache_entries, 7);
+        assert_eq!(
+            decoded.metrics.stateful_sessions,
+            crate::metrics::StatefulSessions::new(2)
+        );
+        assert_eq!(
+            decoded.metrics.cache_entries,
+            crate::metrics::CacheEntries::new(7)
+        );
         assert_eq!(decoded.metrics.cache_size_bytes, 8192);
         assert_eq!(decoded.metrics.cache_hit_rate, 12.5);
-        assert_eq!(decoded.metrics.pipeline_batches, 6);
-        assert_eq!(decoded.metrics.pipeline_commands, 12);
+        assert_eq!(
+            decoded.metrics.pipeline_batches,
+            crate::metrics::PipelineBatches::new(6)
+        );
+        assert_eq!(
+            decoded.metrics.pipeline_commands,
+            crate::metrics::PipelineCommands::new(12)
+        );
         assert_eq!(decoded.top_users.len(), 1);
         assert_eq!(decoded.top_users[0].username, "alice");
         assert_eq!(decoded.top_users[0].active_connections.get(), 2);
@@ -1560,8 +1579,14 @@ mod tests {
         let app = TuiApp::new(metrics, Arc::new(router), servers);
         let snapshot = app.snapshot_state();
 
-        assert_eq!(snapshot.backend_views[0].pending_count, 5);
-        assert_eq!(snapshot.metrics.in_flight_requests, 5);
+        assert_eq!(
+            snapshot.backend_views[0].pending_count,
+            crate::metrics::PendingRequests::new(5)
+        );
+        assert_eq!(
+            snapshot.metrics.in_flight_requests,
+            crate::metrics::PendingRequests::new(5)
+        );
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -753,15 +753,8 @@ impl TuiApp {
         history_limit: Option<usize>,
     ) -> DashboardState {
         let buffer_pool = self.buffer_pool.as_ref().map(Self::snapshot_buffer_pool);
-        let mut metrics = DashboardMetrics::from_snapshot(self.snapshot.as_ref());
-        metrics.in_flight_requests = self
-            .servers
-            .iter()
-            .enumerate()
-            .map(|(idx, _)| self.backend_pending_count(idx))
-            .sum();
         DashboardState {
-            metrics,
+            metrics: self.snapshot_metrics(),
             backend_views: self.snapshot_backend_views(history_limit),
             top_users: self.snapshot_top_users(),
             client_history: Self::snapshot_history_points(
@@ -784,15 +777,8 @@ impl TuiApp {
         history_limit: Option<usize>,
         top_user_limit: Option<usize>,
     ) -> RemoteDashboardState {
-        let mut metrics = DashboardMetrics::from_snapshot(self.snapshot.as_ref());
-        metrics.in_flight_requests = self
-            .servers
-            .iter()
-            .enumerate()
-            .map(|(idx, _)| self.backend_pending_count(idx))
-            .sum();
         RemoteDashboardState {
-            metrics,
+            metrics: self.snapshot_metrics(),
             backend_views: self.snapshot_remote_backend_views(history_limit),
             top_users: self.snapshot_top_users_with_limit(top_user_limit),
             latest_client_throughput: self.client_history.latest().cloned(),
@@ -914,6 +900,17 @@ impl TuiApp {
         }
     }
 
+    fn snapshot_metrics(&self) -> DashboardMetrics {
+        let mut metrics = DashboardMetrics::from(self.snapshot.as_ref());
+        metrics.in_flight_requests = self
+            .servers
+            .iter()
+            .enumerate()
+            .map(|(idx, _)| self.backend_pending_count(idx))
+            .sum();
+        metrics
+    }
+
     fn snapshot_top_users(&self) -> Vec<DashboardUserStats> {
         self.snapshot_top_users_with_limit(Some(10))
     }
@@ -926,7 +923,7 @@ impl TuiApp {
             .snapshot
             .user_stats
             .iter()
-            .map(DashboardUserStats::from_user_stats)
+            .map(DashboardUserStats::from)
             .collect::<Vec<_>>();
         top_users.sort_by_key(|user| std::cmp::Reverse(user.total_bytes()));
         if let Some(limit) = top_user_limit {

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -1,8 +1,10 @@
 //! Serializable dashboard state shared between local and attached TUI modes.
 
 use crate::metrics::{
-    ActiveConnections, BackendHealthStatus, BackendStats, CommandCount, DiskCacheStats, ErrorCount,
-    MetricsSnapshot, UserStats,
+    ActiveConnections, BackendHealthStatus, BackendStats, CacheEntries, CommandCount,
+    DiskCacheStats, ErrorCount, MetricsSnapshot, PendingRequests, PipelineBatches,
+    PipelineCommands, PipelineRequestsCompleted, PipelineRequestsQueued, StatefulSessions,
+    UserStats,
 };
 use crate::tui::app::{ThroughputPoint, ViewMode};
 use crate::tui::system_stats::SystemStats;
@@ -10,14 +12,42 @@ use crate::types::{
     BackendToClientBytes, BytesPerSecondRate, BytesReceived, BytesSent, ClientToBackendBytes,
     HostName, MaxConnections, Port, ServerName, TotalConnections,
 };
+use std::fmt;
 use std::time::Duration;
+
+macro_rules! buffer_count_type {
+    ($(#[$meta:meta])* $name:ident) => {
+        crate::count_newtype!($(#[$meta])* $name, usize);
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+    };
+}
+
+buffer_count_type!(
+    /// Number of buffers available in the pool
+    AvailableBuffers
+);
+
+buffer_count_type!(
+    /// Number of buffers currently in use
+    InUseBuffers
+);
+
+buffer_count_type!(
+    /// Total number of buffers in the pool
+    TotalBuffers
+);
 
 /// Snapshot of the I/O buffer pool used by the summary panel.
 #[derive(Debug, Clone, Copy, Default, serde::Serialize, serde::Deserialize)]
 pub struct BufferPoolStats {
-    pub available: usize,
-    pub in_use: usize,
-    pub total: usize,
+    pub available: AvailableBuffers,
+    pub in_use: InUseBuffers,
+    pub total: TotalBuffers,
 }
 
 /// A backend entry rendered in the backend list and chart panels.
@@ -36,9 +66,9 @@ pub struct BackendView {
     pub stats: BackendStats,
     pub active_connections: ActiveConnections,
     pub health_status: BackendHealthStatus,
-    pub pending_count: usize,
+    pub pending_count: PendingRequests,
     pub load_ratio: Option<f64>,
-    pub stateful_count: usize,
+    pub stateful_count: StatefulSessions,
     pub traffic_share: Option<f64>,
     pub history: Vec<ThroughputPoint>,
 }
@@ -57,8 +87,8 @@ pub struct RemoteBackendView {
     pub stats: BackendStats,
     pub active_connections: ActiveConnections,
     pub health_status: BackendHealthStatus,
-    pub pending_count: usize,
-    pub stateful_count: usize,
+    pub pending_count: PendingRequests,
+    pub stateful_count: StatefulSessions,
     pub traffic_share: Option<f64>,
     pub history: Vec<ThroughputPoint>,
 }
@@ -119,20 +149,20 @@ impl From<&UserStats> for DashboardUserStats {
 pub struct DashboardMetrics {
     pub total_connections: TotalConnections,
     pub active_connections: ActiveConnections,
-    pub stateful_sessions: usize,
+    pub stateful_sessions: StatefulSessions,
     pub client_to_backend_bytes: ClientToBackendBytes,
     pub backend_to_client_bytes: BackendToClientBytes,
     pub uptime: Duration,
-    pub cache_entries: u64,
+    pub cache_entries: CacheEntries,
     pub cache_size_bytes: u64,
     pub cache_hit_rate: f64,
     pub disk_cache: Option<DiskCacheStats>,
-    pub pipeline_batches: u64,
-    pub pipeline_commands: u64,
-    pub pipeline_requests_queued: u64,
-    pub pipeline_requests_completed: u64,
+    pub pipeline_batches: PipelineBatches,
+    pub pipeline_commands: PipelineCommands,
+    pub pipeline_requests_queued: PipelineRequestsQueued,
+    pub pipeline_requests_completed: PipelineRequestsCompleted,
     #[serde(default)]
-    pub in_flight_requests: usize,
+    pub in_flight_requests: PendingRequests,
 }
 
 impl DashboardMetrics {
@@ -180,7 +210,7 @@ impl From<&MetricsSnapshot> for DashboardMetrics {
             pipeline_commands: snapshot.pipeline_commands,
             pipeline_requests_queued: snapshot.pipeline_requests_queued,
             pipeline_requests_completed: snapshot.pipeline_requests_completed,
-            in_flight_requests: 0,
+            in_flight_requests: PendingRequests::ZERO,
         }
     }
 }
@@ -234,9 +264,9 @@ impl DashboardState {
     }
 
     #[must_use]
-    pub fn backend_pending_count(&self, backend_idx: usize) -> usize {
+    pub fn backend_pending_count(&self, backend_idx: usize) -> PendingRequests {
         self.backend_view(backend_idx)
-            .map_or(0, |view| view.pending_count)
+            .map_or(PendingRequests::ZERO, |view| view.pending_count)
     }
 
     #[must_use]
@@ -246,9 +276,9 @@ impl DashboardState {
     }
 
     #[must_use]
-    pub fn backend_stateful_count(&self, backend_idx: usize) -> usize {
+    pub fn backend_stateful_count(&self, backend_idx: usize) -> StatefulSessions {
         self.backend_view(backend_idx)
-            .map_or(0, |view| view.stateful_count)
+            .map_or(StatefulSessions::ZERO, |view| view.stateful_count)
     }
 
     #[must_use]
@@ -275,15 +305,15 @@ impl RemoteDashboardState {
     }
 
     #[must_use]
-    pub fn backend_pending_count(&self, backend_idx: usize) -> usize {
+    pub fn backend_pending_count(&self, backend_idx: usize) -> PendingRequests {
         self.backend_view(backend_idx)
-            .map_or(0, |view| view.pending_count)
+            .map_or(PendingRequests::ZERO, |view| view.pending_count)
     }
 
     #[must_use]
-    pub fn backend_stateful_count(&self, backend_idx: usize) -> usize {
+    pub fn backend_stateful_count(&self, backend_idx: usize) -> StatefulSessions {
         self.backend_view(backend_idx)
-            .map_or(0, |view| view.stateful_count)
+            .map_or(StatefulSessions::ZERO, |view| view.stateful_count)
     }
 
     #[must_use]
@@ -344,9 +374,9 @@ mod tests {
             stats: BackendStats::default(),
             active_connections: ActiveConnections::new(1),
             health_status: BackendHealthStatus::Healthy,
-            pending_count: 2,
+            pending_count: PendingRequests::new(2),
             load_ratio: Some(0.5),
-            stateful_count: 3,
+            stateful_count: StatefulSessions::new(3),
             traffic_share: Some(42.0),
             history: vec![ThroughputPoint::new_backend(
                 Timestamp::now(),
@@ -373,9 +403,9 @@ mod tests {
 
         assert!(state.latest_backend_throughput(1).is_none());
         assert!(state.throughput_history(1).is_none());
-        assert_eq!(state.backend_pending_count(1), 0);
+        assert_eq!(state.backend_pending_count(1), PendingRequests::ZERO);
         assert!(state.backend_load_ratio(1).is_none());
-        assert_eq!(state.backend_stateful_count(1), 0);
+        assert_eq!(state.backend_stateful_count(1), StatefulSessions::ZERO);
         assert!(state.backend_traffic_share(1).is_none());
     }
 
@@ -403,9 +433,9 @@ mod tests {
             show_details: true,
             log_lines: vec!["hello".to_string()],
             buffer_pool: Some(BufferPoolStats {
-                available: 1,
-                in_use: 2,
-                total: 3,
+                available: AvailableBuffers::new(1),
+                in_use: InUseBuffers::new(2),
+                total: TotalBuffers::new(3),
             }),
         };
 

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -4,7 +4,7 @@ use crate::metrics::{
     ActiveConnections, BackendHealthStatus, BackendStats, CacheEntries, CommandCount,
     DiskCacheStats, ErrorCount, MetricsSnapshot, PendingRequests, PipelineBatches,
     PipelineCommands, PipelineRequestsCompleted, PipelineRequestsQueued, StatefulSessions,
-    UserStats,
+    UserActiveConnections, UserStats,
 };
 use crate::tui::app::{ThroughputPoint, ViewMode};
 use crate::tui::system_stats::SystemStats;
@@ -106,7 +106,7 @@ impl RemoteBackendView {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DashboardUserStats {
     pub username: String,
-    pub active_connections: ActiveConnections,
+    pub active_connections: UserActiveConnections,
     pub total_connections: TotalConnections,
     pub bytes_sent: BytesSent,
     pub bytes_received: BytesReceived,
@@ -134,7 +134,7 @@ impl From<&UserStats> for DashboardUserStats {
     fn from(user: &UserStats) -> Self {
         Self {
             username: user.username.clone(),
-            active_connections: ActiveConnections::new(user.active_connections.get()),
+            active_connections: user.active_connections,
             total_connections: user.total_connections,
             bytes_sent: user.bytes_sent,
             bytes_received: user.bytes_received,

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -111,7 +111,7 @@ impl DashboardUserStats {
 /// Serialized metrics used by the dashboard payload.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct DashboardMetrics {
-    pub total_connections: u64,
+    pub total_connections: TotalConnections,
     pub active_connections: ActiveConnections,
     pub stateful_sessions: usize,
     pub client_to_backend_bytes: ClientToBackendBytes,
@@ -134,7 +134,7 @@ impl DashboardMetrics {
     pub fn from_snapshot(snapshot: &MetricsSnapshot) -> Self {
         Self {
             total_connections: snapshot.total_connections,
-            active_connections: ActiveConnections::new(snapshot.active_connections),
+            active_connections: snapshot.active_connections,
             stateful_sessions: snapshot.stateful_sessions,
             client_to_backend_bytes: snapshot.client_to_backend_bytes,
             backend_to_client_bytes: snapshot.backend_to_client_bytes,

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -87,6 +87,19 @@ pub struct DashboardUserStats {
 impl DashboardUserStats {
     #[must_use]
     pub fn from_user_stats(user: &UserStats) -> Self {
+        Self::from(user)
+    }
+
+    #[must_use]
+    pub const fn total_bytes(&self) -> u64 {
+        self.bytes_sent
+            .as_u64()
+            .saturating_add(self.bytes_received.as_u64())
+    }
+}
+
+impl From<&UserStats> for DashboardUserStats {
+    fn from(user: &UserStats) -> Self {
         Self {
             username: user.username.clone(),
             active_connections: ActiveConnections::new(user.active_connections.get()),
@@ -98,13 +111,6 @@ impl DashboardUserStats {
             total_commands: user.total_commands,
             errors: user.errors,
         }
-    }
-
-    #[must_use]
-    pub const fn total_bytes(&self) -> u64 {
-        self.bytes_sent
-            .as_u64()
-            .saturating_add(self.bytes_received.as_u64())
     }
 }
 
@@ -132,23 +138,7 @@ pub struct DashboardMetrics {
 impl DashboardMetrics {
     #[must_use]
     pub fn from_snapshot(snapshot: &MetricsSnapshot) -> Self {
-        Self {
-            total_connections: snapshot.total_connections,
-            active_connections: snapshot.active_connections,
-            stateful_sessions: snapshot.stateful_sessions,
-            client_to_backend_bytes: snapshot.client_to_backend_bytes,
-            backend_to_client_bytes: snapshot.backend_to_client_bytes,
-            uptime: snapshot.uptime,
-            cache_entries: snapshot.cache_entries,
-            cache_size_bytes: snapshot.cache_size_bytes,
-            cache_hit_rate: snapshot.cache_hit_rate,
-            disk_cache: snapshot.disk_cache,
-            pipeline_batches: snapshot.pipeline_batches,
-            pipeline_commands: snapshot.pipeline_commands,
-            pipeline_requests_queued: snapshot.pipeline_requests_queued,
-            pipeline_requests_completed: snapshot.pipeline_requests_completed,
-            in_flight_requests: 0,
-        }
+        Self::from(snapshot)
     }
 
     #[must_use]
@@ -170,6 +160,28 @@ impl DashboardMetrics {
     #[must_use]
     pub const fn total_bytes(&self) -> u64 {
         self.client_to_backend_bytes.as_u64() + self.backend_to_client_bytes.as_u64()
+    }
+}
+
+impl From<&MetricsSnapshot> for DashboardMetrics {
+    fn from(snapshot: &MetricsSnapshot) -> Self {
+        Self {
+            total_connections: snapshot.total_connections,
+            active_connections: snapshot.active_connections,
+            stateful_sessions: snapshot.stateful_sessions,
+            client_to_backend_bytes: snapshot.client_to_backend_bytes,
+            backend_to_client_bytes: snapshot.backend_to_client_bytes,
+            uptime: snapshot.uptime,
+            cache_entries: snapshot.cache_entries,
+            cache_size_bytes: snapshot.cache_size_bytes,
+            cache_hit_rate: snapshot.cache_hit_rate,
+            disk_cache: snapshot.disk_cache,
+            pipeline_batches: snapshot.pipeline_batches,
+            pipeline_commands: snapshot.pipeline_commands,
+            pipeline_requests_queued: snapshot.pipeline_requests_queued,
+            pipeline_requests_completed: snapshot.pipeline_requests_completed,
+            in_flight_requests: 0,
+        }
     }
 }
 

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -12,7 +12,9 @@ use crate::types::{
     BackendToClientBytes, BytesPerSecondRate, BytesReceived, BytesSent, ClientToBackendBytes,
     HostName, MaxConnections, Port, ServerName, TotalConnections,
 };
+use arrayvec::ArrayString;
 use std::fmt;
+use std::fmt::Write as _;
 use std::time::Duration;
 
 macro_rules! buffer_count_type {
@@ -172,19 +174,22 @@ impl DashboardMetrics {
     }
 
     #[must_use]
-    pub fn format_uptime(&self) -> String {
+    pub fn format_uptime(&self) -> ArrayString<24> {
         let secs = self.uptime.as_secs();
         let hours = secs / 3600;
         let minutes = (secs % 3600) / 60;
         let seconds = secs % 60;
 
+        let mut text = ArrayString::<24>::new();
         if hours > 0 {
-            format!("{hours}h {minutes}m {seconds}s")
+            let _ = write!(&mut text, "{hours}h {minutes}m {seconds}s");
         } else if minutes > 0 {
-            format!("{minutes}m {seconds}s")
+            let _ = write!(&mut text, "{minutes}m {seconds}s");
         } else {
-            format!("{seconds}s")
+            let _ = write!(&mut text, "{seconds}s");
         }
+
+        text
     }
 
     #[must_use]

--- a/src/tui/helpers.rs
+++ b/src/tui/helpers.rs
@@ -6,6 +6,7 @@ use ratatui::style::Color;
 use super::constants::{BACKEND_COLORS, throughput};
 use super::dashboard::BackendView;
 use super::types::{BackendChartData, ChartDataVec, ChartPoint, ChartX, ChartY, PointVec};
+use crate::metrics::{ErrorCount, FailureCount};
 use crate::tui::app::ThroughputPoint;
 
 // ============================================================================
@@ -247,9 +248,9 @@ pub const fn error_rate_color(rate: f64) -> Color {
 
 /// Color for error count
 #[must_use]
-pub const fn error_count_color(has_errors: bool) -> Color {
+pub const fn error_count_color(errors: ErrorCount) -> Color {
     use super::constants::styles;
-    if has_errors {
+    if !errors.is_zero() {
         Color::Yellow
     } else {
         styles::VALUE_NEUTRAL
@@ -258,9 +259,9 @@ pub const fn error_count_color(has_errors: bool) -> Color {
 
 /// Color for connection failures
 #[must_use]
-pub const fn connection_failure_color(failures: u64) -> Color {
+pub fn connection_failure_color(failures: FailureCount) -> Color {
     use super::constants::styles;
-    if failures > 0 {
+    if !failures.is_zero() {
         Color::Red
     } else {
         styles::VALUE_NEUTRAL

--- a/src/tui/helpers.rs
+++ b/src/tui/helpers.rs
@@ -392,8 +392,8 @@ mod tests {
     #[test]
     fn test_chart_data_vec_type() {
         // Verify ChartDataVec can hold typical backend count on stack
-        let mut chart_data = ChartDataVec::new();
         let names: Vec<String> = (0..8).map(|i| format!("Server {i}")).collect();
+        let mut chart_data = ChartDataVec::new();
 
         // Add 8 backends (at SmallVec capacity)
         for (i, name) in names.iter().enumerate() {

--- a/src/tui/helpers.rs
+++ b/src/tui/helpers.rs
@@ -76,7 +76,7 @@ pub fn create_sparkline_text(value: u64, max_value: u64) -> ArrayString<64> {
 /// 3. Accumulates results with global max tracking
 ///
 /// Returns (`chart_data`, `global_max_throughput`)
-pub fn build_chart_data(backend_views: &[BackendView]) -> (ChartDataVec, f64) {
+pub fn build_chart_data<'a>(backend_views: &'a [BackendView]) -> (ChartDataVec<'a>, f64) {
     /// Extract data from a single throughput point
     #[inline]
     fn extract_point_data(idx: usize, point: &ThroughputPoint) -> (ChartPoint, ChartPoint, ChartY) {
@@ -118,7 +118,7 @@ pub fn build_chart_data(backend_views: &[BackendView]) -> (ChartDataVec, f64) {
 
             (
                 BackendChartData::new(
-                    backend.server.name.as_str().to_string(),
+                    backend.server.name.as_str(),
                     backend_color(index),
                     &sent_points,
                     &recv_points,
@@ -393,11 +393,12 @@ mod tests {
     fn test_chart_data_vec_type() {
         // Verify ChartDataVec can hold typical backend count on stack
         let mut chart_data = ChartDataVec::new();
+        let names: Vec<String> = (0..8).map(|i| format!("Server {i}")).collect();
 
         // Add 8 backends (at SmallVec capacity)
-        for i in 0..8 {
+        for (i, name) in names.iter().enumerate() {
             chart_data.push(BackendChartData::new(
-                format!("Server {i}"),
+                name.as_str(),
                 backend_color(i),
                 &PointVec::new(),
                 &PointVec::new(),
@@ -412,7 +413,7 @@ mod tests {
     #[test]
     fn test_backend_chart_data_structure() {
         let data = BackendChartData::new(
-            "Test Server".to_string(),
+            "Test Server",
             backend_color(0),
             &PointVec::new(),
             &PointVec::new(),

--- a/src/tui/helpers.rs
+++ b/src/tui/helpers.rs
@@ -2,6 +2,8 @@
 
 use arrayvec::ArrayString;
 use ratatui::style::Color;
+use std::fmt::Write as _;
+use std::net::SocketAddr;
 
 use super::constants::{BACKEND_COLORS, throughput};
 use super::dashboard::BackendView;
@@ -173,14 +175,16 @@ pub fn round_up_throughput(value: f64) -> f64 {
 ///
 /// Returns human-readable string like "10 MiB/s", "500 KiB/s", "100 B/s"
 #[must_use]
-pub fn format_throughput_label(value: f64) -> String {
+pub fn format_throughput_label(value: f64) -> ArrayString<24> {
+    let mut text = ArrayString::<24>::new();
     if value >= throughput::ONE_MIB {
-        format!("{:.0} MiB/s", value / throughput::ONE_MIB)
+        let _ = write!(&mut text, "{:.0} MiB/s", value / throughput::ONE_MIB);
     } else if value >= throughput::ONE_KIB {
-        format!("{:.0} KiB/s", value / throughput::ONE_KIB)
+        let _ = write!(&mut text, "{:.0} KiB/s", value / throughput::ONE_KIB);
     } else {
-        format!("{value:.0} B/s")
+        let _ = write!(&mut text, "{value:.0} B/s");
     }
+    text
 }
 
 // ============================================================================
@@ -189,23 +193,45 @@ pub fn format_throughput_label(value: f64) -> String {
 
 /// Format throughput strings for summary display
 #[must_use]
-pub fn format_summary_throughput(latest_throughput: Option<&ThroughputPoint>) -> (String, String) {
+pub fn format_summary_throughput(
+    latest_throughput: Option<&ThroughputPoint>,
+) -> (ArrayString<24>, ArrayString<24>) {
     use super::constants::text;
 
     latest_throughput.map_or_else(
         || {
-            (
-                format!("{}{}", text::ARROW_UP, text::DEFAULT_THROUGHPUT),
-                format!("{}{}", text::ARROW_DOWN, text::DEFAULT_THROUGHPUT),
-            )
+            let mut up = ArrayString::<24>::new();
+            let mut down = ArrayString::<24>::new();
+            let _ = write!(&mut up, "{}{}", text::ARROW_UP, text::DEFAULT_THROUGHPUT);
+            let _ = write!(
+                &mut down,
+                "{}{}",
+                text::ARROW_DOWN,
+                text::DEFAULT_THROUGHPUT
+            );
+            (up, down)
         },
         |point| {
-            (
-                format!("{}{}", text::ARROW_UP, point.sent_per_sec()),
-                format!("{}{}", text::ARROW_DOWN, point.received_per_sec()),
-            )
+            let mut up = ArrayString::<24>::new();
+            let mut down = ArrayString::<24>::new();
+            let _ = write!(&mut up, "{}{}", text::ARROW_UP, point.sent_per_sec());
+            let _ = write!(
+                &mut down,
+                "{}{}",
+                text::ARROW_DOWN,
+                point.received_per_sec()
+            );
+            (up, down)
         },
     )
+}
+
+/// Format a socket address for display without heap allocation.
+#[must_use]
+pub fn socket_addr_text(addr: SocketAddr) -> ArrayString<64> {
+    let mut text = ArrayString::<64>::new();
+    let _ = write!(&mut text, "{addr}");
+    text
 }
 
 // ============================================================================
@@ -330,17 +356,17 @@ mod tests {
 
     #[test]
     fn test_format_throughput_label() {
-        assert_eq!(format_throughput_label(10_485_760.0), "10 MiB/s");
-        assert_eq!(format_throughput_label(500_000.0), "488 KiB/s");
-        assert_eq!(format_throughput_label(100.0), "100 B/s");
+        assert_eq!(format_throughput_label(10_485_760.0).as_str(), "10 MiB/s");
+        assert_eq!(format_throughput_label(500_000.0).as_str(), "488 KiB/s");
+        assert_eq!(format_throughput_label(100.0).as_str(), "100 B/s");
     }
 
     #[test]
     fn test_format_throughput_label_boundaries() {
         // Test boundary values
-        assert_eq!(format_throughput_label(1_048_576.0), "1 MiB/s");
-        assert_eq!(format_throughput_label(1_024.0), "1 KiB/s");
-        assert_eq!(format_throughput_label(0.0), "0 B/s");
+        assert_eq!(format_throughput_label(1_048_576.0).as_str(), "1 MiB/s");
+        assert_eq!(format_throughput_label(1_024.0).as_str(), "1 KiB/s");
+        assert_eq!(format_throughput_label(0.0).as_str(), "0 B/s");
     }
 
     #[test]

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -585,9 +585,9 @@ mod tests {
                 stats: crate::metrics::BackendStats::default(),
                 active_connections: crate::metrics::ActiveConnections::new(0),
                 health_status: crate::metrics::BackendHealthStatus::Healthy,
-                pending_count: 0,
+                pending_count: crate::metrics::PendingRequests::ZERO,
                 load_ratio: None,
-                stateful_count: 0,
+                stateful_count: crate::metrics::StatefulSessions::ZERO,
                 traffic_share: None,
                 history: vec![ThroughputPoint::new_backend(
                     Timestamp::now(),
@@ -1006,9 +1006,9 @@ mod tests {
             show_details: false,
             log_lines: vec!["first".to_string()],
             buffer_pool: Some(BufferPoolStats {
-                available: 1,
-                in_use: 0,
-                total: 1,
+                available: crate::tui::dashboard::AvailableBuffers::new(1),
+                in_use: crate::tui::dashboard::InUseBuffers::new(0),
+                total: crate::tui::dashboard::TotalBuffers::new(1),
             }),
         };
         let mut second = first.clone();
@@ -1176,9 +1176,9 @@ mod tests {
             show_details: true,
             log_lines: vec!["second".to_string()],
             buffer_pool: Some(BufferPoolStats {
-                available: 2,
-                in_use: 1,
-                total: 3,
+                available: crate::tui::dashboard::AvailableBuffers::new(2),
+                in_use: crate::tui::dashboard::InUseBuffers::new(1),
+                total: crate::tui::dashboard::TotalBuffers::new(3),
             }),
             ..empty_dashboard_state()
         };
@@ -1195,7 +1195,7 @@ mod tests {
         assert!(second_observed.show_details);
         assert_eq!(
             second_observed.buffer_pool.as_ref().map(|pool| pool.total),
-            Some(3)
+            Some(crate::tui::dashboard::TotalBuffers::new(3))
         );
         assert_eq!(
             state_rx.borrow().status,

--- a/src/tui/remote.rs
+++ b/src/tui/remote.rs
@@ -864,7 +864,7 @@ mod tests {
             top_users: (0..10)
                 .map(|idx| crate::tui::dashboard::DashboardUserStats {
                     username: format!("user-{idx}"),
-                    active_connections: crate::metrics::ActiveConnections::new(0),
+                    active_connections: crate::metrics::UserActiveConnections::new(0),
                     total_connections: crate::types::TotalConnections::new(0),
                     bytes_sent: crate::types::BytesSent::ZERO,
                     bytes_received: crate::types::BytesReceived::ZERO,

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -236,12 +236,7 @@ mod tests {
         sent_points.push(ChartPoint::new(ChartX::new(0.0), ChartY::new(100.0)));
         sent_points.push(ChartPoint::new(ChartX::new(1.0), ChartY::new(200.0)));
 
-        let data = BackendChartData::new(
-            "Test".to_string(),
-            Color::Green,
-            &sent_points,
-            &PointVec::new(),
-        );
+        let data = BackendChartData::new("Test", Color::Green, &sent_points, &PointVec::new());
 
         let tuples = data.sent_points_as_tuples();
         assert_eq!(tuples.len(), 2);

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -127,9 +127,9 @@ pub struct BackendChartData {
     /// Color for this backend's lines
     pub color: Color,
     /// Pre-computed tuples for ratatui (cached to avoid allocation on render)
-    sent_tuples: Vec<(f64, f64)>,
+    sent_tuples: SmallVec<[(f64, f64); 64]>,
     /// Pre-computed tuples for ratatui (cached to avoid allocation on render)
-    recv_tuples: Vec<(f64, f64)>,
+    recv_tuples: SmallVec<[(f64, f64); 64]>,
 }
 
 impl BackendChartData {
@@ -141,8 +141,10 @@ impl BackendChartData {
         sent_points: &[ChartPoint],
         recv_points: &[ChartPoint],
     ) -> Self {
-        let sent_tuples = sent_points.iter().map(ChartPoint::as_tuple).collect();
-        let recv_tuples = recv_points.iter().map(ChartPoint::as_tuple).collect();
+        let sent_tuples: SmallVec<[(f64, f64); 64]> =
+            sent_points.iter().map(ChartPoint::as_tuple).collect();
+        let recv_tuples: SmallVec<[(f64, f64); 64]> =
+            recv_points.iter().map(ChartPoint::as_tuple).collect();
         Self {
             name,
             color,

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -115,15 +115,15 @@ pub type PointVec = SmallVec<[ChartPoint; 64]>;
 
 /// Stack-allocated chart data for typical backend counts.
 /// Most deployments have 1-4 backends, so this avoids heap allocation
-pub type ChartDataVec = SmallVec<[BackendChartData; 8]>;
+pub type ChartDataVec<'a> = SmallVec<[BackendChartData<'a>; 8]>;
 
 /// Chart data for a single backend server
 ///
 /// Pre-computed data points to avoid nested iterations during rendering
 #[derive(Debug, Clone)]
-pub struct BackendChartData {
+pub struct BackendChartData<'a> {
     /// Server name for legend
-    pub name: String,
+    pub name: &'a str,
     /// Color for this backend's lines
     pub color: Color,
     /// Pre-computed tuples for ratatui (cached to avoid allocation on render)
@@ -132,11 +132,11 @@ pub struct BackendChartData {
     recv_tuples: SmallVec<[(f64, f64); 64]>,
 }
 
-impl BackendChartData {
+impl<'a> BackendChartData<'a> {
     /// Create new chart data with pre-computed tuples
     #[must_use]
     pub fn new(
-        name: String,
+        name: &'a str,
         color: Color,
         sent_points: &[ChartPoint],
         recv_points: &[ChartPoint],

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -501,8 +501,8 @@ fn render_local_title_status_row(
     metrics: &DashboardMetrics,
 ) {
     let uptime = metrics.format_uptime();
-    let active = connections_text(metrics.active_connections.get());
-    let total = connections_text_u64(metrics.total_connections.get());
+    let active = connections_text(metrics.active_connections);
+    let total = connections_text(metrics.total_connections);
 
     write_part(
         buffer,
@@ -671,13 +671,7 @@ fn render_target_part(
     );
 }
 
-fn connections_text(count: usize) -> ArrayString<32> {
-    let mut value = ArrayString::<32>::new();
-    let _ = write!(&mut value, "{count} connections");
-    value
-}
-
-fn connections_text_u64(count: u64) -> ArrayString<32> {
+fn connections_text(count: impl std::fmt::Display) -> ArrayString<32> {
     let mut value = ArrayString::<32>::new();
     let _ = write!(&mut value, "{count} connections");
     value
@@ -710,8 +704,7 @@ fn build_title_lines(
                 "  |  Active: ".fg(styles::LABEL),
                 format!("{} connections", metrics.active_connections).fg(styles::VALUE_SECONDARY),
                 "  |  Total: ".fg(styles::LABEL),
-                format!("{} connections", metrics.total_connections.get())
-                    .fg(styles::VALUE_NEUTRAL),
+                format!("{} connections", metrics.total_connections).fg(styles::VALUE_NEUTRAL),
             ])
         },
         build_remote_title_status_line,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -502,7 +502,7 @@ fn render_local_title_status_row(
 ) {
     let uptime = metrics.format_uptime();
     let active = connections_text(metrics.active_connections.get());
-    let total = connections_text_u64(metrics.total_connections);
+    let total = connections_text_u64(metrics.total_connections.get());
 
     write_part(
         buffer,
@@ -710,7 +710,8 @@ fn build_title_lines(
                 "  |  Active: ".fg(styles::LABEL),
                 format!("{} connections", metrics.active_connections).fg(styles::VALUE_SECONDARY),
                 "  |  Total: ".fg(styles::LABEL),
-                format!("{} connections", metrics.total_connections).fg(styles::VALUE_NEUTRAL),
+                format!("{} connections", metrics.total_connections.get())
+                    .fg(styles::VALUE_NEUTRAL),
             ])
         },
         build_remote_title_status_line,
@@ -2414,7 +2415,7 @@ mod tests {
         let state = DashboardState {
             metrics: DashboardMetrics {
                 active_connections: crate::metrics::ActiveConnections::new(3),
-                total_connections: 5,
+                total_connections: crate::types::TotalConnections::new(5),
                 ..DashboardMetrics::default()
             },
             backend_views: Vec::new(),
@@ -2450,7 +2451,7 @@ mod tests {
     fn title_lines_show_active_and_total_connections_separately() {
         let metrics = DashboardMetrics {
             active_connections: crate::metrics::ActiveConnections::new(3),
-            total_connections: 42,
+            total_connections: crate::types::TotalConnections::new(42),
             ..DashboardMetrics::default()
         };
 

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -18,6 +18,7 @@ use crate::tui::helpers::{
     health_indicator, socket_addr_text,
 };
 use crate::types::MaxConnections;
+use crate::types::TotalConnections;
 use arrayvec::ArrayString;
 use ratatui::{
     Frame,
@@ -91,7 +92,9 @@ ui_count_type!(
     PipelineRequestsQueued,
     StatefulSessions,
     TotalBuffers,
+    TotalConnections,
     UserActiveConnections,
+    MaxConnections,
 );
 
 // ============================================================================
@@ -722,9 +725,9 @@ fn render_target_part(
     );
 }
 
-fn connections_text(count: impl std::fmt::Display) -> ArrayString<32> {
+fn connections_text(count: impl UiCount) -> ArrayString<32> {
     let mut value = ArrayString::<32>::new();
-    let _ = write!(&mut value, "{count} connections");
+    let _ = write!(&mut value, "{} connections", count.as_count());
     value
 }
 
@@ -1817,9 +1820,11 @@ fn count_text(count: impl UiCount) -> ArrayString<32> {
     text
 }
 
-fn connections_used_max_text(used: ActiveConnections, max: MaxConnections) -> ArrayString<32> {
+fn connections_used_max_text(used: impl UiCount, max: impl UiCount) -> ArrayString<32> {
+    let used = used.as_count();
+    let max = max.as_count();
     let mut text = ArrayString::<32>::new();
-    let _ = write!(&mut text, "{used}/{}", max.get());
+    let _ = write!(&mut text, "{used}/{max}");
     text
 }
 
@@ -2431,7 +2436,7 @@ mod tests {
     fn user_stats(name: &str, total_bytes: u64) -> DashboardUserStats {
         DashboardUserStats {
             username: name.to_string(),
-            active_connections: crate::metrics::ActiveConnections::new(0),
+            active_connections: crate::metrics::UserActiveConnections::new(0),
             total_connections: crate::types::TotalConnections::new(0),
             bytes_sent: crate::types::BytesSent::new(total_bytes),
             bytes_received: crate::types::BytesReceived::ZERO,
@@ -2818,7 +2823,7 @@ mod tests {
     fn user_stats_line_uses_live_active_connections_column() {
         let user = DashboardUserStats {
             username: "alice".to_string(),
-            active_connections: crate::metrics::ActiveConnections::new(7),
+            active_connections: crate::metrics::UserActiveConnections::new(7),
             total_connections: crate::types::TotalConnections::new(99),
             bytes_sent: crate::types::BytesSent::ZERO,
             bytes_received: crate::types::BytesReceived::ZERO,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -15,7 +15,7 @@ use crate::tui::dashboard::{
 use crate::tui::helpers::{
     build_chart_data, calculate_chart_bounds, connection_failure_color, create_sparkline_text,
     error_count_color, error_rate_color, format_summary_throughput, format_throughput_label,
-    health_indicator,
+    health_indicator, socket_addr_text,
 };
 use crate::types::MaxConnections;
 use arrayvec::ArrayString;
@@ -30,6 +30,7 @@ use ratatui::{
 };
 use std::collections::VecDeque;
 use std::fmt::Write as _;
+use std::sync::LazyLock;
 
 #[cfg(test)]
 use crate::formatting::format_bytes;
@@ -710,8 +711,7 @@ fn render_target_part(
         "  |  Target: ",
         Style::default().fg(styles::LABEL),
     );
-    let mut target_buf = ArrayString::<64>::new();
-    let _ = write!(&mut target_buf, "{target}");
+    let target_buf = socket_addr_text(*target);
     write_part(
         buffer,
         x,
@@ -732,6 +732,10 @@ fn build_title_lines(
     metrics: &DashboardMetrics,
     remote_status: Option<&RemoteDashboardStatus>,
 ) -> Vec<Line<'static>> {
+    let uptime = metrics.format_uptime().to_string();
+    let active = connections_text(metrics.active_connections).to_string();
+    let total = connections_text(metrics.total_connections).to_string();
+
     let title_suffix = remote_status.map_or_else(
         || Span::from("- Real-Time Metrics Dashboard").fg(Color::White),
         |status| match status {
@@ -751,11 +755,11 @@ fn build_title_lines(
         || {
             Line::from(vec![
                 "Uptime: ".fg(styles::LABEL),
-                metrics.format_uptime().fg(styles::VALUE_PRIMARY).bold(),
+                uptime.fg(styles::VALUE_PRIMARY).bold(),
                 "  |  Active: ".fg(styles::LABEL),
-                format!("{} connections", metrics.active_connections).fg(styles::VALUE_SECONDARY),
+                active.fg(styles::VALUE_SECONDARY),
                 "  |  Total: ".fg(styles::LABEL),
-                format!("{} connections", metrics.total_connections).fg(styles::VALUE_NEUTRAL),
+                total.fg(styles::VALUE_NEUTRAL),
             ])
         },
         build_remote_title_status_line,
@@ -885,7 +889,7 @@ fn render_app_summary_panel(
         &mut row,
         right,
         "Uptime: ",
-        &uptime,
+        uptime.as_str(),
         Style::default().fg(styles::VALUE_PRIMARY),
     );
 
@@ -1170,7 +1174,7 @@ fn render_transfer_summary_panel(f: &mut Frame, area: Rect, state: &DashboardSta
         &mut row,
         right,
         "Client → Backend: ",
-        &client_to_backend,
+        client_to_backend.as_str(),
         Style::default().fg(styles::VALUE_SECONDARY),
     );
     render_label_value_row(
@@ -1179,7 +1183,7 @@ fn render_transfer_summary_panel(f: &mut Frame, area: Rect, state: &DashboardSta
         &mut row,
         right,
         "Backend → Client: ",
-        &backend_to_client,
+        backend_to_client.as_str(),
         Style::default()
             .fg(styles::VALUE_PRIMARY)
             .add_modifier(Modifier::BOLD),
@@ -1326,7 +1330,10 @@ fn build_app_summary_lines(
     let mut lines = vec![
         Line::from(vec![
             "Uptime: ".fg(styles::LABEL),
-            metrics.format_uptime().fg(styles::VALUE_PRIMARY),
+            metrics
+                .format_uptime()
+                .to_string()
+                .fg(styles::VALUE_PRIMARY),
         ]),
         Line::from(vec![
             "Stateful Sessions: ".fg(styles::LABEL),
@@ -1991,6 +1998,7 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
     // Calculate chart bounds (extracted for testing)
     let max_throughput_rounded = calculate_chart_bounds(max_throughput);
     let max_label = format_throughput_label(max_throughput_rounded);
+    let half_label = format_throughput_label(max_throughput_rounded / 2.0);
 
     fn dataset_name<'a>(backend_name: &'a str, direction: &'static str) -> Line<'a> {
         Line::from(vec![
@@ -2001,38 +2009,32 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
     }
 
     // Build datasets directly from pre-computed chart data
-    let datasets: Vec<Dataset> = chart_data
-        .iter()
-        .flat_map(|data| {
-            let mut ds = Vec::with_capacity(2);
+    let mut datasets = Vec::with_capacity(chart_data.len() * 2);
+    for data in &chart_data {
+        let sent_points = data.sent_points_as_tuples();
+        if !sent_points.is_empty() {
+            datasets.push(
+                Dataset::default()
+                    .name(dataset_name(&data.name, text::ARROW_UP))
+                    .marker(symbols::Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(data.color))
+                    .data(sent_points),
+            );
+        }
 
-            // Sent data (upload to backend)
-            if !data.sent_points_as_tuples().is_empty() {
-                ds.push(
-                    Dataset::default()
-                        .name(dataset_name(&data.name, text::ARROW_UP))
-                        .marker(symbols::Marker::Braille)
-                        .graph_type(GraphType::Line)
-                        .style(Style::default().fg(data.color))
-                        .data(data.sent_points_as_tuples()),
-                );
-            }
-
-            // Received data (download from backend)
-            if !data.recv_points_as_tuples().is_empty() {
-                ds.push(
-                    Dataset::default()
-                        .name(dataset_name(&data.name, text::ARROW_DOWN))
-                        .marker(symbols::Marker::Braille)
-                        .graph_type(GraphType::Line)
-                        .style(Style::default().fg(data.color).add_modifier(Modifier::BOLD))
-                        .data(data.recv_points_as_tuples()),
-                );
-            }
-
-            ds
-        })
-        .collect();
+        let recv_points = data.recv_points_as_tuples();
+        if !recv_points.is_empty() {
+            datasets.push(
+                Dataset::default()
+                    .name(dataset_name(&data.name, text::ARROW_DOWN))
+                    .marker(symbols::Marker::Braille)
+                    .graph_type(GraphType::Line)
+                    .style(Style::default().fg(data.color).add_modifier(Modifier::BOLD))
+                    .data(recv_points),
+            );
+        }
+    }
 
     // Build and render chart
     let chart = Chart::new(datasets)
@@ -2042,7 +2044,7 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
                 .title("")
                 .style(Style::default().fg(styles::LABEL))
                 .bounds([0.0, chart::HISTORY_POINTS])
-                .labels(vec![
+                .labels([
                     Line::from(chart::X_LABEL_15S),
                     Line::from(chart::X_LABEL_10S),
                     Line::from(chart::X_LABEL_5S),
@@ -2054,10 +2056,10 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
                 .title("Throughput")
                 .style(Style::default().fg(styles::LABEL))
                 .bounds([0.0, max_throughput_rounded])
-                .labels(vec![
+                .labels([
                     Line::from(chart::Y_LABEL_ZERO),
-                    Line::from(format_throughput_label(max_throughput_rounded / 2.0)),
-                    Line::from(max_label),
+                    Line::from(half_label.as_str()),
+                    Line::from(max_label.as_str()),
                 ]),
         );
 
@@ -2066,17 +2068,20 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
 
 /// Render footer with help text
 fn render_footer(f: &mut Frame, area: Rect) {
-    let footer = footer_help_line();
     render_block_lines(
         f,
         area,
         untitled_bordered_block(styles::LABEL),
-        std::slice::from_ref(&footer),
+        std::slice::from_ref(footer_help_line()),
         Alignment::Center,
     );
 }
 
-fn footer_help_line() -> Line<'static> {
+fn footer_help_line() -> &'static Line<'static> {
+    &FOOTER_HELP_LINE
+}
+
+static FOOTER_HELP_LINE: LazyLock<Line<'static>> = LazyLock::new(|| {
     Line::from(vec![
         "Press ".fg(styles::LABEL),
         "q".fg(styles::VALUE_INFO).bold(),
@@ -2090,7 +2095,7 @@ fn footer_help_line() -> Line<'static> {
         "Ctrl+C".fg(styles::VALUE_INFO).bold(),
         " to shutdown".fg(styles::LABEL),
     ])
-}
+});
 
 /// Render recent log messages
 fn render_logs(f: &mut Frame, area: Rect, log_source: LogSource<'_>, show_details: bool) {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2447,6 +2447,25 @@ mod tests {
     }
 
     #[test]
+    fn title_lines_show_active_and_total_connections_separately() {
+        let metrics = DashboardMetrics {
+            active_connections: crate::metrics::ActiveConnections::new(3),
+            total_connections: 42,
+            ..DashboardMetrics::default()
+        };
+
+        let info_line = build_title_lines(&metrics, None)
+            .get(1)
+            .expect("title info line")
+            .to_string();
+
+        assert!(info_line.contains("Active:"));
+        assert!(info_line.contains("3 connections"));
+        assert!(info_line.contains("Total:"));
+        assert!(info_line.contains("42 connections"));
+    }
+
+    #[test]
     fn render_user_stats_uses_pre_sorted_users() {
         let users = [
             user_stats("bob", 30),
@@ -2645,6 +2664,30 @@ mod tests {
             rate_text(text::ARROW_UP, 1024).as_str(),
             format!("{}{}/s", text::ARROW_UP, format_bytes(1024))
         );
+    }
+
+    #[test]
+    fn user_stats_line_uses_live_active_connections_column() {
+        let user = DashboardUserStats {
+            username: "alice".to_string(),
+            active_connections: crate::metrics::ActiveConnections::new(7),
+            total_connections: crate::types::TotalConnections::new(99),
+            bytes_sent: crate::types::BytesSent::ZERO,
+            bytes_received: crate::types::BytesReceived::ZERO,
+            bytes_sent_per_sec: crate::types::BytesPerSecondRate::ZERO,
+            bytes_received_per_sec: crate::types::BytesPerSecondRate::ZERO,
+            total_commands: CommandCount::ZERO,
+            errors: ErrorCount::ZERO,
+        };
+
+        let first_line = user_stat_lines_for_test(&user)
+            .into_iter()
+            .next()
+            .expect("user line")
+            .to_string();
+
+        assert!(first_line.contains(&format!("{:>5}", 7)));
+        assert!(!first_line.contains(&format!("{:>5}", 99)));
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -1,16 +1,23 @@
 //! TUI rendering and layout
 
 use crate::formatting::format_bytes_into;
+use crate::metrics::{
+    ActiveConnections, ArticleCount, CacheEntries, CommandCount, DiskHits, DiskReadIos,
+    DiskWriteIos, ErrorCount, FailureCount, PendingRequests, PipelineBatches, PipelineCommands,
+    PipelineRequestsCompleted, PipelineRequestsQueued, StatefulSessions, UserActiveConnections,
+};
 use crate::tui::RemoteDashboardStatus;
 use crate::tui::constants::{chart, layout, styles, text};
 use crate::tui::dashboard::{
-    BufferPoolStats, DashboardMetrics, DashboardState, DashboardUserStats,
+    AvailableBuffers, BufferPoolStats, DashboardMetrics, DashboardState, DashboardUserStats,
+    InUseBuffers, TotalBuffers,
 };
 use crate::tui::helpers::{
     build_chart_data, calculate_chart_bounds, connection_failure_color, create_sparkline_text,
     error_count_color, error_rate_color, format_summary_throughput, format_throughput_label,
     health_indicator,
 };
+use crate::types::MaxConnections;
 use arrayvec::ArrayString;
 use ratatui::{
     Frame,
@@ -30,17 +37,61 @@ use crate::formatting::format_bytes;
 use crate::tui::helpers::{create_sparkline, format_error_rate};
 
 #[allow(clippy::cast_precision_loss)] // Chart labels and percentages are presentation-only values.
-const fn counter_as_f64(value: u64) -> f64 {
+fn counter_as_f64(value: impl UiCount) -> f64 {
     // These chart labels and percentages are display-only aggregates; the
     // underlying pipeline counters remain exact integers in the snapshot.
-    value as f64
+    value.as_count() as f64
 }
 
 #[allow(clippy::cast_precision_loss)] // Pool utilization is displayed as a percentage in the UI.
-const fn size_as_f64(value: usize) -> f64 {
+fn size_as_f64(value: impl UiCount) -> f64 {
     // Pool utilization is presented as a percentage in the UI, not used for control flow.
-    value as f64
+    value.as_count() as f64
 }
+
+trait UiCount: Copy {
+    fn as_count(self) -> u64;
+
+    #[inline]
+    fn is_zero(self) -> bool {
+        self.as_count() == 0
+    }
+}
+
+macro_rules! ui_count_type {
+    ($($ty:ty),+ $(,)?) => {
+        $(
+            impl UiCount for $ty {
+                #[inline]
+                fn as_count(self) -> u64 {
+                    self.get() as u64
+                }
+            }
+        )+
+    };
+}
+
+ui_count_type!(
+    ActiveConnections,
+    ArticleCount,
+    AvailableBuffers,
+    CacheEntries,
+    CommandCount,
+    DiskHits,
+    DiskReadIos,
+    DiskWriteIos,
+    ErrorCount,
+    FailureCount,
+    InUseBuffers,
+    PendingRequests,
+    PipelineBatches,
+    PipelineCommands,
+    PipelineRequestsCompleted,
+    PipelineRequestsQueued,
+    StatefulSessions,
+    TotalBuffers,
+    UserActiveConnections,
+);
 
 // ============================================================================
 // Widget Creation Helpers (Pure Functions)
@@ -795,15 +846,17 @@ fn render_app_summary_panel(
         }
     }
 
-    fn session_color(count: usize) -> Color {
-        if count > 0 {
+    fn session_color(count: impl UiCount) -> Color {
+        if !count.is_zero() {
             styles::VALUE_PRIMARY
         } else {
             styles::VALUE_NEUTRAL
         }
     }
 
-    fn buffer_color(in_use: usize, total: usize) -> Color {
+    fn buffer_color(in_use: impl UiCount, total: impl UiCount) -> Color {
+        let in_use = in_use.as_count();
+        let total = total.as_count();
         let percent = (in_use * 100).checked_div(total).unwrap_or_default();
         if percent > 80 {
             Color::Red
@@ -836,7 +889,7 @@ fn render_app_summary_panel(
         Style::default().fg(styles::VALUE_PRIMARY),
     );
 
-    let stateful = count_usize_text(metrics.stateful_sessions);
+    let stateful = count_text(metrics.stateful_sessions);
     render_label_value_row(
         buffer,
         inner,
@@ -910,7 +963,7 @@ fn render_app_summary_panel(
         Style::default().fg(styles::VALUE_INFO),
     );
 
-    if metrics.pipeline_batches > 0 {
+    if !metrics.pipeline_batches.is_zero() {
         let avg_batch =
             counter_as_f64(metrics.pipeline_commands) / counter_as_f64(metrics.pipeline_batches);
         let mut text = ArrayString::<64>::new();
@@ -930,7 +983,7 @@ fn render_app_summary_panel(
         );
     }
 
-    if metrics.pipeline_requests_queued > 0 {
+    if !metrics.pipeline_requests_queued.is_zero() {
         let mut text = ArrayString::<64>::new();
         let _ = write!(
             &mut text,
@@ -949,8 +1002,8 @@ fn render_app_summary_panel(
     }
 
     if show_details && let Some(pool) = buffer_pool {
-        let usage_percent = if pool.total > 0 {
-            size_as_f64(pool.in_use * 100) / size_as_f64(pool.total)
+        let usage_percent = if !pool.total.is_zero() {
+            size_as_f64(pool.in_use) * 100.0 / size_as_f64(pool.total)
         } else {
             0.0
         };
@@ -973,8 +1026,8 @@ fn render_app_summary_panel(
 }
 
 fn render_cache_summary_panel(f: &mut Frame, area: Rect, metrics: &DashboardMetrics) {
-    const fn entries_color(count: u64) -> Color {
-        if count > 0 {
+    fn entries_color(count: impl UiCount) -> Color {
+        if !count.is_zero() {
             styles::VALUE_INFO
         } else {
             styles::VALUE_NEUTRAL
@@ -991,8 +1044,8 @@ fn render_cache_summary_panel(f: &mut Frame, area: Rect, metrics: &DashboardMetr
         }
     }
 
-    const fn non_zero_color(value: u64) -> Color {
-        if value > 0 {
+    fn non_zero_color(value: impl Into<u64>) -> Color {
+        if value.into() > 0 {
             styles::VALUE_INFO
         } else {
             styles::VALUE_NEUTRAL
@@ -1249,15 +1302,17 @@ fn build_app_summary_lines(
         }
     }
 
-    fn session_color(count: usize) -> Color {
-        if count > 0 {
+    fn session_color(count: impl UiCount) -> Color {
+        if !count.is_zero() {
             styles::VALUE_PRIMARY
         } else {
             styles::VALUE_NEUTRAL
         }
     }
 
-    fn buffer_color(in_use: usize, total: usize) -> Color {
+    fn buffer_color(in_use: impl UiCount, total: impl UiCount) -> Color {
+        let in_use = in_use.as_count();
+        let total = total.as_count();
         let percent = (in_use * 100).checked_div(total).unwrap_or_default();
         if percent > 80 {
             Color::Red
@@ -1312,7 +1367,7 @@ fn build_app_summary_lines(
         format!("{} requests", metrics.in_flight_requests).fg(styles::VALUE_INFO),
     ]));
 
-    if metrics.pipeline_batches > 0 {
+    if !metrics.pipeline_batches.is_zero() {
         let avg_batch =
             counter_as_f64(metrics.pipeline_commands) / counter_as_f64(metrics.pipeline_batches);
         lines.push(Line::from(vec![
@@ -1325,7 +1380,7 @@ fn build_app_summary_lines(
         ]));
     }
 
-    if metrics.pipeline_requests_queued > 0 {
+    if !metrics.pipeline_requests_queued.is_zero() {
         lines.push(Line::from(vec![
             "Mux Totals: ".fg(styles::LABEL),
             format!(
@@ -1337,8 +1392,8 @@ fn build_app_summary_lines(
     }
 
     if show_details && let Some(pool) = buffer_pool {
-        let usage_percent = if pool.total > 0 {
-            size_as_f64(pool.in_use * 100) / size_as_f64(pool.total)
+        let usage_percent = if !pool.total.is_zero() {
+            size_as_f64(pool.in_use) * 100.0 / size_as_f64(pool.total)
         } else {
             0.0
         };
@@ -1497,11 +1552,7 @@ fn render_backend_list(f: &mut Frame, area: Rect, state: &DashboardState, show_d
             &mut x,
             y,
             right,
-            connections_used_max_text(
-                backend.active_connections.get(),
-                server.max_connections.get(),
-            )
-            .as_str(),
+            connections_used_max_text(backend.active_connections, server.max_connections).as_str(),
             Style::default().fg(styles::VALUE_SECONDARY),
         );
         write_part(
@@ -1651,7 +1702,7 @@ fn render_backend_list(f: &mut Frame, area: Rect, state: &DashboardState, show_d
             &mut x,
             y,
             right,
-            count_text(backend_stats.article_count.get()).as_str(),
+            count_text(backend_stats.article_count).as_str(),
             Style::default().fg(styles::VALUE_NEUTRAL),
         );
         row = row.saturating_add(1);
@@ -1674,12 +1725,8 @@ fn render_backend_list(f: &mut Frame, area: Rect, state: &DashboardState, show_d
             &mut x,
             y,
             right,
-            error_counts_text(
-                backend_stats.errors_4xx.get(),
-                backend_stats.errors_5xx.get(),
-            )
-            .as_str(),
-            Style::default().fg(error_count_color(!backend_stats.errors.is_zero())),
+            error_counts_text(backend_stats.errors_4xx, backend_stats.errors_5xx).as_str(),
+            Style::default().fg(error_count_color(backend_stats.errors)),
         );
         write_part(
             buffer,
@@ -1694,10 +1741,8 @@ fn render_backend_list(f: &mut Frame, area: Rect, state: &DashboardState, show_d
             &mut x,
             y,
             right,
-            count_text(backend_stats.connection_failures.get()).as_str(),
-            Style::default().fg(connection_failure_color(
-                backend_stats.connection_failures.get(),
-            )),
+            count_text(backend_stats.connection_failures).as_str(),
+            Style::default().fg(connection_failure_color(backend_stats.connection_failures)),
         );
         row = row.saturating_add(1);
 
@@ -1759,25 +1804,19 @@ fn bytes_text(bytes: u64) -> ArrayString<32> {
     text
 }
 
-fn count_text(count: u64) -> ArrayString<32> {
+fn count_text(count: impl UiCount) -> ArrayString<32> {
     let mut text = ArrayString::<32>::new();
-    let _ = write!(&mut text, "{count}");
+    let _ = write!(&mut text, "{}", count.as_count());
     text
 }
 
-fn count_usize_text(count: usize) -> ArrayString<32> {
+fn connections_used_max_text(used: ActiveConnections, max: MaxConnections) -> ArrayString<32> {
     let mut text = ArrayString::<32>::new();
-    let _ = write!(&mut text, "{count}");
+    let _ = write!(&mut text, "{used}/{}", max.get());
     text
 }
 
-fn connections_used_max_text(used: usize, max: usize) -> ArrayString<32> {
-    let mut text = ArrayString::<32>::new();
-    let _ = write!(&mut text, "{used}/{max}");
-    text
-}
-
-fn error_counts_text(errors_4xx: u64, errors_5xx: u64) -> ArrayString<48> {
+fn error_counts_text(errors_4xx: ErrorCount, errors_5xx: ErrorCount) -> ArrayString<48> {
     let mut text = ArrayString::<48>::new();
     let _ = write!(&mut text, "4xx:{errors_4xx} 5xx:{errors_5xx}");
     text
@@ -1788,12 +1827,12 @@ fn write_backend_details(
     x: &mut u16,
     y: u16,
     right: u16,
-    pending: usize,
-    stateful: usize,
+    pending: PendingRequests,
+    stateful: StatefulSessions,
 ) {
     let style = Style::default().fg(styles::LABEL);
 
-    if stateful > 0 {
+    if !stateful.is_zero() {
         write_part(buffer, x, y, right, "  Stateful: ", style);
         write_fmt_part::<32>(buffer, x, y, right, format_args!("{stateful}"), style);
         write_part(buffer, x, y, right, " | ", style);
@@ -1823,9 +1862,9 @@ fn user_name_text(username: &str) -> ArrayString<64> {
     text
 }
 
-fn active_connections_text(count: usize) -> ArrayString<16> {
+fn active_connections_text(count: impl UiCount) -> ArrayString<16> {
     let mut text = ArrayString::<16>::new();
-    let _ = write!(&mut text, "{count:>5}");
+    let _ = write!(&mut text, "{:>5}", count.as_count());
     text
 }
 
@@ -1844,10 +1883,10 @@ fn rate_text(prefix: &str, bytes_per_sec: u64) -> ArrayString<40> {
 }
 
 #[cfg(test)]
-fn backend_details_text(pending: usize, stateful: usize) -> String {
+fn backend_details_text(pending: PendingRequests, stateful: StatefulSessions) -> String {
     let mut text = String::new();
 
-    if stateful > 0 {
+    if !stateful.is_zero() {
         text.push_str(&format!("  Stateful: {stateful} | "));
     }
 
@@ -1894,10 +1933,7 @@ fn backend_row_texts(state: &DashboardState, show_details: bool) -> Vec<String> 
         });
         rows.push(format!(
             "  Used/Max: {}/{} | Cmd/s: {} | TTFB: {}",
-            backend.active_connections,
-            server.max_connections.get(),
-            cmd_per_sec,
-            ttfb
+            backend.active_connections, server.max_connections, cmd_per_sec, ttfb
         ));
         rows.push(format!(
             "  {} {}  {} {}",
@@ -1909,13 +1945,12 @@ fn backend_row_texts(state: &DashboardState, show_details: bool) -> Vec<String> 
         rows.push(format!(
             "  Avg Article: {} | Articles: {}",
             avg_size,
-            backend_stats.article_count.get()
+            count_text(backend_stats.article_count).as_str()
         ));
         rows.push(format!(
-            "  Errors: 4xx:{} 5xx:{} | Conn Fails: {}",
-            backend_stats.errors_4xx.get(),
-            backend_stats.errors_5xx.get(),
-            backend_stats.connection_failures.get()
+            "  Errors: {} | Conn Fails: {}",
+            error_counts_text(backend_stats.errors_4xx, backend_stats.errors_5xx).as_str(),
+            count_text(backend_stats.connection_failures).as_str()
         ));
 
         if show_details {
@@ -2272,7 +2307,7 @@ fn render_user_stats(f: &mut Frame, area: Rect, top_users: &[DashboardUserStats]
             &mut x,
             y,
             right,
-            active_connections_text(user.active_connections.get()).as_str(),
+            active_connections_text(user.active_connections).as_str(),
             Style::default().fg(Color::Green),
         );
         row = row.saturating_add(1);
@@ -2419,9 +2454,9 @@ mod tests {
             show_details: false,
             log_lines: vec!["line".to_string()],
             buffer_pool: Some(BufferPoolStats {
-                available: 3,
-                in_use: 1,
-                total: 4,
+                available: crate::tui::dashboard::AvailableBuffers::new(3),
+                in_use: crate::tui::dashboard::InUseBuffers::new(1),
+                total: crate::tui::dashboard::TotalBuffers::new(4),
             }),
         };
 
@@ -2487,9 +2522,9 @@ mod tests {
         let metrics = DashboardMetrics::default();
         let system_stats = crate::tui::SystemStats::default();
         let buffer_pool = BufferPoolStats {
-            available: 3,
-            in_use: 2,
-            total: 5,
+            available: crate::tui::dashboard::AvailableBuffers::new(3),
+            in_use: crate::tui::dashboard::InUseBuffers::new(2),
+            total: crate::tui::dashboard::TotalBuffers::new(5),
         };
 
         let local_lines =
@@ -2626,7 +2661,7 @@ mod tests {
 
     #[test]
     fn backend_details_line_includes_pending_and_stateful_counts() {
-        let details = backend_details_text(4, 1);
+        let details = backend_details_text(PendingRequests::new(4), StatefulSessions::new(1));
 
         assert!(details.contains("Stateful: 1"));
         assert!(details.contains("Pending: 4"));
@@ -2639,17 +2674,36 @@ mod tests {
         assert_eq!(error_rate_text(1.2).as_str(), format_error_rate(1.2));
         assert_eq!(error_rate_text(7.8).as_str(), format_error_rate(7.8));
         assert_eq!(bytes_text(29_312_178).as_str(), format_bytes(29_312_178));
-        assert_eq!(count_text(42).as_str(), "42");
-        assert_eq!(count_usize_text(42).as_str(), "42");
-        assert_eq!(connections_used_max_text(3, 10).as_str(), "3/10");
-        assert_eq!(error_counts_text(4, 5).as_str(), "4xx:4 5xx:5");
+        assert_eq!(
+            count_text(crate::metrics::CommandCount::new(42)).as_str(),
+            "42"
+        );
+        assert_eq!(
+            connections_used_max_text(
+                crate::metrics::ActiveConnections::new(3),
+                crate::types::MaxConnections::try_new(10).unwrap(),
+            )
+            .as_str(),
+            "3/10"
+        );
+        assert_eq!(
+            error_counts_text(
+                crate::metrics::ErrorCount::new(4),
+                crate::metrics::ErrorCount::new(5),
+            )
+            .as_str(),
+            "4xx:4 5xx:5"
+        );
     }
 
     #[test]
     fn user_stats_stack_formatters_match_owned_display_text() {
         assert_eq!(user_name_text("alice").as_str(), format!("{:<12}", "alice"));
         assert_eq!(user_name_text("averylongusername").as_str(), "averylong...");
-        assert_eq!(active_connections_text(7).as_str(), format!("{:>5}", 7));
+        assert_eq!(
+            active_connections_text(crate::metrics::UserActiveConnections::new(7)).as_str(),
+            format!("{:>5}", 7)
+        );
         assert_eq!(
             padded_bytes_text(29_312_178).as_str(),
             format!("{:>8}", format_bytes(29_312_178))
@@ -2720,9 +2774,9 @@ mod tests {
             stats: BackendStats::default(),
             active_connections: crate::metrics::ActiveConnections::new(0),
             health_status: BackendHealthStatus::Healthy,
-            pending_count: 0,
+            pending_count: crate::metrics::PendingRequests::ZERO,
             load_ratio: None,
-            stateful_count: 0,
+            stateful_count: crate::metrics::StatefulSessions::ZERO,
             traffic_share: None,
             history: Vec::new(),
         }
@@ -2751,7 +2805,7 @@ mod tests {
                 " ".into(),
                 create_sparkline(user.total_bytes(), user.total_bytes()).fg(Color::Blue),
                 " ".into(),
-                format!("{:>5}", user.active_connections.get()).fg(Color::Green),
+                format!("{:>5}", user.active_connections.as_count()).fg(Color::Green),
             ]),
             Line::from(vec![
                 "  ↑".into(),

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2015,7 +2015,7 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
         if !sent_points.is_empty() {
             datasets.push(
                 Dataset::default()
-                    .name(dataset_name(&data.name, text::ARROW_UP))
+                    .name(dataset_name(data.name, text::ARROW_UP))
                     .marker(symbols::Marker::Braille)
                     .graph_type(GraphType::Line)
                     .style(Style::default().fg(data.color))
@@ -2027,7 +2027,7 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
         if !recv_points.is_empty() {
             datasets.push(
                 Dataset::default()
-                    .name(dataset_name(&data.name, text::ARROW_DOWN))
+                    .name(dataset_name(data.name, text::ARROW_DOWN))
                     .marker(symbols::Marker::Braille)
                     .graph_type(GraphType::Line)
                     .style(Style::default().fg(data.color).add_modifier(Modifier::BOLD))

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -26,11 +26,11 @@ use ratatui::{
     style::{Color, Modifier, Style, Stylize},
     symbols,
     text::{Line, Span},
-    widgets::{Axis, Block, Chart, Dataset, GraphType, Paragraph, Wrap},
+    widgets::{Axis, Block, Chart, Dataset, GraphType},
 };
-use std::collections::VecDeque;
 use std::fmt::Write as _;
 use std::sync::LazyLock;
+use unicode_width::UnicodeWidthChar;
 
 #[cfg(test)]
 use crate::formatting::format_bytes;
@@ -2123,39 +2123,14 @@ fn render_snapshot_logs(
     fetch_count: usize,
     show_details: bool,
 ) {
-    if show_details {
-        let paragraph = Paragraph::new(recent_log_text_lines(log_lines, fetch_count))
-            .style(Style::default().fg(Color::Gray))
-            .block(bordered_block(" Recent Logs ", styles::BORDER_ACTIVE))
-            .wrap(Wrap { trim: false });
-        f.render_widget(paragraph, area);
-        return;
-    }
-
-    let block = bordered_block(" Recent Logs ", styles::BORDER_ACTIVE);
-    let inner = block.inner(area);
-    f.render_widget(block, area);
-
-    if inner.width == 0 || inner.height == 0 {
-        return;
-    }
-
-    for (row, line) in recent_log_lines(log_lines, fetch_count)
-        .iter()
-        .take(inner.height as usize)
-        .enumerate()
-    {
-        let rendered = Line::from(Span::styled(
-            line.as_str(),
-            Style::default().fg(Color::Gray),
-        ));
-        f.buffer_mut().set_line(
-            inner.left(),
-            inner.top().saturating_add(row as u16),
-            &rendered,
-            inner.width,
-        );
-    }
+    render_recent_log_lines(
+        f,
+        area,
+        recent_log_lines(log_lines, fetch_count)
+            .iter()
+            .map(String::as_str),
+        show_details,
+    );
 }
 
 fn render_buffer_logs(
@@ -2166,41 +2141,123 @@ fn render_buffer_logs(
     show_details: bool,
 ) {
     let _ = log_buffer.with_recent_lines(fetch_count, |lines, skip| {
-        if show_details {
-            let paragraph = Paragraph::new(recent_log_text_lines_from_deque(lines, skip))
-                .style(Style::default().fg(Color::Gray))
-                .block(bordered_block(" Recent Logs ", styles::BORDER_ACTIVE))
-                .wrap(Wrap { trim: false });
-            f.render_widget(paragraph, area);
-            return;
-        }
-
-        let block = bordered_block(" Recent Logs ", styles::BORDER_ACTIVE);
-        let inner = block.inner(area);
-        f.render_widget(block, area);
-
-        if inner.width == 0 || inner.height == 0 {
-            return;
-        }
-
-        for (row, line) in lines
-            .iter()
-            .skip(skip)
-            .take(inner.height as usize)
-            .enumerate()
-        {
-            let rendered = Line::from(Span::styled(
-                line.as_str(),
-                Style::default().fg(Color::Gray),
-            ));
-            f.buffer_mut().set_line(
-                inner.left(),
-                inner.top().saturating_add(row as u16),
-                &rendered,
-                inner.width,
-            );
-        }
+        render_recent_log_lines(
+            f,
+            area,
+            lines.iter().skip(skip).map(String::as_str),
+            show_details,
+        );
     });
+}
+
+fn render_recent_log_lines<'a, I>(f: &mut Frame, area: Rect, lines: I, show_details: bool)
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let block = bordered_block(" Recent Logs ", styles::BORDER_ACTIVE);
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let buffer = f.buffer_mut();
+    let style = Style::default().fg(Color::Gray);
+
+    if show_details {
+        render_wrapped_log_lines(buffer, inner, lines, style);
+    } else {
+        render_truncated_log_lines(buffer, inner, lines, style);
+    }
+}
+
+fn render_truncated_log_lines<'a, I>(buffer: &mut Buffer, area: Rect, lines: I, style: Style)
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let width = area.width as usize;
+    for (row, line) in lines.into_iter().take(area.height as usize).enumerate() {
+        buffer.set_stringn(
+            area.left(),
+            area.top().saturating_add(row as u16),
+            line,
+            width,
+            style,
+        );
+    }
+}
+
+fn render_wrapped_log_lines<'a, I>(buffer: &mut Buffer, area: Rect, lines: I, style: Style)
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let width = area.width as usize;
+    let mut row = 0u16;
+
+    for line in lines {
+        if row >= area.height {
+            break;
+        }
+
+        let mut remaining = line;
+        loop {
+            if row >= area.height {
+                return;
+            }
+
+            let (chunk, rest) = split_display_width_prefix(remaining, width);
+            buffer.set_stringn(
+                area.left(),
+                area.top().saturating_add(row),
+                chunk,
+                width,
+                style,
+            );
+            row = row.saturating_add(1);
+
+            if rest.is_empty() {
+                break;
+            }
+
+            remaining = rest;
+        }
+    }
+}
+
+fn split_display_width_prefix(text: &str, max_width: usize) -> (&str, &str) {
+    if text.is_empty() {
+        return ("", "");
+    }
+
+    if max_width == 0 {
+        return ("", text);
+    }
+
+    let mut width = 0usize;
+    let mut end = 0usize;
+
+    for (idx, ch) in text.char_indices() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if width + ch_width > max_width {
+            if end == 0 {
+                end = idx + ch.len_utf8();
+            }
+            break;
+        }
+
+        width += ch_width;
+        end = idx + ch.len_utf8();
+        if width == max_width {
+            break;
+        }
+    }
+
+    if end == 0 {
+        end = text.len();
+    }
+
+    (&text[..end], &text[end..])
 }
 
 fn render_block_lines(
@@ -2240,17 +2297,10 @@ fn recent_log_lines(lines: &[String], count: usize) -> &[String] {
     &lines[start..]
 }
 
+#[cfg(test)]
 fn recent_log_text_lines(lines: &[String], count: usize) -> Vec<Line<'_>> {
     recent_log_lines(lines, count)
         .iter()
-        .map(|line| Line::from(line.as_str()))
-        .collect()
-}
-
-fn recent_log_text_lines_from_deque(lines: &VecDeque<String>, skip: usize) -> Vec<Line<'_>> {
-    lines
-        .iter()
-        .skip(skip)
         .map(|line| Line::from(line.as_str()))
         .collect()
 }
@@ -2375,6 +2425,7 @@ mod tests {
     use crate::metrics::{CommandCount, ErrorCount};
     use crate::tui::app::ViewMode;
     use crate::tui::dashboard::{BufferPoolStats, DashboardMetrics};
+    use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
 
     fn user_stats(name: &str, total_bytes: u64) -> DashboardUserStats {
@@ -2433,6 +2484,50 @@ mod tests {
             .collect::<Vec<_>>();
 
         assert_eq!(rendered, vec!["two".to_string(), "three".to_string()]);
+    }
+
+    #[test]
+    fn split_display_width_prefix_keeps_progress_on_wide_characters() {
+        let (prefix, suffix) = split_display_width_prefix("你好世界", 2);
+
+        assert_eq!(prefix, "你");
+        assert_eq!(suffix, "好世界");
+    }
+
+    #[test]
+    fn render_truncated_log_lines_writes_rows_directly_to_buffer() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 3, 2));
+        render_truncated_log_lines(
+            &mut buffer,
+            Rect::new(0, 0, 3, 2),
+            ["abc", "def"],
+            Style::default(),
+        );
+
+        assert_eq!(buffer.cell((0, 0)).unwrap().symbol(), "a");
+        assert_eq!(buffer.cell((1, 0)).unwrap().symbol(), "b");
+        assert_eq!(buffer.cell((2, 0)).unwrap().symbol(), "c");
+        assert_eq!(buffer.cell((0, 1)).unwrap().symbol(), "d");
+        assert_eq!(buffer.cell((1, 1)).unwrap().symbol(), "e");
+        assert_eq!(buffer.cell((2, 1)).unwrap().symbol(), "f");
+    }
+
+    #[test]
+    fn render_wrapped_log_lines_wraps_without_building_text() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 3, 2));
+        render_wrapped_log_lines(
+            &mut buffer,
+            Rect::new(0, 0, 3, 2),
+            ["abcdef"],
+            Style::default(),
+        );
+
+        assert_eq!(buffer.cell((0, 0)).unwrap().symbol(), "a");
+        assert_eq!(buffer.cell((1, 0)).unwrap().symbol(), "b");
+        assert_eq!(buffer.cell((2, 0)).unwrap().symbol(), "c");
+        assert_eq!(buffer.cell((0, 1)).unwrap().symbol(), "d");
+        assert_eq!(buffer.cell((1, 1)).unwrap().symbol(), "e");
+        assert_eq!(buffer.cell((2, 1)).unwrap().symbol(), "f");
     }
 
     #[test]

--- a/src/tui/ui_tests.rs
+++ b/src/tui/ui_tests.rs
@@ -127,10 +127,10 @@ mod tests {
         let max_throughput = 10_485_760.0; // 10 MiB/s
         let label = format_throughput_label(max_throughput);
 
-        assert_eq!(label, "10 MiB/s");
+        assert_eq!(label.as_str(), "10 MiB/s");
 
         let half_label = format_throughput_label(max_throughput / 2.0);
-        assert_eq!(half_label, "5 MiB/s");
+        assert_eq!(half_label.as_str(), "5 MiB/s");
     }
 
     #[test]

--- a/tests/proxy/metrics/collector.rs
+++ b/tests/proxy/metrics/collector.rs
@@ -24,32 +24,32 @@ fn test_connection_lifecycle() {
 
     // Initially zero
     let snapshot = collector.snapshot(None);
-    assert_eq!(snapshot.total_connections, 0);
-    assert_eq!(snapshot.active_connections, 0);
+    assert_eq!(snapshot.total_connections.get(), 0);
+    assert_eq!(snapshot.active_connections.get(), 0);
 
     // Open connection
     collector.connection_opened();
     let snapshot = collector.snapshot(None);
-    assert_eq!(snapshot.total_connections, 1);
-    assert_eq!(snapshot.active_connections, 1);
+    assert_eq!(snapshot.total_connections.get(), 1);
+    assert_eq!(snapshot.active_connections.get(), 1);
 
     // Open another
     collector.connection_opened();
     let snapshot = collector.snapshot(None);
-    assert_eq!(snapshot.total_connections, 2);
-    assert_eq!(snapshot.active_connections, 2);
+    assert_eq!(snapshot.total_connections.get(), 2);
+    assert_eq!(snapshot.active_connections.get(), 2);
 
     // Close one
     collector.connection_closed();
     let snapshot = collector.snapshot(None);
-    assert_eq!(snapshot.total_connections, 2); // Total stays
-    assert_eq!(snapshot.active_connections, 1); // Active decrements
+    assert_eq!(snapshot.total_connections.get(), 2); // Total stays
+    assert_eq!(snapshot.active_connections.get(), 1); // Active decrements
 
     // Close another
     collector.connection_closed();
     let snapshot = collector.snapshot(None);
-    assert_eq!(snapshot.total_connections, 2);
-    assert_eq!(snapshot.active_connections, 0);
+    assert_eq!(snapshot.total_connections.get(), 2);
+    assert_eq!(snapshot.active_connections.get(), 0);
 }
 
 /// Test stateful session tracking

--- a/tests/proxy/metrics/collector.rs
+++ b/tests/proxy/metrics/collector.rs
@@ -4,7 +4,7 @@
 
 use nntp_proxy::cache::MAX_BACKENDS;
 use nntp_proxy::constants::user::ANONYMOUS;
-use nntp_proxy::metrics::{BackendHealthStatus, MetricsCollector};
+use nntp_proxy::metrics::{BackendHealthStatus, MetricsCollector, StatefulSessions};
 use nntp_proxy::types::{BackendId, MetricsBytes, Unrecorded};
 
 /// Test `MetricsCollector` creation
@@ -58,27 +58,27 @@ fn test_stateful_session_tracking() {
     let collector = MetricsCollector::new(1);
 
     let snapshot = collector.snapshot(None);
-    assert_eq!(snapshot.stateful_sessions, 0);
+    assert_eq!(snapshot.stateful_sessions, StatefulSessions::ZERO);
 
     // Start session
     collector.stateful_session_started();
     let snapshot = collector.snapshot(None);
-    assert_eq!(snapshot.stateful_sessions, 1);
+    assert_eq!(snapshot.stateful_sessions, StatefulSessions::new(1));
 
     // Start another
     collector.stateful_session_started();
     let snapshot = collector.snapshot(None);
-    assert_eq!(snapshot.stateful_sessions, 2);
+    assert_eq!(snapshot.stateful_sessions, StatefulSessions::new(2));
 
     // End one
     collector.stateful_session_ended();
     let snapshot = collector.snapshot(None);
-    assert_eq!(snapshot.stateful_sessions, 1);
+    assert_eq!(snapshot.stateful_sessions, StatefulSessions::new(1));
 
     // End another
     collector.stateful_session_ended();
     let snapshot = collector.snapshot(None);
-    assert_eq!(snapshot.stateful_sessions, 0);
+    assert_eq!(snapshot.stateful_sessions, StatefulSessions::ZERO);
 }
 
 /// Test command recording for backends

--- a/tests/test_metrics.rs
+++ b/tests/test_metrics.rs
@@ -98,7 +98,7 @@ fn test_metrics_snapshot_total_bytes() {
     let snapshot = MetricsSnapshot {
         total_connections: TotalConnections::new(10),
         active_connections: ActiveConnections::new(5),
-        stateful_sessions: 2,
+        stateful_sessions: StatefulSessions::new(2),
         client_to_backend_bytes: ClientToBackendBytes::new(1000),
         backend_to_client_bytes: BackendToClientBytes::new(5000),
         uptime: std::time::Duration::from_secs(60),
@@ -113,7 +113,7 @@ fn test_metrics_snapshot_throughput() {
     let snapshot = MetricsSnapshot {
         total_connections: TotalConnections::new(10),
         active_connections: ActiveConnections::new(5),
-        stateful_sessions: 2,
+        stateful_sessions: StatefulSessions::new(2),
         client_to_backend_bytes: ClientToBackendBytes::new(2000),
         backend_to_client_bytes: BackendToClientBytes::new(8000),
         uptime: Duration::from_secs(10),
@@ -235,7 +235,7 @@ fn test_metrics_snapshot_with_multiple_backends() {
     let snapshot = MetricsSnapshot {
         total_connections: TotalConnections::new(20),
         active_connections: ActiveConnections::new(10),
-        stateful_sessions: 5,
+        stateful_sessions: StatefulSessions::new(5),
         client_to_backend_bytes: ClientToBackendBytes::new(1500),
         backend_to_client_bytes: BackendToClientBytes::new(15000),
         uptime: Duration::from_secs(100),

--- a/tests/test_metrics.rs
+++ b/tests/test_metrics.rs
@@ -96,8 +96,8 @@ fn test_backend_stats_error_rate() {
 #[test]
 fn test_metrics_snapshot_total_bytes() {
     let snapshot = MetricsSnapshot {
-        total_connections: 10,
-        active_connections: 5,
+        total_connections: TotalConnections::new(10),
+        active_connections: ActiveConnections::new(5),
         stateful_sessions: 2,
         client_to_backend_bytes: ClientToBackendBytes::new(1000),
         backend_to_client_bytes: BackendToClientBytes::new(5000),
@@ -111,8 +111,8 @@ fn test_metrics_snapshot_total_bytes() {
 #[test]
 fn test_metrics_snapshot_throughput() {
     let snapshot = MetricsSnapshot {
-        total_connections: 10,
-        active_connections: 5,
+        total_connections: TotalConnections::new(10),
+        active_connections: ActiveConnections::new(5),
         stateful_sessions: 2,
         client_to_backend_bytes: ClientToBackendBytes::new(2000),
         backend_to_client_bytes: BackendToClientBytes::new(8000),
@@ -233,8 +233,8 @@ fn test_metrics_snapshot_with_multiple_backends() {
     };
 
     let snapshot = MetricsSnapshot {
-        total_connections: 20,
-        active_connections: 10,
+        total_connections: TotalConnections::new(20),
+        active_connections: ActiveConnections::new(10),
         stateful_sessions: 5,
         client_to_backend_bytes: ClientToBackendBytes::new(1500),
         backend_to_client_bytes: BackendToClientBytes::new(15000),


### PR DESCRIPTION
This branch tightens the session/user-count pipeline and cleans up the TUI hot path.

- Fixes user connection counts so they stay tied to the session-owned active connection state instead of drifting or disappearing.
- Pushes the relevant counts through typed newtypes in metrics snapshots, dashboard conversions, and TUI rendering so misuse becomes a compile-time error instead of a runtime bug.
- Keeps unauthenticated users visible while they are still unauthenticated.
- Reduces TUI render allocations by writing directly into the buffer, borrowing chart data names, and using stack-backed formatting where possible.
- Updates the tests and metrics fixtures to match the typed-count model.

Validation:
- nix develop -c cargo fmt --check
- nix develop -c cargo check
- nix develop -c cargo nextest run
- nix develop -c cargo clippy