### PR TITLE
Fix TUI dashboard count normalization

### DIFF
--- a/src/proxy/lifecycle.rs
+++ b/src/proxy/lifecycle.rs
@@ -81,11 +81,8 @@ impl NntpProxy {
 
         let last_activity_nanos = self.last_activity_nanos.load(Ordering::Relaxed);
 
-        // If never been active, no need to clear
-        if last_activity_nanos == 0 {
-            return false;
-        }
-
+        // Before the first client connects, prewarmed backend pools still age
+        // from process start and must be eligible for idle cleanup.
         let last_activity = Duration::from_nanos(last_activity_nanos);
         let now = self.start_instant.elapsed();
         let idle_duration = now.saturating_sub(last_activity);
@@ -452,6 +449,49 @@ mod tests {
     use crate::config::RoutingMode;
     use crate::session::SessionMode;
     use std::sync::Arc;
+    use std::time::Duration;
+
+    async fn spawn_mock_backend() -> std::net::SocketAddr {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        tokio::spawn(async move {
+            while let Ok((mut stream, _)) = listener.accept().await {
+                tokio::spawn(async move {
+                    if stream
+                        .write_all(b"200 Mock Backend Ready\r\n")
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+
+                    let mut buffer = [0u8; 1024];
+                    loop {
+                        let n = match stream.read(&mut buffer).await {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => n,
+                        };
+
+                        let cmd = String::from_utf8_lossy(&buffer[..n]).to_uppercase();
+                        if cmd.starts_with("DATE") {
+                            let _ = stream.write_all(b"111 20260101000000\r\n").await;
+                        } else if cmd.starts_with("QUIT") {
+                            let _ = stream.write_all(b"205 Goodbye\r\n").await;
+                            break;
+                        } else {
+                            let _ = stream.write_all(b"200 OK\r\n").await;
+                        }
+                    }
+                });
+            }
+        });
+
+        addr
+    }
 
     fn create_test_config() -> crate::config::Config {
         super::super::tests::create_test_config()
@@ -920,6 +960,34 @@ mod tests {
         // No prior activity (last_activity_nanos = 0)
         let cleared = proxy.check_and_clear_stale_pools();
         assert!(!cleared);
+    }
+
+    #[tokio::test]
+    async fn test_check_and_clear_clears_prewarmed_pools_without_client_activity() {
+        use crate::config::{Config, Server};
+        use crate::types::{MaxConnections, Port};
+
+        let backend_addr = spawn_mock_backend().await;
+        let config = Config {
+            servers: vec![
+                Server::builder("127.0.0.1", Port::try_new(backend_addr.port()).unwrap())
+                    .name("Prewarmed Backend")
+                    .max_connections(MaxConnections::try_new(1).unwrap())
+                    .backend_idle_timeout(Duration::from_nanos(1))
+                    .build()
+                    .unwrap(),
+            ],
+            ..Default::default()
+        };
+        let proxy = NntpProxy::new_sync(config, RoutingMode::Stateful).unwrap();
+
+        proxy.prewarm_connections().await.unwrap();
+        tokio::time::sleep(Duration::from_millis(1)).await;
+
+        assert!(
+            proxy.check_and_clear_stale_pools(),
+            "prewarmed idle backend pools should clear even before any client ever connects"
+        );
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1649,6 +1649,34 @@ mod tests {
     }
 
     #[test]
+    fn test_snapshot_state_does_not_publish_disk_hit_rate_above_one_hundred_percent() {
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            disk_cache: Some(crate::metrics::DiskCacheStats {
+                disk_hit_rate: 125.0,
+                ..crate::metrics::DiskCacheStats::default()
+            }),
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+        let disk = snapshot
+            .metrics
+            .disk_cache
+            .expect("disk cache stats should be published");
+
+        assert!(
+            disk.disk_hit_rate <= 100.0,
+            "dashboard must not publish a disk hit rate above 100%, got {:.1}%",
+            disk.disk_hit_rate
+        );
+    }
+
+    #[test]
     fn test_snapshot_state_does_not_publish_user_active_connections_above_global_active() {
         use crate::metrics::{CommandCount, ErrorCount};
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -759,20 +759,17 @@ impl TuiApp {
         history_limit: Option<usize>,
     ) -> DashboardState {
         let buffer_pool = self.buffer_pool.as_ref().map(Self::snapshot_buffer_pool);
-        DashboardState {
-            metrics: self.snapshot_metrics(),
-            backend_views: self.snapshot_backend_views(history_limit),
-            top_users: self.snapshot_top_users(),
-            client_history: Self::snapshot_history_points(
-                self.client_history.points(),
-                history_limit,
-            ),
-            system_stats: self.system_stats.clone(),
-            view_mode: self.view_mode,
-            show_details: self.show_details,
-            log_lines: self.snapshot_log_lines(log_limit),
+        DashboardState::new(
+            self.snapshot_metrics(),
+            self.snapshot_backend_views(history_limit),
+            self.snapshot_top_users(),
+            Self::snapshot_history_points(self.client_history.points(), history_limit),
+            self.system_stats.clone(),
+            self.view_mode,
+            self.show_details,
+            self.snapshot_log_lines(log_limit),
             buffer_pool,
-        }
+        )
     }
 
     /// Build a serializable attached-dashboard snapshot with only remote-render fields.
@@ -783,14 +780,14 @@ impl TuiApp {
         history_limit: Option<usize>,
         top_user_limit: Option<usize>,
     ) -> RemoteDashboardState {
-        RemoteDashboardState {
-            metrics: self.snapshot_metrics(),
-            backend_views: self.snapshot_remote_backend_views(history_limit),
-            top_users: self.snapshot_top_users_with_limit(top_user_limit),
-            latest_client_throughput: self.client_history.latest().cloned(),
-            system_stats: self.system_stats.clone(),
-            log_lines: self.snapshot_log_lines(log_limit),
-        }
+        RemoteDashboardState::new(
+            self.snapshot_metrics(),
+            self.snapshot_remote_backend_views(history_limit),
+            self.snapshot_top_users_with_limit(top_user_limit),
+            self.client_history.latest().cloned(),
+            self.system_stats.clone(),
+            self.snapshot_log_lines(log_limit),
+        )
     }
 
     fn snapshot_log_lines(&self, log_limit: Option<usize>) -> Vec<String> {
@@ -932,11 +929,6 @@ impl TuiApp {
             .iter()
             .map(DashboardUserStats::from)
             .collect::<Vec<_>>();
-        if self.snapshot.active_connections.is_zero() {
-            top_users.iter_mut().for_each(|user| {
-                user.active_connections = crate::metrics::UserActiveConnections::ZERO;
-            });
-        }
         top_users.sort_by_key(|user| std::cmp::Reverse(user.total_bytes()));
         if let Some(limit) = top_user_limit {
             top_users.truncate(limit);
@@ -1585,6 +1577,223 @@ mod tests {
             nzbget.active_connections,
             crate::metrics::UserActiveConnections::ZERO,
             "dashboard must not publish stale per-user active connections when global active connections is zero"
+        );
+    }
+
+    #[test]
+    fn test_snapshot_state_does_not_publish_user_active_connections_above_global_active() {
+        use crate::metrics::{CommandCount, ErrorCount};
+
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            active_connections: crate::metrics::ActiveConnections::new(2),
+            user_stats: vec![
+                crate::metrics::UserStats {
+                    username: "nzbget".to_string(),
+                    active_connections: crate::metrics::UserActiveConnections::new(5),
+                    total_connections: crate::types::TotalConnections::new(5),
+                    bytes_sent: crate::types::BytesSent::new(10_000),
+                    bytes_received: crate::types::BytesReceived::new(20_000),
+                    bytes_sent_per_sec: crate::types::BytesPerSecondRate::ZERO,
+                    bytes_received_per_sec: crate::types::BytesPerSecondRate::ZERO,
+                    total_commands: CommandCount::new(10),
+                    errors: ErrorCount::ZERO,
+                },
+                crate::metrics::UserStats {
+                    username: "sabnzbd".to_string(),
+                    active_connections: crate::metrics::UserActiveConnections::new(1),
+                    total_connections: crate::types::TotalConnections::new(1),
+                    bytes_sent: crate::types::BytesSent::new(2_000),
+                    bytes_received: crate::types::BytesReceived::new(4_000),
+                    bytes_sent_per_sec: crate::types::BytesPerSecondRate::ZERO,
+                    bytes_received_per_sec: crate::types::BytesPerSecondRate::ZERO,
+                    total_commands: CommandCount::new(2),
+                    errors: ErrorCount::ZERO,
+                },
+            ],
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+        let displayed_user_active = snapshot
+            .top_users
+            .iter()
+            .map(|user| user.active_connections.get())
+            .sum::<usize>();
+
+        assert!(
+            displayed_user_active <= snapshot.metrics.active_connections.get(),
+            "dashboard must not publish {displayed_user_active} displayed user-active connections when only {} global connections are active",
+            snapshot.metrics.active_connections.get()
+        );
+    }
+
+    #[test]
+    fn test_remote_snapshot_does_not_publish_user_active_connections_above_global_active() {
+        use crate::metrics::{CommandCount, ErrorCount};
+
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            active_connections: crate::metrics::ActiveConnections::new(1),
+            user_stats: vec![crate::metrics::UserStats {
+                username: "nzbget".to_string(),
+                active_connections: crate::metrics::UserActiveConnections::new(5),
+                total_connections: crate::types::TotalConnections::new(5),
+                bytes_sent: crate::types::BytesSent::new(10_000),
+                bytes_received: crate::types::BytesReceived::new(20_000),
+                bytes_sent_per_sec: crate::types::BytesPerSecondRate::ZERO,
+                bytes_received_per_sec: crate::types::BytesPerSecondRate::ZERO,
+                total_commands: CommandCount::new(10),
+                errors: ErrorCount::ZERO,
+            }],
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_remote_state_with_limits(None, None, Some(5));
+        let displayed_user_active = snapshot
+            .top_users
+            .iter()
+            .map(|user| user.active_connections.get())
+            .sum::<usize>();
+
+        assert!(
+            displayed_user_active <= snapshot.metrics.active_connections.get(),
+            "remote dashboard must not publish {displayed_user_active} displayed user-active connections when only {} global connections are active",
+            snapshot.metrics.active_connections.get()
+        );
+    }
+
+    #[test]
+    fn test_snapshot_state_does_not_publish_user_active_connections_above_user_total_connections() {
+        use crate::metrics::{CommandCount, ErrorCount};
+
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            active_connections: crate::metrics::ActiveConnections::new(5),
+            user_stats: vec![crate::metrics::UserStats {
+                username: "nzbget".to_string(),
+                active_connections: crate::metrics::UserActiveConnections::new(5),
+                total_connections: crate::types::TotalConnections::new(1),
+                bytes_sent: crate::types::BytesSent::new(10_000),
+                bytes_received: crate::types::BytesReceived::new(20_000),
+                bytes_sent_per_sec: crate::types::BytesPerSecondRate::ZERO,
+                bytes_received_per_sec: crate::types::BytesPerSecondRate::ZERO,
+                total_commands: CommandCount::new(10),
+                errors: ErrorCount::ZERO,
+            }],
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+        let nzbget = snapshot
+            .top_users
+            .iter()
+            .find(|user| user.username == "nzbget")
+            .expect("nzbget row should still be present for historical traffic");
+
+        assert!(
+            nzbget.active_connections.get() as u64 <= nzbget.total_connections.get(),
+            "dashboard must not publish {} active connections for a user with only {} total connections",
+            nzbget.active_connections.get(),
+            nzbget.total_connections.get()
+        );
+    }
+
+    #[test]
+    fn test_snapshot_state_does_not_publish_active_connections_above_total_connections() {
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            total_connections: crate::types::TotalConnections::new(1),
+            active_connections: crate::metrics::ActiveConnections::new(5),
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+        let active_connections = snapshot.metrics.active_connections.get() as u64;
+
+        assert!(
+            active_connections <= snapshot.metrics.total_connections.get(),
+            "dashboard must not publish {} active connections when only {} total connections have ever opened",
+            snapshot.metrics.active_connections.get(),
+            snapshot.metrics.total_connections.get()
+        );
+    }
+
+    #[test]
+    fn test_snapshot_state_does_not_publish_backend_active_connections_above_global_active() {
+        let metrics = MetricsCollector::new(2);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(2);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            active_connections: crate::metrics::ActiveConnections::new(1),
+            backend_stats: vec![
+                crate::metrics::BackendStats {
+                    backend_id: crate::types::BackendId::from_index(0),
+                    active_connections: crate::metrics::ActiveConnections::new(3),
+                    ..crate::metrics::BackendStats::default()
+                },
+                crate::metrics::BackendStats {
+                    backend_id: crate::types::BackendId::from_index(1),
+                    active_connections: crate::metrics::ActiveConnections::new(2),
+                    ..crate::metrics::BackendStats::default()
+                },
+            ]
+            .into(),
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+        let displayed_backend_active = snapshot
+            .backend_views
+            .iter()
+            .map(|backend| backend.active_connections.get())
+            .sum::<usize>();
+
+        assert!(
+            displayed_backend_active <= snapshot.metrics.active_connections.get(),
+            "dashboard must not publish {displayed_backend_active} displayed backend-active connections when only {} global connections are active",
+            snapshot.metrics.active_connections.get()
+        );
+    }
+
+    #[test]
+    fn test_snapshot_state_does_not_publish_stateful_sessions_above_active_connections() {
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            active_connections: crate::metrics::ActiveConnections::new(1),
+            stateful_sessions: crate::metrics::StatefulSessions::new(3),
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+
+        assert!(
+            snapshot.metrics.stateful_sessions.get() <= snapshot.metrics.active_connections.get(),
+            "dashboard must not publish {} stateful sessions when only {} connections are active",
+            snapshot.metrics.stateful_sessions.get(),
+            snapshot.metrics.active_connections.get()
         );
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1628,6 +1628,27 @@ mod tests {
     }
 
     #[test]
+    fn test_snapshot_state_does_not_publish_cache_hit_rate_above_one_hundred_percent() {
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            cache_hit_rate: 125.0,
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+
+        assert!(
+            snapshot.metrics.cache_hit_rate <= 100.0,
+            "dashboard must not publish a cache hit rate above 100%, got {:.1}%",
+            snapshot.metrics.cache_hit_rate
+        );
+    }
+
+    #[test]
     fn test_snapshot_state_does_not_publish_user_active_connections_above_global_active() {
         use crate::metrics::{CommandCount, ErrorCount};
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1677,7 +1677,7 @@ mod tests {
     }
 
     #[test]
-    fn test_snapshot_state_does_not_publish_backend_errors_above_total_commands() {
+    fn test_snapshot_state_preserves_backend_errors_not_tied_to_commands() {
         let metrics = MetricsCollector::new(1);
         let router = Arc::new(BackendSelector::new());
         let servers = create_test_servers(1);
@@ -1697,11 +1697,10 @@ mod tests {
         let snapshot = app.snapshot_state();
         let backend = &snapshot.backend_views[0].stats;
 
-        assert!(
-            backend.errors.get() <= backend.total_commands.get(),
-            "dashboard must not publish {} backend errors when only {} commands ran",
+        assert_eq!(
             backend.errors.get(),
-            backend.total_commands.get()
+            5,
+            "dashboard must preserve backend/session errors even when they happen before commands are recorded"
         );
     }
 
@@ -1926,7 +1925,7 @@ mod tests {
     }
 
     #[test]
-    fn test_snapshot_state_does_not_publish_backend_active_connections_above_global_active() {
+    fn test_snapshot_state_preserves_backend_active_connections_above_global_active() {
         let metrics = MetricsCollector::new(2);
         let router = Arc::new(BackendSelector::new());
         let servers = create_test_servers(2);
@@ -1957,10 +1956,9 @@ mod tests {
             .map(|backend| backend.active_connections.get())
             .sum::<usize>();
 
-        assert!(
-            displayed_backend_active <= snapshot.metrics.active_connections.get(),
-            "dashboard must not publish {displayed_backend_active} displayed backend-active connections when only {} global connections are active",
-            snapshot.metrics.active_connections.get()
+        assert_eq!(
+            displayed_backend_active, 5,
+            "dashboard must preserve backend pool activity because backend checkouts are not capped by client connections"
         );
     }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1581,6 +1581,30 @@ mod tests {
     }
 
     #[test]
+    fn test_snapshot_state_does_not_publish_more_completed_pipeline_requests_than_queued() {
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            pipeline_requests_queued: crate::metrics::PipelineRequestsQueued::new(1),
+            pipeline_requests_completed: crate::metrics::PipelineRequestsCompleted::new(5),
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+
+        assert!(
+            snapshot.metrics.pipeline_requests_completed.get()
+                <= snapshot.metrics.pipeline_requests_queued.get(),
+            "dashboard must not publish {} completed pipeline requests when only {} were queued",
+            snapshot.metrics.pipeline_requests_completed.get(),
+            snapshot.metrics.pipeline_requests_queued.get()
+        );
+    }
+
+    #[test]
     fn test_snapshot_state_does_not_publish_user_active_connections_above_global_active() {
         use crate::metrics::{CommandCount, ErrorCount};
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1739,6 +1739,38 @@ mod tests {
     }
 
     #[test]
+    fn test_snapshot_state_does_not_publish_user_errors_above_total_commands() {
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            user_stats: vec![crate::metrics::UserStats {
+                username: "nzbget".to_string(),
+                total_commands: crate::metrics::CommandCount::new(1),
+                errors: crate::metrics::ErrorCount::new(5),
+                ..crate::metrics::UserStats::default()
+            }],
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+        let user = snapshot
+            .top_users
+            .iter()
+            .find(|user| user.username == "nzbget")
+            .expect("user row should be published");
+
+        assert!(
+            user.errors.get() <= user.total_commands.get(),
+            "dashboard must not publish {} user errors when only {} commands ran",
+            user.errors.get(),
+            user.total_commands.get()
+        );
+    }
+
+    #[test]
     fn test_snapshot_state_does_not_publish_user_active_connections_above_global_active() {
         use crate::metrics::{CommandCount, ErrorCount};
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1706,6 +1706,39 @@ mod tests {
     }
 
     #[test]
+    fn test_snapshot_state_does_not_publish_backend_error_subcounts_above_total_errors() {
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            backend_stats: vec![crate::metrics::BackendStats {
+                backend_id: crate::types::BackendId::from_index(0),
+                errors: crate::metrics::ErrorCount::new(1),
+                errors_4xx: crate::metrics::ErrorCount::new(3),
+                errors_5xx: crate::metrics::ErrorCount::new(2),
+                ..crate::metrics::BackendStats::default()
+            }]
+            .into(),
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+        let backend = &snapshot.backend_views[0].stats;
+        let classified_errors = backend
+            .errors_4xx
+            .get()
+            .saturating_add(backend.errors_5xx.get());
+
+        assert!(
+            classified_errors <= backend.errors.get(),
+            "dashboard must not publish {classified_errors} classified backend errors when only {} total errors exist",
+            backend.errors.get()
+        );
+    }
+
+    #[test]
     fn test_snapshot_state_does_not_publish_user_active_connections_above_global_active() {
         use crate::metrics::{CommandCount, ErrorCount};
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -932,6 +932,11 @@ impl TuiApp {
             .iter()
             .map(DashboardUserStats::from)
             .collect::<Vec<_>>();
+        if self.snapshot.active_connections.is_zero() {
+            top_users.iter_mut().for_each(|user| {
+                user.active_connections = crate::metrics::UserActiveConnections::ZERO;
+            });
+        }
         top_users.sort_by_key(|user| std::cmp::Reverse(user.total_bytes()));
         if let Some(limit) = top_user_limit {
             top_users.truncate(limit);
@@ -1542,6 +1547,45 @@ mod tests {
         assert_eq!(decoded.top_users[0].active_connections.get(), 2);
         assert_eq!(decoded.top_users[0].bytes_sent_per_sec.get(), 11);
         assert_eq!(decoded.top_users[0].bytes_received_per_sec.get(), 13);
+    }
+
+    #[test]
+    fn test_snapshot_state_does_not_publish_stale_user_active_connections() {
+        use crate::metrics::{CommandCount, ErrorCount};
+
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            active_connections: crate::metrics::ActiveConnections::ZERO,
+            user_stats: vec![crate::metrics::UserStats {
+                username: "nzbget".to_string(),
+                active_connections: crate::metrics::UserActiveConnections::new(5),
+                total_connections: crate::types::TotalConnections::new(5),
+                bytes_sent: crate::types::BytesSent::new(10_000),
+                bytes_received: crate::types::BytesReceived::new(20_000),
+                bytes_sent_per_sec: crate::types::BytesPerSecondRate::ZERO,
+                bytes_received_per_sec: crate::types::BytesPerSecondRate::ZERO,
+                total_commands: CommandCount::new(10),
+                errors: ErrorCount::ZERO,
+            }],
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+        let nzbget = snapshot
+            .top_users
+            .iter()
+            .find(|user| user.username == "nzbget")
+            .expect("nzbget row should still be present for historical traffic");
+
+        assert_eq!(
+            nzbget.active_connections,
+            crate::metrics::UserActiveConnections::ZERO,
+            "dashboard must not publish stale per-user active connections when global active connections is zero"
+        );
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1605,6 +1605,29 @@ mod tests {
     }
 
     #[test]
+    fn test_snapshot_state_does_not_publish_more_pipeline_batches_than_commands() {
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            pipeline_batches: crate::metrics::PipelineBatches::new(5),
+            pipeline_commands: crate::metrics::PipelineCommands::new(1),
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+
+        assert!(
+            snapshot.metrics.pipeline_batches.get() <= snapshot.metrics.pipeline_commands.get(),
+            "dashboard must not publish {} pipeline batches when only {} pipeline commands were processed",
+            snapshot.metrics.pipeline_batches.get(),
+            snapshot.metrics.pipeline_commands.get()
+        );
+    }
+
+    #[test]
     fn test_snapshot_state_does_not_publish_user_active_connections_above_global_active() {
         use crate::metrics::{CommandCount, ErrorCount};
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1677,6 +1677,35 @@ mod tests {
     }
 
     #[test]
+    fn test_snapshot_state_does_not_publish_backend_errors_above_total_commands() {
+        let metrics = MetricsCollector::new(1);
+        let router = Arc::new(BackendSelector::new());
+        let servers = create_test_servers(1);
+        let mut app = TuiAppBuilder::new(metrics, router, servers).build();
+
+        app.snapshot = Arc::new(MetricsSnapshot {
+            backend_stats: vec![crate::metrics::BackendStats {
+                backend_id: crate::types::BackendId::from_index(0),
+                total_commands: crate::metrics::CommandCount::new(1),
+                errors: crate::metrics::ErrorCount::new(5),
+                ..crate::metrics::BackendStats::default()
+            }]
+            .into(),
+            ..MetricsSnapshot::default()
+        });
+
+        let snapshot = app.snapshot_state();
+        let backend = &snapshot.backend_views[0].stats;
+
+        assert!(
+            backend.errors.get() <= backend.total_commands.get(),
+            "dashboard must not publish {} backend errors when only {} commands ran",
+            backend.errors.get(),
+            backend.total_commands.get()
+        );
+    }
+
+    #[test]
     fn test_snapshot_state_does_not_publish_user_active_connections_above_global_active() {
         use crate::metrics::{CommandCount, ErrorCount};
 

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -194,6 +194,20 @@ fn cap_error_count(count: ErrorCount, limit: CommandCount) -> ErrorCount {
     ErrorCount::new(count.get().min(limit.get()))
 }
 
+fn cap_completed_requests_to_queued(
+    completed: PipelineRequestsCompleted,
+    queued: PipelineRequestsQueued,
+) -> PipelineRequestsCompleted {
+    PipelineRequestsCompleted::new(completed.get().min(queued.get()))
+}
+
+fn cap_pipeline_batches_to_commands(
+    batches: PipelineBatches,
+    commands: PipelineCommands,
+) -> PipelineBatches {
+    PipelineBatches::new(batches.get().min(commands.get()))
+}
+
 fn cap_user_active_connections(
     active: UserActiveConnections,
     total: TotalConnections,
@@ -241,10 +255,48 @@ impl ActiveConnectionBudget {
 fn normalize_backend_stats(stats: &mut BackendStats) {
     stats.errors = cap_error_count(stats.errors, stats.total_commands);
 
+    cap_classified_errors_to_total_errors(stats);
+}
+
+fn cap_classified_errors_to_total_errors(stats: &mut BackendStats) {
     let errors_4xx = stats.errors_4xx.get().min(stats.errors.get());
     let remaining_errors = stats.errors.get().saturating_sub(errors_4xx);
     stats.errors_4xx = ErrorCount::new(errors_4xx);
     stats.errors_5xx = ErrorCount::new(stats.errors_5xx.get().min(remaining_errors));
+}
+
+trait BackendSnapshotView {
+    fn active_connections(&self) -> ActiveConnections;
+    fn set_active_connections(&mut self, active_connections: ActiveConnections);
+    fn stats_mut(&mut self) -> &mut BackendStats;
+}
+
+impl BackendSnapshotView for BackendView {
+    fn active_connections(&self) -> ActiveConnections {
+        self.active_connections
+    }
+
+    fn set_active_connections(&mut self, active_connections: ActiveConnections) {
+        self.active_connections = active_connections;
+    }
+
+    fn stats_mut(&mut self) -> &mut BackendStats {
+        &mut self.stats
+    }
+}
+
+impl BackendSnapshotView for RemoteBackendView {
+    fn active_connections(&self) -> ActiveConnections {
+        self.active_connections
+    }
+
+    fn set_active_connections(&mut self, active_connections: ActiveConnections) {
+        self.active_connections = active_connections;
+    }
+
+    fn stats_mut(&mut self) -> &mut BackendStats {
+        &mut self.stats
+    }
 }
 
 /// Serialized metrics used by the dashboard payload.
@@ -289,13 +341,10 @@ impl DashboardMetrics {
     ) -> Self {
         let active_connections = cap_active_connections(active_connections, total_connections);
         let stateful_sessions = cap_stateful_sessions(stateful_sessions, active_connections);
-        let pipeline_requests_completed = PipelineRequestsCompleted::new(
-            pipeline_requests_completed
-                .get()
-                .min(pipeline_requests_queued.get()),
-        );
+        let pipeline_requests_completed =
+            cap_completed_requests_to_queued(pipeline_requests_completed, pipeline_requests_queued);
         let pipeline_batches =
-            PipelineBatches::new(pipeline_batches.get().min(pipeline_commands.get()));
+            cap_pipeline_batches_to_commands(pipeline_batches, pipeline_commands);
         let cache_hit_rate = clamp_percent(cache_hit_rate);
         let disk_cache = disk_cache.map(|mut stats| {
             stats.disk_hit_rate = clamp_percent(stats.disk_hit_rate);
@@ -411,7 +460,7 @@ impl DashboardState {
         log_lines: Vec<String>,
         buffer_pool: Option<BufferPoolStats>,
     ) -> Self {
-        normalize_backend_active_counts(&mut backend_views, metrics.active_connections);
+        normalize_backend_views(&mut backend_views, metrics.active_connections);
         normalize_user_active_counts(&mut top_users, metrics.active_connections);
 
         Self {
@@ -490,7 +539,7 @@ impl RemoteDashboardState {
         system_stats: SystemStats,
         log_lines: Vec<String>,
     ) -> Self {
-        normalize_remote_backend_active_counts(&mut backend_views, metrics.active_connections);
+        normalize_backend_views(&mut backend_views, metrics.active_connections);
         normalize_user_active_counts(&mut top_users, metrics.active_connections);
 
         Self {
@@ -575,22 +624,14 @@ fn normalize_user_active_counts(
     });
 }
 
-fn normalize_backend_active_counts(backends: &mut [BackendView], global_active: ActiveConnections) {
-    let mut budget = ActiveConnectionBudget::new(global_active);
-    backends.iter_mut().for_each(|backend| {
-        backend.active_connections = budget.take_backend(backend.active_connections);
-        normalize_backend_stats(&mut backend.stats);
-    });
-}
-
-fn normalize_remote_backend_active_counts(
-    backends: &mut [RemoteBackendView],
+fn normalize_backend_views<T: BackendSnapshotView>(
+    backends: &mut [T],
     global_active: ActiveConnections,
 ) {
     let mut budget = ActiveConnectionBudget::new(global_active);
     backends.iter_mut().for_each(|backend| {
-        backend.active_connections = budget.take_backend(backend.active_connections);
-        normalize_backend_stats(&mut backend.stats);
+        backend.set_active_connections(budget.take_backend(backend.active_connections()));
+        normalize_backend_stats(backend.stats_mut());
     });
 }
 

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -244,17 +244,9 @@ impl ActiveConnectionBudget {
         self.remaining -= granted;
         UserActiveConnections::new(granted)
     }
-
-    fn take_backend(&mut self, requested: ActiveConnections) -> ActiveConnections {
-        let granted = requested.get().min(self.remaining);
-        self.remaining -= granted;
-        ActiveConnections::new(granted)
-    }
 }
 
 fn normalize_backend_stats(stats: &mut BackendStats) {
-    stats.errors = cap_error_count(stats.errors, stats.total_commands);
-
     cap_classified_errors_to_total_errors(stats);
 }
 
@@ -266,34 +258,16 @@ fn cap_classified_errors_to_total_errors(stats: &mut BackendStats) {
 }
 
 trait BackendSnapshotView {
-    fn active_connections(&self) -> ActiveConnections;
-    fn set_active_connections(&mut self, active_connections: ActiveConnections);
     fn stats_mut(&mut self) -> &mut BackendStats;
 }
 
 impl BackendSnapshotView for BackendView {
-    fn active_connections(&self) -> ActiveConnections {
-        self.active_connections
-    }
-
-    fn set_active_connections(&mut self, active_connections: ActiveConnections) {
-        self.active_connections = active_connections;
-    }
-
     fn stats_mut(&mut self) -> &mut BackendStats {
         &mut self.stats
     }
 }
 
 impl BackendSnapshotView for RemoteBackendView {
-    fn active_connections(&self) -> ActiveConnections {
-        self.active_connections
-    }
-
-    fn set_active_connections(&mut self, active_connections: ActiveConnections) {
-        self.active_connections = active_connections;
-    }
-
     fn stats_mut(&mut self) -> &mut BackendStats {
         &mut self.stats
     }
@@ -460,7 +434,7 @@ impl DashboardState {
         log_lines: Vec<String>,
         buffer_pool: Option<BufferPoolStats>,
     ) -> Self {
-        normalize_backend_views(&mut backend_views, metrics.active_connections);
+        normalize_backend_views(&mut backend_views);
         normalize_user_active_counts(&mut top_users, metrics.active_connections);
 
         Self {
@@ -539,7 +513,7 @@ impl RemoteDashboardState {
         system_stats: SystemStats,
         log_lines: Vec<String>,
     ) -> Self {
-        normalize_backend_views(&mut backend_views, metrics.active_connections);
+        normalize_backend_views(&mut backend_views);
         normalize_user_active_counts(&mut top_users, metrics.active_connections);
 
         Self {
@@ -624,13 +598,8 @@ fn normalize_user_active_counts(
     });
 }
 
-fn normalize_backend_views<T: BackendSnapshotView>(
-    backends: &mut [T],
-    global_active: ActiveConnections,
-) {
-    let mut budget = ActiveConnectionBudget::new(global_active);
+fn normalize_backend_views<T: BackendSnapshotView>(backends: &mut [T]) {
     backends.iter_mut().for_each(|backend| {
-        backend.set_active_connections(budget.take_backend(backend.active_connections()));
         normalize_backend_stats(backend.stats_mut());
     });
 }

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -262,6 +262,8 @@ impl DashboardMetrics {
                 .get()
                 .min(pipeline_requests_queued.get()),
         );
+        let pipeline_batches =
+            PipelineBatches::new(pipeline_batches.get().min(pipeline_commands.get()));
 
         Self {
             total_connections,

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -130,13 +130,11 @@ impl DashboardUserStats {
         total_commands: CommandCount,
         errors: ErrorCount,
     ) -> Self {
+        let active_connections = cap_user_active_connections(active_connections, total_connections);
+
         Self {
             username,
-            active_connections: UserActiveConnections::new(
-                active_connections
-                    .get()
-                    .min(usize::try_from(total_connections.get()).unwrap_or(usize::MAX)),
-            ),
+            active_connections,
             total_connections,
             bytes_sent,
             bytes_received,
@@ -184,6 +182,36 @@ impl From<&UserStats> for DashboardUserStats {
     }
 }
 
+fn u64_to_usize_saturating(value: u64) -> usize {
+    usize::try_from(value).unwrap_or(usize::MAX)
+}
+
+fn clamp_percent(value: f64) -> f64 {
+    value.clamp(0.0, 100.0)
+}
+
+fn cap_error_count(count: ErrorCount, limit: CommandCount) -> ErrorCount {
+    ErrorCount::new(count.get().min(limit.get()))
+}
+
+fn cap_user_active_connections(
+    active: UserActiveConnections,
+    total: TotalConnections,
+) -> UserActiveConnections {
+    UserActiveConnections::new(active.get().min(u64_to_usize_saturating(total.get())))
+}
+
+fn cap_active_connections(active: ActiveConnections, total: TotalConnections) -> ActiveConnections {
+    ActiveConnections::new(active.get().min(u64_to_usize_saturating(total.get())))
+}
+
+fn cap_stateful_sessions(
+    stateful: StatefulSessions,
+    active: ActiveConnections,
+) -> StatefulSessions {
+    StatefulSessions::new(stateful.get().min(active.get()))
+}
+
 #[derive(Debug, Clone, Copy)]
 struct ActiveConnectionBudget {
     remaining: usize,
@@ -208,6 +236,15 @@ impl ActiveConnectionBudget {
         self.remaining -= granted;
         ActiveConnections::new(granted)
     }
+}
+
+fn normalize_backend_stats(stats: &mut BackendStats) {
+    stats.errors = cap_error_count(stats.errors, stats.total_commands);
+
+    let errors_4xx = stats.errors_4xx.get().min(stats.errors.get());
+    let remaining_errors = stats.errors.get().saturating_sub(errors_4xx);
+    stats.errors_4xx = ErrorCount::new(errors_4xx);
+    stats.errors_5xx = ErrorCount::new(stats.errors_5xx.get().min(remaining_errors));
 }
 
 /// Serialized metrics used by the dashboard payload.
@@ -250,13 +287,8 @@ impl DashboardMetrics {
         pipeline_requests_queued: PipelineRequestsQueued,
         pipeline_requests_completed: PipelineRequestsCompleted,
     ) -> Self {
-        let active_connections = ActiveConnections::new(
-            active_connections
-                .get()
-                .min(usize::try_from(total_connections.get()).unwrap_or(usize::MAX)),
-        );
-        let stateful_sessions =
-            StatefulSessions::new(stateful_sessions.get().min(active_connections.get()));
+        let active_connections = cap_active_connections(active_connections, total_connections);
+        let stateful_sessions = cap_stateful_sessions(stateful_sessions, active_connections);
         let pipeline_requests_completed = PipelineRequestsCompleted::new(
             pipeline_requests_completed
                 .get()
@@ -264,9 +296,9 @@ impl DashboardMetrics {
         );
         let pipeline_batches =
             PipelineBatches::new(pipeline_batches.get().min(pipeline_commands.get()));
-        let cache_hit_rate = cache_hit_rate.clamp(0.0, 100.0);
+        let cache_hit_rate = clamp_percent(cache_hit_rate);
         let disk_cache = disk_cache.map(|mut stats| {
-            stats.disk_hit_rate = stats.disk_hit_rate.clamp(0.0, 100.0);
+            stats.disk_hit_rate = clamp_percent(stats.disk_hit_rate);
             stats
         });
 
@@ -539,7 +571,7 @@ fn normalize_user_active_counts(
     let mut budget = ActiveConnectionBudget::new(global_active);
     users.iter_mut().for_each(|user| {
         user.active_connections = budget.take_user(user.active_connections);
-        user.errors = ErrorCount::new(user.errors.get().min(user.total_commands.get()));
+        user.errors = cap_error_count(user.errors, user.total_commands);
     });
 }
 
@@ -547,22 +579,7 @@ fn normalize_backend_active_counts(backends: &mut [BackendView], global_active: 
     let mut budget = ActiveConnectionBudget::new(global_active);
     backends.iter_mut().for_each(|backend| {
         backend.active_connections = budget.take_backend(backend.active_connections);
-        backend.stats.errors = ErrorCount::new(
-            backend
-                .stats
-                .errors
-                .get()
-                .min(backend.stats.total_commands.get()),
-        );
-        let errors_4xx = backend
-            .stats
-            .errors_4xx
-            .get()
-            .min(backend.stats.errors.get());
-        let remaining_errors = backend.stats.errors.get().saturating_sub(errors_4xx);
-        backend.stats.errors_4xx = ErrorCount::new(errors_4xx);
-        backend.stats.errors_5xx =
-            ErrorCount::new(backend.stats.errors_5xx.get().min(remaining_errors));
+        normalize_backend_stats(&mut backend.stats);
     });
 }
 
@@ -573,22 +590,7 @@ fn normalize_remote_backend_active_counts(
     let mut budget = ActiveConnectionBudget::new(global_active);
     backends.iter_mut().for_each(|backend| {
         backend.active_connections = budget.take_backend(backend.active_connections);
-        backend.stats.errors = ErrorCount::new(
-            backend
-                .stats
-                .errors
-                .get()
-                .min(backend.stats.total_commands.get()),
-        );
-        let errors_4xx = backend
-            .stats
-            .errors_4xx
-            .get()
-            .min(backend.stats.errors.get());
-        let remaining_errors = backend.stats.errors.get().saturating_sub(errors_4xx);
-        backend.stats.errors_4xx = ErrorCount::new(errors_4xx);
-        backend.stats.errors_5xx =
-            ErrorCount::new(backend.stats.errors_5xx.get().min(remaining_errors));
+        normalize_backend_stats(&mut backend.stats);
     });
 }
 

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -553,6 +553,15 @@ fn normalize_backend_active_counts(backends: &mut [BackendView], global_active: 
                 .get()
                 .min(backend.stats.total_commands.get()),
         );
+        let errors_4xx = backend
+            .stats
+            .errors_4xx
+            .get()
+            .min(backend.stats.errors.get());
+        let remaining_errors = backend.stats.errors.get().saturating_sub(errors_4xx);
+        backend.stats.errors_4xx = ErrorCount::new(errors_4xx);
+        backend.stats.errors_5xx =
+            ErrorCount::new(backend.stats.errors_5xx.get().min(remaining_errors));
     });
 }
 
@@ -570,6 +579,15 @@ fn normalize_remote_backend_active_counts(
                 .get()
                 .min(backend.stats.total_commands.get()),
         );
+        let errors_4xx = backend
+            .stats
+            .errors_4xx
+            .get()
+            .min(backend.stats.errors.get());
+        let remaining_errors = backend.stats.errors.get().saturating_sub(errors_4xx);
+        backend.stats.errors_4xx = ErrorCount::new(errors_4xx);
+        backend.stats.errors_5xx =
+            ErrorCount::new(backend.stats.errors_5xx.get().min(remaining_errors));
     });
 }
 

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -265,6 +265,10 @@ impl DashboardMetrics {
         let pipeline_batches =
             PipelineBatches::new(pipeline_batches.get().min(pipeline_commands.get()));
         let cache_hit_rate = cache_hit_rate.clamp(0.0, 100.0);
+        let disk_cache = disk_cache.map(|mut stats| {
+            stats.disk_hit_rate = stats.disk_hit_rate.clamp(0.0, 100.0);
+            stats
+        });
 
         Self {
             total_connections,

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -117,9 +117,57 @@ pub struct DashboardUserStats {
 }
 
 impl DashboardUserStats {
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
+    pub fn new(
+        username: String,
+        active_connections: UserActiveConnections,
+        total_connections: TotalConnections,
+        bytes_sent: BytesSent,
+        bytes_received: BytesReceived,
+        bytes_sent_per_sec: BytesPerSecondRate,
+        bytes_received_per_sec: BytesPerSecondRate,
+        total_commands: CommandCount,
+        errors: ErrorCount,
+    ) -> Self {
+        Self {
+            username,
+            active_connections: UserActiveConnections::new(
+                active_connections
+                    .get()
+                    .min(usize::try_from(total_connections.get()).unwrap_or(usize::MAX)),
+            ),
+            total_connections,
+            bytes_sent,
+            bytes_received,
+            bytes_sent_per_sec,
+            bytes_received_per_sec,
+            total_commands,
+            errors,
+        }
+    }
+
     #[must_use]
     pub fn from_user_stats(user: &UserStats) -> Self {
         Self::from(user)
+    }
+
+    #[must_use]
+    pub fn from_user_stats_with_active_connections(
+        user: &UserStats,
+        active_connections: UserActiveConnections,
+    ) -> Self {
+        Self::new(
+            user.username.clone(),
+            active_connections,
+            user.total_connections,
+            user.bytes_sent,
+            user.bytes_received,
+            user.bytes_sent_per_sec,
+            user.bytes_received_per_sec,
+            user.total_commands,
+            user.errors,
+        )
     }
 
     #[must_use]
@@ -132,17 +180,33 @@ impl DashboardUserStats {
 
 impl From<&UserStats> for DashboardUserStats {
     fn from(user: &UserStats) -> Self {
+        Self::from_user_stats_with_active_connections(user, user.active_connections)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ActiveConnectionBudget {
+    remaining: usize,
+}
+
+impl ActiveConnectionBudget {
+    #[must_use]
+    const fn new(global_active: ActiveConnections) -> Self {
         Self {
-            username: user.username.clone(),
-            active_connections: user.active_connections,
-            total_connections: user.total_connections,
-            bytes_sent: user.bytes_sent,
-            bytes_received: user.bytes_received,
-            bytes_sent_per_sec: user.bytes_sent_per_sec,
-            bytes_received_per_sec: user.bytes_received_per_sec,
-            total_commands: user.total_commands,
-            errors: user.errors,
+            remaining: global_active.get(),
         }
+    }
+
+    fn take_user(&mut self, requested: UserActiveConnections) -> UserActiveConnections {
+        let granted = requested.get().min(self.remaining);
+        self.remaining -= granted;
+        UserActiveConnections::new(granted)
+    }
+
+    fn take_backend(&mut self, requested: ActiveConnections) -> ActiveConnections {
+        let granted = requested.get().min(self.remaining);
+        self.remaining -= granted;
+        ActiveConnections::new(granted)
     }
 }
 
@@ -168,6 +232,51 @@ pub struct DashboardMetrics {
 }
 
 impl DashboardMetrics {
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
+    pub fn new(
+        total_connections: TotalConnections,
+        active_connections: ActiveConnections,
+        stateful_sessions: StatefulSessions,
+        client_to_backend_bytes: ClientToBackendBytes,
+        backend_to_client_bytes: BackendToClientBytes,
+        uptime: Duration,
+        cache_entries: CacheEntries,
+        cache_size_bytes: u64,
+        cache_hit_rate: f64,
+        disk_cache: Option<DiskCacheStats>,
+        pipeline_batches: PipelineBatches,
+        pipeline_commands: PipelineCommands,
+        pipeline_requests_queued: PipelineRequestsQueued,
+        pipeline_requests_completed: PipelineRequestsCompleted,
+    ) -> Self {
+        let active_connections = ActiveConnections::new(
+            active_connections
+                .get()
+                .min(usize::try_from(total_connections.get()).unwrap_or(usize::MAX)),
+        );
+        let stateful_sessions =
+            StatefulSessions::new(stateful_sessions.get().min(active_connections.get()));
+
+        Self {
+            total_connections,
+            active_connections,
+            stateful_sessions,
+            client_to_backend_bytes,
+            backend_to_client_bytes,
+            uptime,
+            cache_entries,
+            cache_size_bytes,
+            cache_hit_rate,
+            disk_cache,
+            pipeline_batches,
+            pipeline_commands,
+            pipeline_requests_queued,
+            pipeline_requests_completed,
+            in_flight_requests: PendingRequests::ZERO,
+        }
+    }
+
     #[must_use]
     pub fn from_snapshot(snapshot: &MetricsSnapshot) -> Self {
         Self::from(snapshot)
@@ -200,23 +309,22 @@ impl DashboardMetrics {
 
 impl From<&MetricsSnapshot> for DashboardMetrics {
     fn from(snapshot: &MetricsSnapshot) -> Self {
-        Self {
-            total_connections: snapshot.total_connections,
-            active_connections: snapshot.active_connections,
-            stateful_sessions: snapshot.stateful_sessions,
-            client_to_backend_bytes: snapshot.client_to_backend_bytes,
-            backend_to_client_bytes: snapshot.backend_to_client_bytes,
-            uptime: snapshot.uptime,
-            cache_entries: snapshot.cache_entries,
-            cache_size_bytes: snapshot.cache_size_bytes,
-            cache_hit_rate: snapshot.cache_hit_rate,
-            disk_cache: snapshot.disk_cache,
-            pipeline_batches: snapshot.pipeline_batches,
-            pipeline_commands: snapshot.pipeline_commands,
-            pipeline_requests_queued: snapshot.pipeline_requests_queued,
-            pipeline_requests_completed: snapshot.pipeline_requests_completed,
-            in_flight_requests: PendingRequests::ZERO,
-        }
+        Self::new(
+            snapshot.total_connections,
+            snapshot.active_connections,
+            snapshot.stateful_sessions,
+            snapshot.client_to_backend_bytes,
+            snapshot.backend_to_client_bytes,
+            snapshot.uptime,
+            snapshot.cache_entries,
+            snapshot.cache_size_bytes,
+            snapshot.cache_hit_rate,
+            snapshot.disk_cache,
+            snapshot.pipeline_batches,
+            snapshot.pipeline_commands,
+            snapshot.pipeline_requests_queued,
+            snapshot.pipeline_requests_completed,
+        )
     }
 }
 
@@ -246,6 +354,35 @@ pub struct RemoteDashboardState {
 }
 
 impl DashboardState {
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
+    pub fn new(
+        metrics: DashboardMetrics,
+        mut backend_views: Vec<BackendView>,
+        mut top_users: Vec<DashboardUserStats>,
+        client_history: Vec<ThroughputPoint>,
+        system_stats: SystemStats,
+        view_mode: ViewMode,
+        show_details: bool,
+        log_lines: Vec<String>,
+        buffer_pool: Option<BufferPoolStats>,
+    ) -> Self {
+        normalize_backend_active_counts(&mut backend_views, metrics.active_connections);
+        normalize_user_active_counts(&mut top_users, metrics.active_connections);
+
+        Self {
+            metrics,
+            backend_views,
+            top_users,
+            client_history,
+            system_stats,
+            view_mode,
+            show_details,
+            log_lines,
+            buffer_pool,
+        }
+    }
+
     #[must_use]
     fn backend_view(&self, backend_idx: usize) -> Option<&BackendView> {
         self.backend_views.get(backend_idx)
@@ -299,6 +436,29 @@ impl DashboardState {
 }
 
 impl RemoteDashboardState {
+    #[allow(clippy::too_many_arguments)]
+    #[must_use]
+    pub fn new(
+        metrics: DashboardMetrics,
+        mut backend_views: Vec<RemoteBackendView>,
+        mut top_users: Vec<DashboardUserStats>,
+        latest_client_throughput: Option<ThroughputPoint>,
+        system_stats: SystemStats,
+        log_lines: Vec<String>,
+    ) -> Self {
+        normalize_remote_backend_active_counts(&mut backend_views, metrics.active_connections);
+        normalize_user_active_counts(&mut top_users, metrics.active_connections);
+
+        Self {
+            metrics,
+            backend_views,
+            top_users,
+            latest_client_throughput,
+            system_stats,
+            log_lines,
+        }
+    }
+
     #[must_use]
     fn backend_view(&self, backend_idx: usize) -> Option<&RemoteBackendView> {
         self.backend_views.get(backend_idx)
@@ -345,19 +505,46 @@ impl From<BackendView> for RemoteBackendView {
 
 impl From<DashboardState> for RemoteDashboardState {
     fn from(state: DashboardState) -> Self {
-        Self {
-            metrics: state.metrics,
-            backend_views: state
+        Self::new(
+            state.metrics,
+            state
                 .backend_views
                 .into_iter()
                 .map(RemoteBackendView::from)
                 .collect(),
-            top_users: state.top_users,
-            latest_client_throughput: state.client_history.last().cloned(),
-            system_stats: state.system_stats,
-            log_lines: state.log_lines,
-        }
+            state.top_users,
+            state.client_history.last().cloned(),
+            state.system_stats,
+            state.log_lines,
+        )
     }
+}
+
+fn normalize_user_active_counts(
+    users: &mut [DashboardUserStats],
+    global_active: ActiveConnections,
+) {
+    let mut budget = ActiveConnectionBudget::new(global_active);
+    users.iter_mut().for_each(|user| {
+        user.active_connections = budget.take_user(user.active_connections);
+    });
+}
+
+fn normalize_backend_active_counts(backends: &mut [BackendView], global_active: ActiveConnections) {
+    let mut budget = ActiveConnectionBudget::new(global_active);
+    backends.iter_mut().for_each(|backend| {
+        backend.active_connections = budget.take_backend(backend.active_connections);
+    });
+}
+
+fn normalize_remote_backend_active_counts(
+    backends: &mut [RemoteBackendView],
+    global_active: ActiveConnections,
+) {
+    let mut budget = ActiveConnectionBudget::new(global_active);
+    backends.iter_mut().for_each(|backend| {
+        backend.active_connections = budget.take_backend(backend.active_connections);
+    });
 }
 
 #[cfg(test)]

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -257,6 +257,11 @@ impl DashboardMetrics {
         );
         let stateful_sessions =
             StatefulSessions::new(stateful_sessions.get().min(active_connections.get()));
+        let pipeline_requests_completed = PipelineRequestsCompleted::new(
+            pipeline_requests_completed
+                .get()
+                .min(pipeline_requests_queued.get()),
+        );
 
         Self {
             total_connections,

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -539,6 +539,7 @@ fn normalize_user_active_counts(
     let mut budget = ActiveConnectionBudget::new(global_active);
     users.iter_mut().for_each(|user| {
         user.active_connections = budget.take_user(user.active_connections);
+        user.errors = ErrorCount::new(user.errors.get().min(user.total_commands.get()));
     });
 }
 

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -546,6 +546,13 @@ fn normalize_backend_active_counts(backends: &mut [BackendView], global_active: 
     let mut budget = ActiveConnectionBudget::new(global_active);
     backends.iter_mut().for_each(|backend| {
         backend.active_connections = budget.take_backend(backend.active_connections);
+        backend.stats.errors = ErrorCount::new(
+            backend
+                .stats
+                .errors
+                .get()
+                .min(backend.stats.total_commands.get()),
+        );
     });
 }
 
@@ -556,6 +563,13 @@ fn normalize_remote_backend_active_counts(
     let mut budget = ActiveConnectionBudget::new(global_active);
     backends.iter_mut().for_each(|backend| {
         backend.active_connections = budget.take_backend(backend.active_connections);
+        backend.stats.errors = ErrorCount::new(
+            backend
+                .stats
+                .errors
+                .get()
+                .min(backend.stats.total_commands.get()),
+        );
     });
 }
 

--- a/src/tui/dashboard.rs
+++ b/src/tui/dashboard.rs
@@ -264,6 +264,7 @@ impl DashboardMetrics {
         );
         let pipeline_batches =
             PipelineBatches::new(pipeline_batches.get().min(pipeline_commands.get()));
+        let cache_hit_rate = cache_hit_rate.clamp(0.0, 100.0);
 
         Self {
             total_connections,


### PR DESCRIPTION
## Summary

Fixes several TUI dashboard snapshot invariants so stale or internally inconsistent metric data does not get published to local or attached dashboard renderers.

Changes include:
- suppressing stale per-user active connection counts when global active connections are lower or zero
- clamping dashboard active/stateful connection counts to plausible totals
- clamping pipeline, cache hit-rate, backend error, classified error, and user error counts before rendering/serialization
- routing local and remote dashboard state through normalized snapshot constructors
- consolidating dashboard invariant normalization into named helpers without adding heap allocation on the normalization path
- clearing prewarmed backend pools after idle timeout as included in this branch

## Why

The TUI could report impossible values, such as a user still having active connections after the service had been idle. The root issue was that dashboard snapshots serialized raw metric fields without consistently enforcing relationships between counters.

## Validation

- `nix develop -c cargo fmt --check`
- `nix develop -c cargo test tui:: --lib -- --nocapture`
- `nix develop -c cargo clippy`

Pre-commit hooks also ran `cargo fmt` and `cargo clippy` for the final commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard metrics validation improved to handle edge cases with hit rates, error counts, and connection states.
  * Backend connection pool cleanup enhanced for prewarmed connections.

* **Tests**
  * Added comprehensive validation tests for dashboard state consistency and metric bounds checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->