### PR TITLE
Compact ordinary development artifacts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,12 +185,15 @@ name = "end_to_end_proxy"
 harness = false
 
 [profile.dev]
+debug = 0             # Use the profiling/bench profiles when symbols are needed
+incremental = false   # Avoid retaining a second full set of object files
 split-debuginfo = "unpacked"  # Faster linking — don't bundle debuginfo into binary
 
 [profile.dev.package."*"]
 opt-level = 1  # Compile dependencies with optimizations in dev mode
                # Huge runtime speedup for rustls/ring/foyer/moka
                # Minimal compile-time cost (deps cached after first build)
+debug = 0      # Keep dependency artifacts compact in the dev profile
 
 [profile.release]
 debug = false          # No debug symbols for smaller binaries


### PR DESCRIPTION
## Summary
- disable debug symbol emission in the ordinary dev profile
- disable incremental object retention to avoid a second full set of build artifacts
- keep symbol-heavy profiling and benchmark profiles available when needed

## Branch-added checks
- A clean Nix-based dev build was measured before and after the profile change: the generated target fell from about 1.6 GiB with full dev DWARF and incremental objects to about 711 MiB.
- Full formatting, strict all-target clippy, and the 2,268-test nextest suite passed under the compact profile.