### PR TITLE
Tighten ratatui chart rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -892,7 +892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2798,14 +2798,15 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.30.1"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1695748e3a735b34968c887ceea5a380b43545903868ae8f5b666593100f6b68"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
 dependencies = [
  "instability",
  "ratatui-core",
  "ratatui-crossterm",
  "ratatui-macros",
+ "ratatui-termina",
  "ratatui-termwiz",
  "ratatui-widgets",
  "serde",
@@ -2813,15 +2814,14 @@ dependencies = [
 
 [[package]]
 name = "ratatui-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3603f354bba8c595fa47860e60142d7372b7210c27044c6a7d0e1a4336b44"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
  "bitflags 2.13.0",
  "compact_str",
  "critical-section",
  "hashbrown 0.17.1",
- "indoc",
  "itertools",
  "kasuari",
  "lru",
@@ -2836,9 +2836,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-crossterm"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2867bedcbd6a690ca4f8672a687b730ec07660c79844517b084311b529980c"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
 dependencies = [
  "cfg-if",
  "crossterm",
@@ -2848,19 +2848,30 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80fac59720679490d89d200df411faa249be728681adcabed3d047ae72c48f1d"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
 dependencies = [
  "ratatui-core",
  "ratatui-widgets",
 ]
 
 [[package]]
-name = "ratatui-termwiz"
-version = "0.1.1"
+name = "ratatui-termina"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "386b8ff8f74ed749509391c56d549761a2fcdb408e1f42e467286bcb7dac8967"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
 dependencies = [
  "ratatui-core",
  "termwiz",
@@ -2868,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "ratatui-widgets"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef4f17dd7ac3abf5adc2b920a03c61eee4bfe6a88fa5191936895525371d79c"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.17.1",
@@ -2969,7 +2980,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3415,7 +3426,20 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4246,7 +4270,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ uuid = { version = "1.23", features = ["v4"] }  # Unique IDs for request trackin
 moka = { version = "0.12", features = ["future"], default-features = false }  # Async LRU cache, minimal features
 foyer = { version = "0.22", features = ["serde"] }  # Hybrid memory+disk cache for large article caching
 bytes = "1.11"  # Efficient byte buffer for zero-copy operations
-ratatui = "0.30"  # Terminal UI framework
+ratatui = "0.30.2"  # Terminal UI framework
 crossterm = "0.29"  # Cross-platform terminal manipulation
 smallvec = { version = "1.15", features = ["serde"] }  # Stack-allocated vectors for small collections
 arrayvec = "0.7"  # Stack-backed strings for small display formatting without heap allocation

--- a/src/tui/helpers.rs
+++ b/src/tui/helpers.rs
@@ -311,6 +311,10 @@ pub fn calculate_chart_bounds(max_throughput: f64) -> f64 {
 #[allow(clippy::float_cmp)] // These helper tests use exact expected fixture values for chart math.
 mod tests {
     use super::*;
+    use crate::metrics::{BackendHealthStatus, BackendStats};
+    use crate::tui::dashboard::{BackendDisplay, BackendView};
+    use crate::types::tui::{CommandsPerSecond, Throughput, Timestamp};
+    use crate::types::{HostName, MaxConnections, Port, ServerName};
 
     #[test]
     fn test_backend_color_cycles() {
@@ -423,6 +427,53 @@ mod tests {
         // Verify pre-computed tuples are empty
         assert_eq!(data.sent_points_as_tuples().len(), 0);
         assert_eq!(data.recv_points_as_tuples().len(), 0);
+    }
+
+    #[test]
+    fn test_build_chart_data_preserves_sent_and_recv_series() {
+        let backend_views = vec![BackendView {
+            server: BackendDisplay {
+                host: HostName::try_new("backend.example.com".to_string()).unwrap(),
+                port: Port::try_new(119).unwrap(),
+                name: ServerName::try_new("Backend".to_string()).unwrap(),
+                max_connections: MaxConnections::try_new(10).unwrap(),
+            },
+            stats: BackendStats::default(),
+            active_connections: crate::metrics::ActiveConnections::new(1),
+            health_status: BackendHealthStatus::Healthy,
+            pending_count: crate::metrics::PendingRequests::new(0),
+            load_ratio: Some(0.5),
+            stateful_count: crate::metrics::StatefulSessions::new(0),
+            traffic_share: Some(42.0),
+            history: vec![
+                ThroughputPoint::new_backend(
+                    Timestamp::now(),
+                    Throughput::new(100.0),
+                    Throughput::new(200.0),
+                    CommandsPerSecond::new(10.0),
+                ),
+                ThroughputPoint::new_backend(
+                    Timestamp::now(),
+                    Throughput::new(150.0),
+                    Throughput::new(175.0),
+                    CommandsPerSecond::new(12.0),
+                ),
+            ],
+        }];
+
+        let (chart_data, max_throughput) = build_chart_data(&backend_views);
+
+        assert_eq!(chart_data.len(), 1);
+        assert_eq!(chart_data[0].name, "Backend");
+        assert_eq!(
+            chart_data[0].sent_points_as_tuples(),
+            &[(0.0, 100.0), (1.0, 150.0)]
+        );
+        assert_eq!(
+            chart_data[0].recv_points_as_tuples(),
+            &[(0.0, 200.0), (1.0, 175.0)]
+        );
+        assert_eq!(max_throughput, 200.0);
     }
 
     // ========================================================================

--- a/src/tui/helpers.rs
+++ b/src/tui/helpers.rs
@@ -76,7 +76,7 @@ pub fn create_sparkline_text(value: u64, max_value: u64) -> ArrayString<64> {
 /// 3. Accumulates results with global max tracking
 ///
 /// Returns (`chart_data`, `global_max_throughput`)
-pub fn build_chart_data<'a>(backend_views: &'a [BackendView]) -> (ChartDataVec<'a>, f64) {
+pub fn build_chart_data(backend_views: &[BackendView]) -> (ChartDataVec, f64) {
     /// Extract data from a single throughput point
     #[inline]
     fn extract_point_data(idx: usize, point: &ThroughputPoint) -> (ChartPoint, ChartPoint, ChartY) {
@@ -117,12 +117,7 @@ pub fn build_chart_data<'a>(backend_views: &'a [BackendView]) -> (ChartDataVec<'
                 );
 
             (
-                BackendChartData::new(
-                    backend.server.name.as_str(),
-                    backend_color(index),
-                    &sent_points,
-                    &recv_points,
-                ),
+                BackendChartData::new(backend_color(index), &sent_points, &recv_points),
                 backend_max.get(),
             )
         })
@@ -396,13 +391,11 @@ mod tests {
     #[test]
     fn test_chart_data_vec_type() {
         // Verify ChartDataVec can hold typical backend count on stack
-        let names: Vec<String> = (0..8).map(|i| format!("Server {i}")).collect();
         let mut chart_data = ChartDataVec::new();
 
         // Add 8 backends (at SmallVec capacity)
-        for (i, name) in names.iter().enumerate() {
+        for i in 0..8 {
             chart_data.push(BackendChartData::new(
-                name.as_str(),
                 backend_color(i),
                 &PointVec::new(),
                 &PointVec::new(),
@@ -410,20 +403,12 @@ mod tests {
         }
 
         assert_eq!(chart_data.len(), 8);
-        assert_eq!(chart_data[0].name, "Server 0");
-        assert_eq!(chart_data[7].name, "Server 7");
     }
 
     #[test]
     fn test_backend_chart_data_structure() {
-        let data = BackendChartData::new(
-            "Test Server",
-            backend_color(0),
-            &PointVec::new(),
-            &PointVec::new(),
-        );
+        let data = BackendChartData::new(backend_color(0), &PointVec::new(), &PointVec::new());
 
-        assert_eq!(data.name, "Test Server");
         // Verify pre-computed tuples are empty
         assert_eq!(data.sent_points_as_tuples().len(), 0);
         assert_eq!(data.recv_points_as_tuples().len(), 0);
@@ -464,7 +449,6 @@ mod tests {
         let (chart_data, max_throughput) = build_chart_data(&backend_views);
 
         assert_eq!(chart_data.len(), 1);
-        assert_eq!(chart_data[0].name, "Backend");
         assert_eq!(
             chart_data[0].sent_points_as_tuples(),
             &[(0.0, 100.0), (1.0, 150.0)]

--- a/src/tui/types.rs
+++ b/src/tui/types.rs
@@ -115,15 +115,13 @@ pub type PointVec = SmallVec<[ChartPoint; 64]>;
 
 /// Stack-allocated chart data for typical backend counts.
 /// Most deployments have 1-4 backends, so this avoids heap allocation
-pub type ChartDataVec<'a> = SmallVec<[BackendChartData<'a>; 8]>;
+pub type ChartDataVec = SmallVec<[BackendChartData; 8]>;
 
 /// Chart data for a single backend server
 ///
 /// Pre-computed data points to avoid nested iterations during rendering
 #[derive(Debug, Clone)]
-pub struct BackendChartData<'a> {
-    /// Server name for legend
-    pub name: &'a str,
+pub struct BackendChartData {
     /// Color for this backend's lines
     pub color: Color,
     /// Pre-computed tuples for ratatui (cached to avoid allocation on render)
@@ -132,21 +130,15 @@ pub struct BackendChartData<'a> {
     recv_tuples: SmallVec<[(f64, f64); 64]>,
 }
 
-impl<'a> BackendChartData<'a> {
+impl BackendChartData {
     /// Create new chart data with pre-computed tuples
     #[must_use]
-    pub fn new(
-        name: &'a str,
-        color: Color,
-        sent_points: &[ChartPoint],
-        recv_points: &[ChartPoint],
-    ) -> Self {
+    pub fn new(color: Color, sent_points: &[ChartPoint], recv_points: &[ChartPoint]) -> Self {
         let sent_tuples: SmallVec<[(f64, f64); 64]> =
             sent_points.iter().map(ChartPoint::as_tuple).collect();
         let recv_tuples: SmallVec<[(f64, f64); 64]> =
             recv_points.iter().map(ChartPoint::as_tuple).collect();
         Self {
-            name,
             color,
             sent_tuples,
             recv_tuples,
@@ -236,7 +228,7 @@ mod tests {
         sent_points.push(ChartPoint::new(ChartX::new(0.0), ChartY::new(100.0)));
         sent_points.push(ChartPoint::new(ChartX::new(1.0), ChartY::new(200.0)));
 
-        let data = BackendChartData::new("Test", Color::Green, &sent_points, &PointVec::new());
+        let data = BackendChartData::new(Color::Green, &sent_points, &PointVec::new());
 
         let tuples = data.sent_points_as_tuples();
         assert_eq!(tuples.len(), 2);

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -13,9 +13,9 @@ use crate::tui::dashboard::{
     InUseBuffers, TotalBuffers,
 };
 use crate::tui::helpers::{
-    build_chart_data, calculate_chart_bounds, connection_failure_color, create_sparkline_text,
-    error_count_color, error_rate_color, format_summary_throughput, format_throughput_label,
-    health_indicator, socket_addr_text,
+    backend_color, build_chart_data, calculate_chart_bounds, connection_failure_color,
+    create_sparkline_text, error_count_color, error_rate_color, format_summary_throughput,
+    format_throughput_label, health_indicator, socket_addr_text,
 };
 use crate::types::MaxConnections;
 use crate::types::TotalConnections;
@@ -1451,10 +1451,22 @@ fn render_backend_list(f: &mut Frame, area: Rect, state: &DashboardState, show_d
         let backend_stats = &backend.stats;
         let server = &backend.server;
         let y = inner.top().saturating_add(row);
+        let chart_color = backend_color(i);
         let (health_icon, health_color) = health_indicator(backend.health_status);
         let error_rate = backend_stats.error_rate_percent();
 
         let mut x = inner.left();
+        write_part(
+            buffer,
+            &mut x,
+            y,
+            right,
+            "■",
+            Style::default()
+                .fg(chart_color)
+                .add_modifier(Modifier::BOLD),
+        );
+        write_part(buffer, &mut x, y, right, " ", Style::default());
         write_part(
             buffer,
             &mut x,
@@ -2013,8 +2025,7 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
             datasets.push(
                 Dataset::default()
                     .marker(symbols::Marker::Braille)
-                    .graph_type(GraphType::Area)
-                    .fill_to_y(0.0)
+                    .graph_type(GraphType::Line)
                     .style(Style::default().fg(data.color).add_modifier(Modifier::BOLD))
                     .data(recv_points),
             );
@@ -2061,6 +2072,51 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
         );
 
     f.render_widget(chart, area);
+    render_data_flow_legend(f.buffer_mut(), area, &state.backend_views);
+}
+
+fn render_data_flow_legend(
+    buffer: &mut Buffer,
+    area: Rect,
+    backends: &[crate::tui::dashboard::BackendView],
+) {
+    if area.width <= 4 || area.height == 0 || backends.is_empty() {
+        return;
+    }
+
+    let title_offset = u16::try_from(chart::TITLE.len())
+        .unwrap_or(u16::MAX)
+        .saturating_add(5);
+    let mut x = area.x.saturating_add(title_offset);
+    let y = area.y;
+    let right = area.right().saturating_sub(1);
+
+    for (index, backend) in backends.iter().enumerate() {
+        if x >= right {
+            break;
+        }
+        if index > 0 {
+            write_part(buffer, &mut x, y, right, "  ", Style::default());
+        }
+        write_part(
+            buffer,
+            &mut x,
+            y,
+            right,
+            "■ ",
+            Style::default()
+                .fg(backend_color(index))
+                .add_modifier(Modifier::BOLD),
+        );
+        write_part(
+            buffer,
+            &mut x,
+            y,
+            right,
+            backend.server.name.as_str(),
+            Style::default().fg(styles::LABEL),
+        );
+    }
 }
 
 /// Render footer with help text
@@ -2854,6 +2910,24 @@ mod tests {
         assert!(lines.iter().any(|line| line.contains("one")));
         assert!(lines.iter().any(|line| line.contains("two")));
         assert!(lines.iter().any(String::is_empty));
+    }
+
+    #[test]
+    fn data_flow_legend_maps_backend_names_to_chart_colors() {
+        let mut buffer = Buffer::empty(Rect::new(0, 0, 80, 3));
+        let backends = vec![test_backend_view("one"), test_backend_view("two")];
+
+        render_data_flow_legend(&mut buffer, Rect::new(0, 0, 80, 3), &backends);
+
+        let row = (0..80)
+            .map(|x| buffer.cell((x, 0)).unwrap().symbol())
+            .collect::<String>();
+        let marker_x = u16::try_from(chart::TITLE.len()).unwrap() + 5;
+
+        assert!(row.contains("one"));
+        assert!(row.contains("two"));
+        assert_eq!(buffer.cell((marker_x, 0)).unwrap().symbol(), "■");
+        assert_eq!(buffer.cell((marker_x, 0)).unwrap().fg, backend_color(0));
     }
 
     fn test_backend_view(name: &str) -> crate::tui::dashboard::BackendView {

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2013,9 +2013,22 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
         ])
     }
 
-    // Build datasets directly from pre-computed chart data
+    // Build datasets directly from pre-computed chart data.
     let mut datasets = Vec::with_capacity(chart_data.len() * 2);
     for data in &chart_data {
+        let recv_points = data.recv_points_as_tuples();
+        if !recv_points.is_empty() {
+            datasets.push(
+                Dataset::default()
+                    .name(dataset_name(data.name, text::ARROW_DOWN))
+                    .marker(symbols::Marker::Braille)
+                    .graph_type(GraphType::Area)
+                    .fill_to_y(0.0)
+                    .style(Style::default().fg(data.color).add_modifier(Modifier::BOLD))
+                    .data(recv_points),
+            );
+        }
+
         let sent_points = data.sent_points_as_tuples();
         if !sent_points.is_empty() {
             datasets.push(
@@ -2025,18 +2038,6 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
                     .graph_type(GraphType::Line)
                     .style(Style::default().fg(data.color))
                     .data(sent_points),
-            );
-        }
-
-        let recv_points = data.recv_points_as_tuples();
-        if !recv_points.is_empty() {
-            datasets.push(
-                Dataset::default()
-                    .name(dataset_name(data.name, text::ARROW_DOWN))
-                    .marker(symbols::Marker::Braille)
-                    .graph_type(GraphType::Line)
-                    .style(Style::default().fg(data.color).add_modifier(Modifier::BOLD))
-                    .data(recv_points),
             );
         }
     }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -2005,14 +2005,6 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
     let max_label = format_throughput_label(max_throughput_rounded);
     let half_label = format_throughput_label(max_throughput_rounded / 2.0);
 
-    fn dataset_name<'a>(backend_name: &'a str, direction: &'static str) -> Line<'a> {
-        Line::from(vec![
-            Span::raw(backend_name),
-            Span::raw(" "),
-            Span::raw(direction),
-        ])
-    }
-
     // Build datasets directly from pre-computed chart data.
     let mut datasets = Vec::with_capacity(chart_data.len() * 2);
     for data in &chart_data {
@@ -2020,7 +2012,6 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
         if !recv_points.is_empty() {
             datasets.push(
                 Dataset::default()
-                    .name(dataset_name(data.name, text::ARROW_DOWN))
                     .marker(symbols::Marker::Braille)
                     .graph_type(GraphType::Area)
                     .fill_to_y(0.0)
@@ -2033,7 +2024,6 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
         if !sent_points.is_empty() {
             datasets.push(
                 Dataset::default()
-                    .name(dataset_name(data.name, text::ARROW_UP))
                     .marker(symbols::Marker::Braille)
                     .graph_type(GraphType::Line)
                     .style(Style::default().fg(data.color))
@@ -2045,6 +2035,7 @@ fn render_data_flow(f: &mut Frame, area: Rect, state: &DashboardState) {
     // Build and render chart
     let chart = Chart::new(datasets)
         .block(bordered_block(chart::TITLE, styles::BORDER_NORMAL))
+        .legend_position(None)
         .x_axis(
             Axis::default()
                 .title("")


### PR DESCRIPTION
## Summary

- Update ratatui to 0.30.2.
- Replace ratatui chart dataset names/legend usage with a direct-buffer legend and backend color markers to avoid the dataset label allocation path.
- Keep throughput series readable by rendering both send and receive as lines instead of filled areas.
- Add tests for preserving send/receive chart series and mapping backend legend names to chart colors.

## Notes

The stock ratatui `Chart` path still allocates internally for dataset/axis/canvas structures, so this PR avoids the avoidable dataset-label/legend allocations without claiming the chart is fully allocation-free. A custom direct-buffer chart renderer would be the next step if we want zero per-frame graph allocation.

## Validation

- `nix develop -c cargo fmt --check`
- `nix develop -c cargo clippy`
- `nix develop -c cargo nextest run`
- `nix develop -c cargo nextest run data_flow_legend_maps_backend_names_to_chart_colors`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ratatui dependency to version 0.30.2.

* **Bug Fixes**
  * Enhanced backend list display with colored square indicators.
  * Improved chart legend rendering with clearer visual markers and backend name display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->