### PR TITLE
Harden advisory and script maintenance tooling

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -126,7 +126,9 @@ jobs:
         with:
           tool: shellcheck,typos
       - name: Run shellcheck
-        run: shellcheck -S warning scripts/*.sh
+        run: |
+          mapfile -t shell_scripts < <(find scripts -maxdepth 1 -type f \( -name '*.sh' -o -perm -111 \) | sort)
+          shellcheck -S warning "${shell_scripts[@]}"
       - name: Run typos
         run: typos
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,7 +2193,6 @@ dependencies = [
  "rustix",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2997,15 +2996,6 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,6 @@ derive_more = { version = "2.1", features = ["deref", "deref_mut", "display", "f
 tokio-rustls = { version = "0.26", features = ["early-data", "ring"], default-features = false }  # TLS with ring only
 rustls = { version = "0.23", features = ["ring", "std"], default-features = false }  # Pure Rust TLS with ring only
 rustls-native-certs = "0.8"  # Load system CA certificates
-rustls-pemfile = "2.2"  # PEM file parsing for custom certificates
 rustls-pki-types = "1.14"  # PKI types for rustls
 webpki-roots = "1.0.7"  # Mozilla CA certificate bundle fallback
 crc32fast = "1.5.0"

--- a/audit.toml
+++ b/audit.toml
@@ -1,11 +1,15 @@
 [advisories]
 ignore = [
-  # Transitive through foyer/iai-callgrind; no safe upgrade is available yet.
+  # Runtime via foyer 0.22.3 and dev-only via iai-callgrind 0.16.1.
+  # Keep iai-callgrind for deterministic perf benches. Revisit by 2026-09-15
+  # or on foyer/iai-callgrind upgrade. Upstream: https://github.com/foyer-rs/foyer
+  # and https://github.com/iai-callgrind/iai-callgrind.
   "RUSTSEC-2025-0141",
-  # Transitive through foyer; no safe upgrade is available yet.
+  # Runtime via foyer 0.22.3. Revisit by 2026-09-15 or on foyer upgrade.
+  # Upstream: https://github.com/foyer-rs/foyer.
   "RUSTSEC-2024-0436",
-  # Transitive through iai-callgrind dev-dependency; no safe upgrade is available yet.
+  # Dev-only via iai-callgrind 0.16.1 macro support.
+  # Keep iai-callgrind for deterministic perf benches. Revisit by 2026-09-15
+  # or on iai-callgrind upgrade. Upstream: https://github.com/iai-callgrind/iai-callgrind.
   "RUSTSEC-2026-0173",
-  # Direct dependency retained until the PEM loading path migrates to rustls-pki-types::PemObject.
-  "RUSTSEC-2025-0134",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -11,14 +11,18 @@ all-features = true
 version = 2
 yanked = "deny"
 ignore = [
-  # Transitive through foyer/iai-callgrind; no safe upgrade is available yet.
+  # Runtime via foyer 0.22.3 and dev-only via iai-callgrind 0.16.1.
+  # Keep iai-callgrind for deterministic perf benches. Revisit by 2026-09-15
+  # or on foyer/iai-callgrind upgrade. Upstream: https://github.com/foyer-rs/foyer
+  # and https://github.com/iai-callgrind/iai-callgrind.
   "RUSTSEC-2025-0141",
-  # Transitive through foyer; no safe upgrade is available yet.
+  # Runtime via foyer 0.22.3. Revisit by 2026-09-15 or on foyer upgrade.
+  # Upstream: https://github.com/foyer-rs/foyer.
   "RUSTSEC-2024-0436",
-  # Transitive through iai-callgrind dev-dependency; no safe upgrade is available yet.
+  # Dev-only via iai-callgrind 0.16.1 macro support.
+  # Keep iai-callgrind for deterministic perf benches. Revisit by 2026-09-15
+  # or on iai-callgrind upgrade. Upstream: https://github.com/iai-callgrind/iai-callgrind.
   "RUSTSEC-2026-0173",
-  # Direct dependency retained until the PEM loading path migrates to rustls-pki-types::PemObject.
-  "RUSTSEC-2025-0134",
 ]
 
 [licenses]

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,6 +18,15 @@ cargo nextest run
 
 Use `cargo test` when you need doctests, exact filtering, or `-- --nocapture` debugging output.
 
+Dependency and advisory triage:
+
+```bash
+scripts/audit-advisories
+```
+
+See [security-advisories.md](security-advisories.md) for ignore policy and
+revisit expectations.
+
 ## Pre-commit hook
 
 The pre-commit hook runs `cargo fmt --check` and `cargo clippy --all-features -- -D warnings`. Install it with:

--- a/docs/security-advisories.md
+++ b/docs/security-advisories.md
@@ -1,0 +1,37 @@
+# Security Advisories
+
+This project treats both advisory tools as authoritative:
+
+```sh
+nix develop -c cargo audit
+nix develop -c cargo deny check advisories
+```
+
+Ignored advisories must document:
+
+- whether the dependency path is direct, runtime transitive, or dev-only
+- why the dependency is being kept
+- the next revisit trigger, such as an upstream release or review date
+- an upstream issue or repository link when one exists
+
+Use `scripts/audit-advisories` when triaging advisory changes. It runs the
+standard advisory checks and prints dependency paths for the currently ignored
+crates, including runtime-only paths where Cargo can express them.
+
+Dev-only performance tooling may be retained when the warning is limited to
+benchmark dependencies and the reason is documented. `iai-callgrind` is in that
+category: it gives deterministic instruction-count benchmarks for hot paths, so
+the current unmaintained transitive crates are tracked rather than removing the
+tool. Revisit those ignores when `iai-callgrind` releases a version that drops
+`bincode 1` or `proc-macro-error2`.
+
+For dependency maintenance, run the advisory checks during normal PR validation
+and periodically run:
+
+```sh
+nix develop -c cargo outdated
+nix develop -c scripts/audit-advisories
+```
+
+When `foyer` or `iai-callgrind` publishes a new version, try the upgrade and
+remove any advisory ignores that disappear.

--- a/scripts/audit-advisories
+++ b/scripts/audit-advisories
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Summarize current RustSec advisory state and the dependency paths behind
+# intentionally ignored advisories.
+
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+run() {
+    echo
+    echo "==> $*"
+    "$@"
+}
+
+require_cargo_subcommand() {
+    local subcommand="$1"
+    if ! cargo "$subcommand" --version >/dev/null 2>&1; then
+        echo "cargo-$subcommand is not available; run through nix develop." >&2
+        exit 127
+    fi
+}
+
+tree_for() {
+    local crate="$1"
+
+    echo
+    echo "==> full dependency paths for $crate"
+    cargo tree --target=all -i "$crate" || true
+
+    echo
+    echo "==> runtime/build dependency paths for $crate"
+    cargo tree --edges normal,build -i "$crate" || true
+}
+
+require_cargo_subcommand audit
+require_cargo_subcommand deny
+
+run cargo audit
+run cargo deny check advisories
+
+tree_for bincode
+tree_for paste
+tree_for proc-macro-error2
+
+echo
+echo "Upstream projects to watch:"
+echo "- foyer: https://github.com/foyer-rs/foyer"
+echo "- iai-callgrind: https://github.com/iai-callgrind/iai-callgrind"

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # ============================================================================
 
 # Check for jq if version argument is not provided
-if [ -z "$1" ]; then
+if [ -z "${1:-}" ]; then
     if ! command -v jq &> /dev/null; then
         echo "Error: jq is required but not installed. Please install jq to continue." >&2
         exit 1

--- a/scripts/parse_flamegraph
+++ b/scripts/parse_flamegraph
@@ -8,6 +8,7 @@ SOURCE="$SCRIPT_DIR/parse_flamegraph.rs"
 # Rebuild if source is newer than binary or binary doesn't exist
 if [ ! -f "$BINARY" ] || [ "$SOURCE" -nt "$BINARY" ]; then
     echo "Compiling parse_flamegraph..." >&2
+    mkdir -p "$(dirname "$BINARY")"
     rustc -O -o "$BINARY" "$SOURCE"
 fi
 

--- a/scripts/parse_flamegraph.rs
+++ b/scripts/parse_flamegraph.rs
@@ -445,9 +445,12 @@ fn categorize(name: &str) -> &'static str {
 }
 
 fn truncate_name(name: &str, max_len: usize) -> String {
-    if name.len() <= max_len {
+    if name.chars().count() <= max_len {
         name.to_string()
+    } else if max_len <= 3 {
+        ".".repeat(max_len)
     } else {
-        format!("{}...", &name[..max_len - 3])
+        let prefix: String = name.chars().take(max_len - 3).collect();
+        format!("{prefix}...")
     }
 }

--- a/scripts/parse_perfdata
+++ b/scripts/parse_perfdata
@@ -8,6 +8,7 @@ SOURCE="$SCRIPT_DIR/parse_perfdata.rs"
 # Rebuild if source is newer than binary or binary doesn't exist
 if [ ! -f "$BINARY" ] || [ "$SOURCE" -nt "$BINARY" ]; then
     echo "Compiling parse_perfdata..." >&2
+    mkdir -p "$(dirname "$BINARY")"
     rustc -O -o "$BINARY" "$SOURCE"
 fi
 

--- a/scripts/parse_perfdata.rs
+++ b/scripts/parse_perfdata.rs
@@ -870,10 +870,13 @@ fn categorize(func: &str) -> &'static str {
 }
 
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
+    if s.chars().count() <= max {
         s.to_string()
+    } else if max <= 3 {
+        ".".repeat(max)
     } else {
-        format!("{}...", &s[..max.saturating_sub(3)])
+        let prefix: String = s.chars().take(max - 3).collect();
+        format!("{prefix}...")
     }
 }
 

--- a/scripts/profile-latency.sh
+++ b/scripts/profile-latency.sh
@@ -29,6 +29,17 @@ if [ $# -gt 0 ]; then
 fi
 
 EXTRA_ARGS=("$@")
+APP_PID=""
+
+cleanup_profile_app() {
+    if [ -n "${APP_PID:-}" ] && kill -0 "$APP_PID" 2>/dev/null; then
+        kill "$APP_PID" 2>/dev/null || true
+        wait "$APP_PID" 2>/dev/null || true
+    fi
+}
+
+trap cleanup_profile_app EXIT
+trap 'cleanup_profile_app; exit 130' INT TERM
 
 if [ "$MODE" = "-h" ] || [ "$MODE" = "--help" ]; then
     echo "Usage: $0 [MODE] [TARGET] [ARGS...]"
@@ -151,16 +162,18 @@ case "$MODE" in
         "$BINARY" "${EXTRA_ARGS[@]}" &
         APP_PID=$!
         sleep 0.5
-        perf sched record -p $APP_PID -o perf-offcpu.data
-        wait $APP_PID || true
+        perf sched record -p "$APP_PID" -o perf-offcpu.data
+        wait "$APP_PID" || true
+        APP_PID=""
         ;;
 
       perf-cpu)
         "$BINARY" "${EXTRA_ARGS[@]}" &
         APP_PID=$!
         sleep 0.5
-        perf record -p $APP_PID -e cpu-clock -g --call-graph fp -F 997 -o perf-offcpu.data
-        wait $APP_PID || true
+        perf record -p "$APP_PID" -e cpu-clock -g --call-graph fp -F 997 -o perf-offcpu.data
+        wait "$APP_PID" || true
+        APP_PID=""
         ;;
     esac
     set -e

--- a/scripts/quality-deep.sh
+++ b/scripts/quality-deep.sh
@@ -33,8 +33,7 @@ features() {
 }
 
 deps() {
-    run cargo deny check
-    run cargo audit
+    run scripts/audit-advisories
     run cargo shear
     if [ -d supply-chain ]; then
         run cargo vet

--- a/scripts/quality-fast.sh
+++ b/scripts/quality-fast.sh
@@ -12,9 +12,11 @@ run() {
     "$@"
 }
 
+mapfile -t shell_scripts < <(find scripts -maxdepth 1 -type f \( -name '*.sh' -o -perm -111 \) | sort)
+
 run cargo fmt --check
 run cargo clippy --all-targets --all-features -- -D warnings
-run shellcheck -S warning scripts/*.sh
+run shellcheck -S warning "${shell_scripts[@]}"
 run scripts/check-guardrails.sh
 run actionlint
 run zizmor .github/workflows

--- a/src/tls.rs
+++ b/src/tls.rs
@@ -9,6 +9,7 @@
 
 use crate::connection_error::ConnectionError;
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
 use rustls::{
     ClientConfig, DigitallySignedStruct, Error as RustlsError, RootCertStore, SignatureScheme,
@@ -369,7 +370,7 @@ impl TlsManager {
         let cert_data = std::fs::read(cert_path)
             .with_context(|| format!("Failed to read TLS certificate from {cert_path}"))?;
 
-        let certs = rustls_pemfile::certs(&mut cert_data.as_slice())
+        let certs = CertificateDer::pem_slice_iter(&cert_data)
             .collect::<Result<Vec<_>, _>>()
             .context("Failed to parse TLS certificate")?;
 


### PR DESCRIPTION
## Summary

- Replace the direct `rustls-pemfile` custom CA parser with `rustls-pki-types::pem::PemObject` and remove the resolved `RUSTSEC-2025-0134` ignore.
- Document remaining RustSec ignores with runtime/dev-only scope, revisit dates, upstream repositories, and the explicit `iai-callgrind` retention rationale.
- Add `docs/security-advisories.md` and `scripts/audit-advisories`, then wire `scripts/quality-deep.sh deps` through the helper.
- Fix release script no-argument handling under `set -u`.
- Make standalone parser wrappers create their `target/release` output directory on fresh checkouts.
- Add cleanup for the app process launched by `scripts/profile-latency.sh offcpu`.
- Expand shellcheck coverage to executable extensionless scripts in both local fast checks and CI.
- Make profiling parser output truncation character-safe for non-ASCII symbol names.

## Why

`RUSTSEC-2025-0134` was actionable locally because `rustls-pemfile` was only used in one PEM certificate loading path. The remaining advisories are upstream-bound: `foyer 0.22.3` currently pulls `bincode`/`paste`, and `iai-callgrind 0.16.1` currently pulls `bincode` plus `proc-macro-error2` through its macro crate.

While reviewing that maintenance surface, several adjacent script issues showed up: a documented release invocation failed before version detection, extensionless helper scripts were outside shellcheck coverage, profiling helpers could fail on fresh checkouts or leak child processes, and standalone parser truncation could panic on non-ASCII names. This branch fixes those as separate commits.

We are intentionally keeping `iai-callgrind` because it is dev-only performance tooling that provides deterministic instruction-count benchmarks for hot paths. The new comments and docs make that tradeoff explicit and give future cleanup a date and upstream-release trigger.

## Validation

- `nix develop -c cargo check`
- `nix develop -c cargo audit` now reports 3 allowed warnings, with `RUSTSEC-2025-0134` gone
- `nix develop -c cargo deny check advisories`
- `nix develop -c scripts/audit-advisories`
- `nix develop -c scripts/quality-deep.sh deps`
- `nix develop -c scripts/quality-fast.sh`
- `nix develop -c cargo fmt --check`
- `nix develop -c cargo nextest run` (`2230 passed, 1 skipped`)
- targeted repros for `build-release.sh`, parser wrapper fresh-checkout compilation, and Unicode `parse_flamegraph diff` truncation
- standalone `rustc -D warnings` for `scripts/parse_flamegraph.rs` and `scripts/parse_perfdata.rs`
- pre-commit hook: `cargo fmt`, `cargo clippy`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added security advisory auditing script and documentation for dependency vulnerability management.

* **Bug Fixes**
  * Fixed Unicode character handling in performance profiling tools.
  * Improved shell script discovery and process cleanup in build utilities.

* **Documentation**
  * Added comprehensive security advisory policy and auditing guidelines.

* **Chores**
  * Removed rustls-pemfile dependency.
  * Updated security advisory ignore list with revisit guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->